### PR TITLE
cleanup efa installer archive before install

### DIFF
--- a/pkg/nodebootstrap/assets/scripts/efa.al2.sh
+++ b/pkg/nodebootstrap/assets/scripts/efa.al2.sh
@@ -7,6 +7,7 @@ set -o nounset
 yum install -y wget
 wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer.tar.gz
 tar -xf /tmp/aws-efa-installer.tar.gz -C /tmp
+rm -rf /tmp/aws-efa-installer.tar.gz
 cd /tmp/aws-efa-installer
 ./efa_installer.sh -y -g
 /opt/amazon/efa/bin/fi_info -p efa

--- a/pkg/nodebootstrap/assets/scripts/efa.al2023.sh
+++ b/pkg/nodebootstrap/assets/scripts/efa.al2023.sh
@@ -7,6 +7,7 @@ set -o nounset
 dnf install -y wget
 wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer.tar.gz
 tar -xf /tmp/aws-efa-installer.tar.gz -C /tmp
+rm -rf /tmp/aws-efa-installer.tar.gz
 cd /tmp/aws-efa-installer
 ./efa_installer.sh -y -g
 /opt/amazon/efa/bin/fi_info -p efa

--- a/pkg/nodebootstrap/assets/scripts/efa.managed.al2023.boothook
+++ b/pkg/nodebootstrap/assets/scripts/efa.managed.al2023.boothook
@@ -2,6 +2,7 @@ cloud-init-per once dnf_wget dnf install -y wget
 cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
 
 cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+cloud-init-per once rm_efa_gz rm -rf /tmp/aws-efa-installer-latest.tar.gz
 pushd /tmp/aws-efa-installer
 cloud-init-per once install_efa ./efa_installer.sh -y -g
 pop /tmp/aws-efa-installer

--- a/pkg/nodebootstrap/assets/scripts/efa.managed.boothook
+++ b/pkg/nodebootstrap/assets/scripts/efa.managed.boothook
@@ -2,6 +2,7 @@ cloud-init-per once yum_wget yum install -y wget
 cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
 
 cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+cloud-init-per once rm_efa_gz rm -rf /tmp/aws-efa-installer-latest.tar.gz
 pushd /tmp/aws-efa-installer
 cloud-init-per once install_efa ./efa_installer.sh -y -g
 pop /tmp/aws-efa-installer

--- a/pkg/nodebootstrap/managed_al2_test.go
+++ b/pkg/nodebootstrap/managed_al2_test.go
@@ -111,6 +111,7 @@ cloud-init-per once yum_wget yum install -y wget
 cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
 
 cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+cloud-init-per once rm_efa_gz rm -rf /tmp/aws-efa-installer-latest.tar.gz
 pushd /tmp/aws-efa-installer
 cloud-init-per once install_efa ./efa_installer.sh -y -g
 pop /tmp/aws-efa-installer
@@ -143,6 +144,7 @@ cloud-init-per once yum_wget yum install -y wget
 cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
 
 cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+cloud-init-per once rm_efa_gz rm -rf /tmp/aws-efa-installer-latest.tar.gz
 pushd /tmp/aws-efa-installer
 cloud-init-per once install_efa ./efa_installer.sh -y -g
 pop /tmp/aws-efa-installer


### PR DESCRIPTION
Currently, the UserData section that runs during cloud init happens before any root volumes are expanded with growpart. Although the best solution would be to ensure the filesystem resize happens before these scripts are run, a quick means to fix the current issue is simply to cleanup the efa installer tar.gz, which is very large. I have tested this with hpc7g for a size 2 and size 8 cluster (previously both not working) and can confirm the devices are functioning after.

![image](https://github.com/eksctl-io/eksctl/assets/814322/9114e547-ad9c-4f66-a784-533769a78c46)

And logs for a running node (what they should look like!)

![image](https://github.com/eksctl-io/eksctl/assets/814322/5c2d0c4d-d276-4af5-9fea-29dbb69d70a6)

This will close https://github.com/eksctl-io/eksctl/issues/6869

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

