### PR TITLE
OIDC IDP creation through CF template

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -385,6 +385,11 @@
           "description": "permissions boundary for the fargate pod execution role`. See [EKS Fargate Support](/usage/fargate-support/)",
           "x-intellij-html-description": "permissions boundary for the fargate pod execution role`. See <a href=\"/usage/fargate-support/\">EKS Fargate Support</a>"
         },
+        "oidcThumbprint": {
+          "type": "string",
+          "description": "thumbprint for the OIDC provider If provided will be used instead of trying to obtain the thumbprint from the certificate of the oidc endpoint Meant to be used in air-gapped installations, where the OIDC endpoint is not reachable",
+          "x-intellij-html-description": "thumbprint for the OIDC provider If provided will be used instead of trying to obtain the thumbprint from the certificate of the oidc endpoint Meant to be used in air-gapped installations, where the OIDC endpoint is not reachable"
+        },
         "serviceAccounts": {
           "items": {
             "$ref": "#/definitions/ClusterIAMServiceAccount"
@@ -419,6 +424,7 @@
         "fargatePodExecutionRoleARN",
         "fargatePodExecutionRolePermissionsBoundary",
         "withOIDC",
+        "oidcThumbprint",
         "serviceAccounts",
         "vpcResourceControllerPolicy"
       ],

--- a/pkg/apis/eksctl.io/v1alpha5/iam.go
+++ b/pkg/apis/eksctl.io/v1alpha5/iam.go
@@ -35,6 +35,12 @@ type ClusterIAM struct {
 	// +optional
 	WithOIDC *bool `json:"withOIDC,omitempty"`
 
+	// OIDCThumbprint is the thumbprint for the OIDC provider
+	// If provided will be used instead of trying to obtain the thumbprint from the certificate of the oidc endpoint
+	// Meant to be used in air-gapped installations, where the OIDC endpoint is not reachable
+	// +optional
+	OIDCThumbprint *string `json:"oidcThumbprint,omitempty"`
+
 	// service accounts to create in the cluster.
 	// See [IAM Service Accounts](/usage/iamserviceaccounts/#usage-with-config-files)
 	// +optional

--- a/pkg/ctl/create/iamserviceaccount.go
+++ b/pkg/ctl/create/iamserviceaccount.go
@@ -22,6 +22,10 @@ func createIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 	})
 }
 
+var (
+	discoverIDPFromCF bool
+)
+
 func createIAMServiceAccountCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, overrideExistingServiceAccounts, roleOnly bool) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
@@ -52,6 +56,7 @@ func createIAMServiceAccountCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *
 		fs.StringVar(&serviceAccount.AttachRoleARN, "attach-role-arn", "", "ARN of the role to attach to the iamserviceaccount")
 		fs.StringVar(&serviceAccount.RoleName, "role-name", "", "Set a custom name for the created role")
 		fs.BoolVar(roleOnly, "role-only", false, "disable service account creation, only the role will be created")
+		fs.BoolVar(&discoverIDPFromCF, "discover-cf-idp", false, "discover the idp from cf template")
 
 		cmdutils.AddStringToStringVarPFlag(fs, &serviceAccount.Tags, "tags", "", map[string]string{}, "Used to tag the IAM role")
 
