### PR TITLE
Fix `k8s.io/kubernetes` version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -576,7 +576,7 @@ replace (
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.25.11
 	k8s.io/kubectl => k8s.io/kubectl v0.25.5
 	k8s.io/kubelet => k8s.io/kubelet v0.25.11
-	k8s.io/kubernetes => k8s.io/kubernetes v0.25.11
+	k8s.io/kubernetes => k8s.io/kubernetes v1.25.11
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.25.11
 	k8s.io/metrics => k8s.io/metrics v0.25.11
 	k8s.io/mount-utils => k8s.io/mount-utils v0.25.11


### PR DESCRIPTION
### Description

Fixes #6867 

Kubernetes version was pinned to the wrong one in https://github.com/eksctl-io/eksctl/commit/fbb6bd72a672a895a43602a7eb106bfeadea73a1

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

