### PR TITLE
Add/hpc7g node arm support

### DIFF
--- a/pkg/addons/assets/efa-device-plugin.yaml
+++ b/pkg/addons/assets/efa-device-plugin.yaml
@@ -63,6 +63,8 @@ spec:
                       - g6.48xlarge
                       - hpc6a.48xlarge
                       - hpc7g.16xlarge
+                      - hpc7g.8xlarge
+                      - hpc7g.4xlarge
                       - i3en.12xlarge
                       - i3en.24xlarge
                       - i3en.metal
@@ -126,6 +128,8 @@ spec:
                       - g6.48xlarge
                       - hpc6a.48xlarge
                       - hpc7g.16xlarge
+                      - hpc7g.8xlarge
+                      - hpc7g.4xlarge
                       - i3en.12xlarge
                       - i3en.24xlarge
                       - i3en.metal

--- a/pkg/addons/assets/efa-device-plugin.yaml
+++ b/pkg/addons/assets/efa-device-plugin.yaml
@@ -37,7 +37,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/instance-type"
+                  - key: "node.kubernetes.io/instance-type"
                     operator: In
                     values:
                       - c5n.18xlarge
@@ -62,6 +62,7 @@ spec:
                       - g6.24xlarge
                       - g6.48xlarge
                       - hpc6a.48xlarge
+                      - hpc7g.16xlarge
                       - i3en.12xlarge
                       - i3en.24xlarge
                       - i3en.metal
@@ -124,6 +125,7 @@ spec:
                       - g6.24xlarge
                       - g6.48xlarge
                       - hpc6a.48xlarge
+                      - hpc7g.16xlarge
                       - i3en.12xlarge
                       - i3en.24xlarge
                       - i3en.metal
@@ -175,3 +177,4 @@ spec:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+

--- a/pkg/utils/instance/instance.go
+++ b/pkg/utils/instance/instance.go
@@ -20,6 +20,7 @@ func IsARMInstanceType(instanceType string) bool {
 		strings.HasPrefix(instanceType, "im4g") ||
 		strings.HasPrefix(instanceType, "is4g") ||
 		strings.HasPrefix(instanceType, "g5g") ||
+		strings.HasPrefix(instanceType, "hpc7g") ||
 		strings.HasPrefix(instanceType, "x2g")
 }
 


### PR DESCRIPTION
### Description

Problem: The new [hpc7g images](https://aws.amazon.com/blogs/aws/new-amazon-ec2-hpc7g-instances-powered-by-aws-graviton3e-processors-optimized-for-high-performance-computing-workloads/) use the graviton2 processor (arm) but are not detected as such by eskctl. In addition, as we have been discussing in https://github.com/weaveworks/eksctl/issues/6222, the daemon set for the efa [device driver](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) does not work with `runAsNonRoot` set to true. I believe this tweak is close, however the final step (I think) needs to also be to provide an ARM build for the driver itself. I believe this is proprietary code, so I wanted to ask here first about that. I was able to figure out the container entrypoint and output, in case that helps:

```bash
$ /usr/bin/efa-k8s-device-plugin 
```
```console
2023/06/27 00:17:39 Fetching EFA devices.
2023/06/27 00:17:39 device: rdmap0s6,uverbs0,/sys/class/infiniband_verbs/uverbs0,/sys/class/infiniband/rdmap0s6

2023/06/27 00:17:39 EFA Device list: [{rdmap0s6 uverbs0 /sys/class/infiniband_verbs/uverbs0 /sys/class/infiniband/rdmap0s6}]
2023/06/27 00:17:39 Starting FS watcher.
2023/06/27 00:17:39 Starting OS watcher.
2023/06/27 00:17:39 device: rdmap0s6,uverbs0,/sys/class/infiniband_verbs/uverbs0,/sys/class/infiniband/rdmap0s6

2023/06/27 00:17:39 Starting to serve on /var/lib/kubelet/device-plugins/aws-efa-device-plugin.sock
2023/06/27 00:17:39 Registered device plugin with Kubelet
```
Note that online examples for efa (e.g., [this repository](https://github.com/aws-samples/aws-efa-eks)) is not exactly what we want - the Dockerfile will build a container that can use EFA but not one that has that particular executable.

Let me know how you would like to proceed! 

