### PR TITLE
Support custom AMIs for self-managed Windows nodegroups

### DIFF
--- a/examples/32-windows-nodes-with-containerd.yaml
+++ b/examples/32-windows-nodes-with-containerd.yaml
@@ -15,6 +15,12 @@ nodeGroups:
     maxSize: 3
     containerRuntime: containerd
 
+  - name: custom-windows
+    amiFamily: WindowsServer2022FullContainer
+    ami: ami-01579b74557facaf7
+    overrideBootstrapCommand: |
+      & $EKSBootstrapScriptFile -EKSClusterName "$EKSClusterName" -APIServerEndpoint "$APIServerEndpoint" -Base64ClusterCA "$Base64ClusterCA" -ContainerRuntime "containerd" -KubeletExtraArgs "$KubeletExtraArgs" 3>&1 4>&1 5>&1 6>&1
+
 managedNodeGroups:
   - name: linux-ng
     instanceType: t2.large

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -171,14 +171,14 @@ var _ = Describe("ClusterConfig validation", func() {
 			ng0.AMIFamily = api.NodeImageFamilyWindowsServer2019CoreContainer
 			Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(Succeed())
 		})
-		It("should throw an error if overrideBootstrapCommand is set and type is Windows", func() {
+		It("should not throw an error if overrideBootstrapCommand is set and type is Windows", func() {
 			cfg := api.NewClusterConfig()
 			ng0 := cfg.NewNodeGroup()
 			ng0.Name = "node-group"
 			ng0.AMI = "ami-1234"
 			ng0.AMIFamily = api.NodeImageFamilyWindowsServer2019CoreContainer
 			ng0.OverrideBootstrapCommand = aws.String("echo 'yo'")
-			Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError(ContainSubstring("overrideBootstrapCommand is not supported for WindowsServer2019CoreContainer nodegroups")))
+			Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(Succeed())
 		})
 		It("should accept ami with a overrideBootstrapCommand set", func() {
 			cfg := api.NewClusterConfig()

--- a/pkg/nodebootstrap/powershell/powershell.go
+++ b/pkg/nodebootstrap/powershell/powershell.go
@@ -1,0 +1,59 @@
+package powershell
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A KeyValue holds a key-value pair.
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+// FormatStringVariables formats params as PowerShell string variables.
+// The caller is responsible for ensuring the keys are valid PowerShell variable names
+// and the values can be surrounded by single-quoted strings.
+func FormatStringVariables(params []KeyValue) string {
+	variables := make([]string, 0, len(params))
+	for _, param := range params {
+		variables = append(variables, fmt.Sprintf("[string]$%s = '%s'", param.Key, param.Value))
+	}
+	return strings.Join(variables, "\n")
+}
+
+// JoinVariables joins the specified variables.
+func JoinVariables(variables ...string) string {
+	return strings.Join(variables, "\n")
+}
+
+// FormatHashTable formats table as a PowerShell hashtable.
+// The caller is responsible for ensuring variableName is a valid PowerShell variable name
+// and the key-value pairs can be surrounded by single-quoted strings.
+func FormatHashTable(table []KeyValue, variableName string) string {
+	values := make([]string, 0, len(table))
+	for _, kv := range table {
+		values = append(values, fmt.Sprintf(" '%s' = '%s'", kv.Key, kv.Value))
+	}
+	return fmt.Sprintf("$%s = @{%s}", variableName, strings.Join(values, ";"))
+}
+
+// FormatParams formats params into `-key "value"`, ignoring keys with empty values.
+func FormatParams(params []KeyValue) string {
+	var args []string
+	for _, param := range params {
+		if param.Value != "" {
+			args = append(args, fmt.Sprintf("-%s %q", param.Key, param.Value))
+		}
+	}
+	return strings.Join(args, " ")
+}
+
+// ToCLIArgs formats params as CLI arguments.
+func ToCLIArgs(params []KeyValue) string {
+	var args []string
+	for _, param := range params {
+		args = append(args, fmt.Sprintf("--%s=%s", param.Key, param.Value))
+	}
+	return strings.Join(args, " ")
+}

--- a/pkg/nodebootstrap/powershell/powershell_test.go
+++ b/pkg/nodebootstrap/powershell/powershell_test.go
@@ -1,0 +1,155 @@
+package powershell_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/weaveworks/eksctl/pkg/nodebootstrap/powershell"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestPowerShellUtils(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("PowerShell", func() {
+
+	type powerShellEntry struct {
+		params         []powershell.KeyValue
+		expectedOutput string
+	}
+
+	DescribeTable("FormatStringVariables", func(e powerShellEntry) {
+		variables := powershell.FormatStringVariables(e.params)
+		Expect(variables).To(Equal(e.expectedOutput))
+	},
+		Entry("standard params", powerShellEntry{
+			params: []powershell.KeyValue{
+				{
+					Key:   "EKSClusterName",
+					Value: "cluster",
+				},
+				{
+					Key:   "APIServerEndpoint",
+					Value: "https://test.com",
+				},
+				{
+					Key:   "Var",
+					Value: "Value",
+				},
+				{
+					Key:   "Key1",
+					Value: `"Value1"`,
+				},
+			},
+			expectedOutput: `[string]$EKSClusterName = 'cluster'
+[string]$APIServerEndpoint = 'https://test.com'
+[string]$Var = 'Value'
+[string]$Key1 = '"Value1"'`,
+		}),
+
+		Entry("empty params", powerShellEntry{
+			expectedOutput: "",
+		}),
+
+		Entry("single param", powerShellEntry{
+			params: []powershell.KeyValue{
+				{
+					Key:   "EKSClusterName",
+					Value: "cluster",
+				},
+			},
+			expectedOutput: `[string]$EKSClusterName = 'cluster'`,
+		}),
+	)
+
+	DescribeTable("FormatHashTable", func(e powerShellEntry, variableName string) {
+		hashtable := powershell.FormatHashTable(e.params, variableName)
+		Expect(hashtable).To(Equal(e.expectedOutput))
+	},
+
+		Entry("standard params", powerShellEntry{
+			params: []powershell.KeyValue{
+				{
+					Key:   "node-labels",
+					Value: "",
+				},
+				{
+					Key:   "key1",
+					Value: "val1",
+				},
+				{
+					Key:   "key2",
+					Value: "val2",
+				},
+			},
+			expectedOutput: `$KubeletExtraArgs = @{ 'node-labels' = ''; 'key1' = 'val1'; 'key2' = 'val2'}`,
+		},
+			"KubeletExtraArgs",
+		),
+
+		Entry(
+			"empty params",
+			powerShellEntry{
+				expectedOutput: `$Map = @{}`,
+			},
+			"Map",
+		),
+	)
+
+	DescribeTable("FormatParams", func(e powerShellEntry) {
+		formatted := powershell.FormatParams(e.params)
+		Expect(formatted).To(Equal(e.expectedOutput))
+	},
+		Entry("standard params", powerShellEntry{
+			params: []powershell.KeyValue{
+				{
+					Key:   "EKSClusterName",
+					Value: "cluster",
+				},
+				{
+					Key:   "APIServerEndpoint",
+					Value: "https://test.com",
+				},
+				{
+					Key:   "Var",
+					Value: "Value",
+				},
+			},
+			expectedOutput: `-EKSClusterName "cluster" -APIServerEndpoint "https://test.com" -Var "Value"`,
+		}),
+
+		Entry("empty params", powerShellEntry{
+			expectedOutput: "",
+		}),
+	)
+
+	DescribeTable("ToCLIArgs", func(e powerShellEntry) {
+		cliArgs := powershell.ToCLIArgs(e.params)
+		Expect(cliArgs).To(Equal(e.expectedOutput))
+	},
+		Entry("standard params", powerShellEntry{
+			params: []powershell.KeyValue{
+				{
+					Key:   "node-labels",
+					Value: "",
+				},
+				{
+					Key:   "key1",
+					Value: "val1",
+				},
+				{
+					Key:   "key2",
+					Value: "val2",
+				},
+			},
+			expectedOutput: "--node-labels= --key1=val1 --key2=val2",
+		}),
+
+		Entry("empty params", powerShellEntry{
+			expectedOutput: "",
+		}),
+	)
+})

--- a/userdocs/src/announcements/nodegroup-override-announcement.md
+++ b/userdocs/src/announcements/nodegroup-override-announcement.md
@@ -1,10 +1,10 @@
 # Nodegroup Bootstrap Override For Custom AMIs
 
 This change was announced in the issue [Breaking: overrideBootstrapCommand soon...](https://github.com/eksctl-io/eksctl/issues/3563).
-Now, it has come to pass in [this](https://github.com/eksctl-io/eksctl/pull/4968) PR. Please read the attached issue carefully about 
+Now, it has come to pass in [this](https://github.com/eksctl-io/eksctl/pull/4968) PR. Please read the attached issue carefully about
 why we decided to move away from supporting custom AMIs without bootstrap scripts or with partial bootstrap scripts.
 
-We still provide a helper! Migrating hopefully is not that painful. `eksctl` still provides a script, which when sourced, 
+We still provide a helper! Migrating hopefully is not that painful. `eksctl` still provides a script, which when sourced,
 will export a couple of helpful environment properties and settings. This script is located [here](https://github.com/eksctl-io/eksctl/blob/70a289d62e3c82e6177930cf2469c2572c82e104/pkg/nodebootstrap/assets/scripts/bootstrap.helper.sh).
 
 The following environment properties will be at your disposal:

--- a/userdocs/src/usage/custom-ami-support.md
+++ b/userdocs/src/usage/custom-ami-support.md
@@ -79,6 +79,33 @@ managedNodeGroups:
 
 The `--node-ami-family` flag can also be used with `eksctl create nodegroup`. `eksctl` requires AMI Family to be explicitly set via config file or via `--node-ami-family` CLI flag, whenever working with a custom AMI.
 
+## Windows custom AMI support
+Only self-managed Windows nodegroups can specify a custom AMI. `amiFamily` should be set to a valid Windows AMI family.
+
+The following PowerShell variables will be available to the bootstrap script:
+
+```
+$EKSBootstrapScriptFile
+$EKSClusterName
+$APIServerEndpoint
+$Base64ClusterCA
+$ServiceCIDR
+$KubeletExtraArgs
+$KubeletExtraArgsMap: A hashtable containing arguments for the kubelet, e.g., @{ 'node-labels' = ''; 'register-with-taints' = ''; 'max-pods' = '10'}
+$DNSClusterIP
+$ContainerRuntime
+```
+
+Config file example:
+```yaml
+nodeGroups:
+  - name: custom-windows
+    amiFamily: WindowsServer2022FullContainer
+    ami: ami-01579b74557facaf7
+    overrideBootstrapCommand: |
+      & $EKSBootstrapScriptFile -EKSClusterName "$EKSClusterName" -APIServerEndpoint "$APIServerEndpoint" -Base64ClusterCA "$Base64ClusterCA" -ContainerRuntime "containerd" -KubeletExtraArgs "$KubeletExtraArgs" 3>&1 4>&1 5>&1 6>&1
+```
+
 ## Bottlerocket custom AMI support
 
 For Bottlerocket nodes, the `overrideBootstrapCommand` is not supported. Instead, to designate their own bootstrap container, one should use the `bottlerocket` field as part of the configuration file. E.g.


### PR DESCRIPTION
### Description

Adds support for custom AMIs for self-managed Windows nodegroups. 

Closes #6463 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