@@ -76,6 +81,14 @@ func doCreateIAMServiceAccount(cmd *cmdutils.Cmd, overrideExistingServiceAccount
 
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
+
+	if discoverIDPFromCF {
+		// just set this to a dummy value, which would prompt the oidc manager to discover
+		// the role ARN from the cf template
+		// doesnt' seem to be used anywhere else
+		dummy := "blbalb"
+		cfg.IAM.OIDCThumbprint = &dummy
+	}
 
 	printer := printers.NewJSONPrinter()
 

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -176,8 +176,13 @@ func (c *ClusterProvider) NewOpenIDConnectManager(ctx context.Context, spec *api
 		return nil, fmt.Errorf("unknown EKS ARN: %q", spec.Status.ARN)
 	}
 
-	return iamoidc.NewOpenIDConnectManager(c.AWSProvider.IAM(), parsedARN.AccountID,
-		*c.Status.ClusterInfo.Cluster.Identity.Oidc.Issuer, parsedARN.Partition, sharedTags(c.Status.ClusterInfo.Cluster))
+	tprint := ""
+	if spec != nil && spec.IAM != nil && spec.IAM.OIDCThumbprint != nil {
+		tprint = *spec.IAM.OIDCThumbprint
+	}
+
+	return iamoidc.NewOpenIDConnectManager(c.AWSProvider.IAM(), c.AWSProvider.CloudFormation(), parsedARN.AccountID,
+		*c.Status.ClusterInfo.Cluster.Identity.Oidc.Issuer, parsedARN.Partition, sharedTags(c.Status.ClusterInfo.Cluster), tprint)
 }
 
 func sharedTags(cluster *ekstypes.Cluster) map[string]string {

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -146,6 +146,8 @@ func getAWSNodeSAARNAnnotation(clientSet kubernetes.Interface) (string, error) {
 
 // DoesAWSNodeUseIRSA evaluates whether an aws-node uses IRSA
 func DoesAWSNodeUseIRSA(ctx context.Context, provider api.ClusterProvider, clientSet kubernetes.Interface) (bool, error) {
+	return true, nil
+
 	roleArn, err := getAWSNodeSAARNAnnotation(clientSet)
 	if err != nil {
 		return false, errors.Wrap(err, "error retrieving aws-node arn")


### PR DESCRIPTION
### Description

**⚠️ This PR is nowhere near ready to be merged and it was a quick PoC to verify that a solution like this would even work. I'm opening it in order to start a discussion on whether such a change is even desirable. As it stands, it works for a particular use-case, where a cluster has to be created from an air-gapped environment and some APIs are unreachable**

Creating a cluster with `oidc` enabled from an air-gapped environment (private subnet, no internet gateway), would fail due to the `eksctl` trying to reach endpoints which are inherently public and for which PrivateLink endpoints don't exist. 

There are a couple of changes in this PR:

##### OIDC Thumbprint

The first endpoint is `oidc.eks.{region}.amazonaws.com`, and it's required to [obtain](https://github.com/weaveworks/eksctl/blob/a4637775c48850be77380289a56bb928bf4129d8/pkg/iam/oidc/api.go#L145-L171C2) the [thumbprint for the identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html). 

Since the cluster's oidc provider is always the regional `oidc.eks.{region}`, and the required thumbprint is of the top-level CA - then they are always the same per region and can be obtained beforehand. If we provide them beforehand, we avoid the need to talk to that endpoint.

Looking at the certs, they are generally valid from 2009 until ~2034, so I don't expect that they change often (unless they get rotated, but at that point there would be bigger issues), so supplying the value manually should be safe.

```bash
openssl s_client -servername oidc.eks.eu-central-1.amazonaws.com -showcerts -connect oidc.eks.eu-central-1.amazonaws.com:443  </dev/null

 3 s:C = US, ST = Arizona, L = Scottsdale, O = "Starfield Technologies, Inc.", CN = Starfield Services Root Certificate Authority - G2
   i:C = US, O = "Starfield Technologies, Inc.", OU = Starfield Class 2 Certification Authority
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Sep  2 00:00:00 2009 GMT; NotAfter: Jun 28 17:39:16 2034 GMT
```

The first change adds `iam.oidcThumbrint` field, and if passed would skip the call to get the thumbprint.

##### Creating the IAM IDP

The second problem is that the actual creation of the IAM IDP requires talking to the IAM API. Since there is no PrivateLink endpoint for it, and it's always public (I imagine that's a side effect of it being in the `us-east-1` region), the IAM IDP can't be created, and also its ARN can't be retrieved.

This can be worked by creating the resources through CF, waiting until they are complete and subsequently getting the ARN from the stack. Right now this change is done by directly calling the CF API.

The problem I see here would be if an IDP already exists, then the CF template would fail. And we wouldn't be able to get the ARN. As a workaround we could have the option to pass the ARN of the IDP in the configuration file, then we can skip template creation. Such a feature would be useful only for clusters that already exist - new clusters shouldn't require that.

##### Creating ServiceAccounts

ServiceAccount creation requires the IDP ARN. I've added a very hacky flag to prompt the manager to look it up from the CF template.

##### Creating NodeGroups

Determining if IRSAs are used requires a call to IAM. [Right now it just returns true](https://github.com/vulkoingim/eksctl/pull/2/files#diff-0109290a87c411fc455c9ac85657661bd794463cacfc112ffa271bfb22facbd3R149). But that probably can be inferred by a check for certain cf templates.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

