### PR TITLE
Add support for creating Scheduled Scaling rules using eksctl CLI

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1524,6 +1524,9 @@ type NodeGroupBase struct {
 	*ScalingConfig
 
 	// +optional
+	ScheduledScalingConfig *ScheduledScalingConfig `json:"scheduledScalingConfig,omitempty"`
+
+	// +optional
 	// VolumeSize gigabytes
 	// Defaults to `80`
 	VolumeSize *int `json:"volumeSize,omitempty"`
@@ -1656,6 +1659,17 @@ type CapacityReservationTarget struct {
 // Placement specifies placement group information
 type Placement struct {
 	GroupName string `json:"groupName,omitempty"`
+}
+
+// ScheduledScalingConfig specifies scheduled scaling configuration for ASG
+type ScheduledScalingConfig struct {
+	MinSize         *int   `json:"minSize,omitempty"`
+	MaxSize         *int   `json:"maxSize,omitempty"`
+	DesiredCapacity *int   `json:"desiredCapacity,omitempty"`
+	StartTime       string `json:"startTime,omitempty"`
+	EndTime         string `json:"endTime,omitempty"`
+	Recurrence      string `json:"recurrence,omitempty"`
+	Timezone        string `json:"timezone,omitempty"`
 }
 
 // ListOptions returns metav1.ListOptions with label selector for the nodegroup

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -334,3 +334,42 @@ func (m *ManagedNodeGroupResourceSet) WithIAM() bool {
 func (m *ManagedNodeGroupResourceSet) WithNamedIAM() bool {
 	return m.nodeGroup.IAM.InstanceRoleName != ""
 }
+
+func (n *ManagedNodeGroupResourceSet) AddManagedNodeGroupScheduledScalingResource(asgName string) error {
+	ngScheduledScalingProps := map[string]interface{}{}
+
+	ngScheduledScalingProps["AutoScalingGroupName"] = asgName
+	if n.nodeGroup.ScheduledScalingConfig.DesiredCapacity != nil {
+		ngScheduledScalingProps["DesiredCapacity"] = fmt.Sprintf("%d", *n.nodeGroup.ScheduledScalingConfig.DesiredCapacity)
+	}
+	if n.nodeGroup.ScheduledScalingConfig.MinSize != nil {
+		ngScheduledScalingProps["MinSize"] = fmt.Sprintf("%d", *n.nodeGroup.ScheduledScalingConfig.MinSize)
+	}
+	if n.nodeGroup.ScheduledScalingConfig.MaxSize != nil {
+		ngScheduledScalingProps["MaxSize"] = fmt.Sprintf("%d", *n.nodeGroup.ScheduledScalingConfig.MaxSize)
+	}
+
+	if n.nodeGroup.ScheduledScalingConfig.StartTime != "" {
+		ngScheduledScalingProps["StartTime"] = n.nodeGroup.ScheduledScalingConfig.StartTime
+	}
+
+	if n.nodeGroup.ScheduledScalingConfig.EndTime != "" {
+		ngScheduledScalingProps["EndTime"] = n.nodeGroup.ScheduledScalingConfig.EndTime
+	}
+
+	if n.nodeGroup.ScheduledScalingConfig.Timezone != "" {
+		ngScheduledScalingProps["Timezone"] = n.nodeGroup.ScheduledScalingConfig.Timezone
+	}
+
+	if n.nodeGroup.ScheduledScalingConfig.Recurrence != "" {
+		ngScheduledScalingProps["Recurrence"] = n.nodeGroup.ScheduledScalingConfig.Recurrence
+	}
+
+	cfnResource := &awsCloudFormationResource{
+		Type:       "AWS::AutoScaling::ScheduledAction",
+		Properties: ngScheduledScalingProps,
+	}
+
+	n.newResource("ManagedNodeGroupScheduledScaling", cfnResource)
+	return nil
+}

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -588,3 +588,42 @@ func metricsCollectionResource(asgMetricsCollection []api.MetricsCollection) []m
 	}
 	return metricsCollections
 }
+
+func (n *NodeGroupResourceSet) AddNodeGroupScheduledScalingResource(asgName string) error {
+	ngScheduledScalingProps := map[string]interface{}{}
+
+	ngScheduledScalingProps["AutoScalingGroupName"] = asgName
+	if n.spec.ScheduledScalingConfig.DesiredCapacity != nil {
+		ngScheduledScalingProps["DesiredCapacity"] = fmt.Sprintf("%d", *n.spec.ScheduledScalingConfig.DesiredCapacity)
+	}
+	if n.spec.ScheduledScalingConfig.MinSize != nil {
+		ngScheduledScalingProps["MinSize"] = fmt.Sprintf("%d", *n.spec.ScheduledScalingConfig.MinSize)
+	}
+	if n.spec.ScheduledScalingConfig.MaxSize != nil {
+		ngScheduledScalingProps["MaxSize"] = fmt.Sprintf("%d", *n.spec.ScheduledScalingConfig.MaxSize)
+	}
+
+	if n.spec.ScheduledScalingConfig.StartTime != "" {
+		ngScheduledScalingProps["StartTime"] = n.spec.ScheduledScalingConfig.StartTime
+	}
+
+	if n.spec.ScheduledScalingConfig.EndTime != "" {
+		ngScheduledScalingProps["EndTime"] = n.spec.ScheduledScalingConfig.EndTime
+	}
+
+	if n.spec.ScheduledScalingConfig.Timezone != "" {
+		ngScheduledScalingProps["Timezone"] = n.spec.ScheduledScalingConfig.Timezone
+	}
+
+	if n.spec.ScheduledScalingConfig.Recurrence != "" {
+		ngScheduledScalingProps["Recurrence"] = n.spec.ScheduledScalingConfig.Recurrence
+	}
+
+	cfnResource := &awsCloudFormationResource{
+		Type:       "AWS::AutoScaling::ScheduledAction",
+		Properties: ngScheduledScalingProps,
+	}
+
+	n.newResource("NodeGroupScheduledScaling", cfnResource)
+	return nil
+}

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -68,6 +68,30 @@ func (t *managedNodeGroupTagsToASGPropagationTask) Do(errorCh chan error) error 
 	return t.stackCollection.propagateManagedNodeGroupTagsToASGTask(t.ctx, errorCh, t.nodeGroup, t.stackCollection.PropagateManagedNodeGroupTagsToASG)
 }
 
