### PR TITLE
fix runAsRoot (true) efa device plugin bug

### DIFF
--- a/pkg/addons/assets/efa-device-plugin.yaml
+++ b/pkg/addons/assets/efa-device-plugin.yaml
@@ -165,7 +165,6 @@ spec:
         - image: "%s.dkr.ecr.%s.%s/eks/aws-efa-k8s-device-plugin:v0.3.3"
           name: aws-efa-k8s-device-plugin
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
The plugins were globally changed to have runAsNonRoot set to true. This breaks the efa plugin, which
currently requires it. This PR was tested and confirmed to fix the bug in several cases. This will close https://github.com/weaveworks/eksctl/issues/6222, and the other suggestions tried are also mentioned there. 

Thanks for working on eksctl, we are using it a lot!

### Checklist
- [ ] Added tests that cover your change (if possible) NA
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

