### PR TITLE
Fix setting link-time variables for release version

### DIFF
--- a/.goreleaser-local.yaml
+++ b/.goreleaser-local.yaml
@@ -8,7 +8,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/eksctl-io/eksctl/pkg/version.buildDate={{.Date}} -X github.com/eksctl-io/eksctl/pkg/version.gitCommit={{.ShortCommit}}
+      - -s -w -X github.com/weaveworks/eksctl/pkg/version.buildDate={{.Date}} -X github.com/weaveworks/eksctl/pkg/version.gitCommit={{.ShortCommit}}
     goos:
       - windows
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       # gitTag set from a generated file (see ./tag_release.sh)
-      - -s -w -X github.com/eksctl-io/eksctl/pkg/version.buildDate={{.Date}} -X github.com/eksctl-io/eksctl/pkg/version.gitCommit={{.ShortCommit}} -X github.com/eksctl-io/eksctl/pkg/version.PreReleaseID={{.Env.PRE_RELEASE_ID}}
+      - -s -w -X github.com/weaveworks/eksctl/pkg/version.buildDate={{.Date}} -X github.com/weaveworks/eksctl/pkg/version.gitCommit={{.ShortCommit}} -X github.com/weaveworks/eksctl/pkg/version.PreReleaseID={{.Env.PRE_RELEASE_ID}}
     goos:
       - windows
       - darwin


### PR DESCRIPTION
### Description

The import name passed to `ldflags` was incorrect, causing variables in the `version` package to remain unset. This was causing `eksctl version` to show a `-dev` suffix for both release candidates and full releases. 

This changelist fixes setting link-time variables for the release version.

Fixes #6835

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