+type nodeGroupScheduledScalingActionTask struct {
+	info            string
+	nodeGroup       *api.NodeGroup
+	stackCollection *StackCollection
+	ctx             context.Context
+}
+
+func (t *nodeGroupScheduledScalingActionTask) Describe() string { return t.info }
+func (t *nodeGroupScheduledScalingActionTask) Do(errorCh chan error) error {
+	return t.stackCollection.createNodeGroupScheduledScalingActionTask(t.ctx, errorCh, t.nodeGroup)
+}
+
+type managedNodeGroupScheduledScalingActionTask struct {
+	info            string
+	nodeGroup       *api.ManagedNodeGroup
+	stackCollection *StackCollection
+	ctx             context.Context
+}
+
+func (t *managedNodeGroupScheduledScalingActionTask) Describe() string { return t.info }
+func (t *managedNodeGroupScheduledScalingActionTask) Do(errorCh chan error) error {
+	return t.stackCollection.createManagedNodeGroupScheduledScalingActionTask(t.ctx, errorCh, t.nodeGroup)
+}
+
 type taskWithClusterIAMServiceAccountSpec struct {
 	info            string
 	stackCollection *StackCollection


### PR DESCRIPTION
### Description
AWS EKS NodeGroups are bound to Autoscaling groups that support ```AWS::AutoScaling::ScheduledAction``` which allows the user to create ```NodeGroup``` scaling rules for predictable load changes. Currently, ```eksctl``` does not support the creation of ```ScheduledAction```. This PR introduces the Scheduled Scaling feature.

Closes https://github.com/weaveworks/eksctl/issues/5524

### Method
The ```AWS::AutoScaling::ScheduledAction``` can be created after an ASG is created therefore this has been added a new ```sub task``` in Unmanaged and Managed NodeGroup creation tasks. 

### Note
This is a draft PR and does not contain updates to test files. 


<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

