### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/build-all-distros-nightly.yaml
+++ b/.github/workflows/build-all-distros-nightly.yaml
@@ -1,7 +1,7 @@
 name: Build all distros
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 9 * * 1-5'
   workflow_dispatch: {}
 
 jobs:
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/
@@ -35,7 +35,7 @@ jobs:
           make build-all
       - name: slack on failure
         if: failure()
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0 #v1.1.0
         with:
           slack_token: ${{ secrets.WEAVEWORKS_SLACK_EKSCTLBOT_TOKEN }}
           message: ":ahhhhhhhhh: build-all-distros has failed"

--- a/.github/workflows/build-all-distros-nightly.yaml
+++ b/.github/workflows/build-all-distros-nightly.yaml
@@ -35,7 +35,7 @@ jobs:
           make build-all
       - name: slack on failure
         if: failure()
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0 #v1.1.0
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0
         with:
           slack_token: ${{ secrets.WEAVEWORKS_SLACK_EKSCTLBOT_TOKEN }}
           message: ":ahhhhhhhhh: build-all-distros has failed"

--- a/.github/workflows/cache-dependencies.yaml
+++ b/.github/workflows/cache-dependencies.yaml
@@ -1,3 +1,4 @@
+name: Cache Dependencies
 on:
   push:
     branches:
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 #4.6.0
         with:
           images: weaveworks/eksctl
       - name: Log in to Docker Hub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
         with:
           username: weaveworkseksctlci
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/ecr-publish-build.yaml
+++ b/.github/workflows/ecr-publish-build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
@@ -29,7 +29,7 @@ jobs:
           registry-type: public
 
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/

--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@1d8459ca65b335265f1285568221e229d45a995e #v1.1.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'Hello ${{ github.event.issue.user.login }} :wave: Thank you for opening an issue in `eksctl` project. The team will review the issue and aim to respond within 1-5 business days. Meanwhile, please read about the Contribution and Code of Conduct guidelines [here](https://github.com/eksctl-io/eksctl#contributions). You can find out more information about `eksctl` on our [website](https://eksctl.io)'

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 #v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Go

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           token: ${{ secrets.EKSCTLBOT_TOKEN }}
           fetch-depth: 0
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: 1.18.x
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/
@@ -35,7 +35,7 @@ jobs:
         run: make publish-docs
       - name: slack on success
         if: success()
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0
         with:
           slack_token: ${{ secrets.WEAVEWORKS_SLACK_EKSCTLBOT_TOKEN }}
           message: ":tada: Docs published successfully :tada:"
@@ -44,7 +44,7 @@ jobs:
           verbose: true
       - name: slack on failure
         if: failure()
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0
         with:
           slack_token: ${{ secrets.WEAVEWORKS_SLACK_EKSCTLBOT_TOKEN }}
           message: ":ahhhhhhhhh: Docs publishing failed."

--- a/.github/workflows/publish-release-type.yaml
+++ b/.github/workflows/publish-release-type.yaml
@@ -1,3 +1,4 @@
+name: Publish Release type
 on:
   workflow_call:
     inputs:
@@ -27,9 +28,9 @@ jobs:
           echo "Available storage:"
           df -h
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/
@@ -61,7 +62,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: slack on success - team-pitch-black
         if: ${{ success() }}
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0
         with:
           slack_token: ${{ secrets.slackToken }}
           message: ":cool-doge: ${{ inputs.name }} successful for tag <https://github.com/eksctl-io/eksctl/releases/tag/${{ steps.get_version.outputs.version }}|${{ steps.get_version.outputs.version }}>"
@@ -70,7 +71,7 @@ jobs:
           verbose: false
       - name: slack on failure - team-pitch-black
         if: ${{ failure() }}
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0
         with:
           slack_token: ${{ secrets.slackToken }}
           message: ":ahhhhhhhhh: ${{ inputs.name }} has failed for tag <https://github.com/eksctl-io/eksctl/releases/tag/${{ steps.get_version.outputs.version }}|${{ steps.get_version.outputs.version }}>"
@@ -79,7 +80,7 @@ jobs:
           verbose: true
       - name: slack on success - aws-dev
         if: ${{ success() }}
-        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a #v1.1.0
         with:
           slack_token: ${{ secrets.slackToken }}
           message: ":tada: <https://github.com/eksctl-io/eksctl/releases/tag/${{ steps.get_version.outputs.version }}|${{ steps.get_version.outputs.version }}> released!"

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Rebase
-        uses: cirrus-actions/rebase@1.8
+        uses: cirrus-actions/rebase@b87d48154a87a85666003575337e27b8cd65f691 #v1.8
         env:
           GITHUB_TOKEN: ${{ secrets.EKSCTLBOT_TOKEN }}

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -10,12 +10,12 @@ jobs:
     container: public.ecr.aws/eksctl/eksctl-build:b06c1f3d2a18a98695327e6f8da535ded95083b7
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           token: ${{ secrets.EKSCTLBOT_TOKEN }}
           fetch-depth: 0
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 #v5.24.0
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Merge release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Setup identity as eksctl-bot
@@ -28,7 +28,7 @@ jobs:
           EDITOR=true git merge --continue
           ! git diff --exit-code $DEFAULT_BRANCH...HEAD || exit 1
           git push --set-upstream origin HEAD
-      - uses: actions/github-script@v6.4.1
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 #v6.4.1
         name: Open PR to ${{env.DEFAULT_BRANCH}}
         with:
           github-token: ${{ secrets.EKSCTLBOT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,12 @@ jobs:
     container: public.ecr.aws/eksctl/eksctl-build:b06c1f3d2a18a98695327e6f8da535ded95083b7
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           token: ${{ secrets.EKSCTLBOT_TOKEN }}
           fetch-depth: 0
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/
@@ -38,11 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/
@@ -65,11 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/

--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -6,6 +6,7 @@ on:
 
 env:
   DEFAULT_BRANCH: main
+  UPDATE_BRANCH: update-aws-node
 
 jobs:
   update_aws_node:
@@ -13,11 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     container: public.ecr.aws/eksctl/eksctl-build:b06c1f3d2a18a98695327e6f8da535ded95083b7
     env:
-      UPDATE_BRANCH: update-aws-node
       GOPRIVATE: ""
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           fetch-depth: 0
       - name: Setup identity as eksctl-bot
@@ -25,7 +25,7 @@ jobs:
         with:
           token: "${{ secrets.EKSCTLBOT_TOKEN }}"
       - name: Cache go-build and mod
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
         with:
           path: |
             ~/.cache/go-build/
@@ -48,7 +48,7 @@ jobs:
           echo "changes=true" >> $GITHUB_OUTPUT
           ! git diff --exit-code $DEFAULT_BRANCH HEAD
           git push --force-with-lease origin HEAD
-      - uses: actions/github-script@v6.4.1
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 #v6.4.1
         name: Open PR to ${{env.DEFAULT_BRANCH}}
         if: ${{ steps.commit.outputs.changes }} == 'true'
         with:


### PR DESCRIPTION
### Description
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
Closes https://github.com/eksctl-io/eksctl-private/issues/1180

Pinned workflows with SHA, running build-distros job only on weekdays and minor improvements

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

