### PR TITLE
Remove mockery config from `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !.git
 !.goreleaser*
 !.golangci*
+!.mockery.yaml
 !build/scripts
 !cmd
 !examples


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

We need `.mockery.yaml` file inside the container so we can call mockery as is and generate all expected mocks.

Official docs:
>From anywhere within your repo, you can simply call mockery once and it will find your config either by respecting the config path you gave it, or by searching upwards from the current working directory.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

