### PR TITLE
Add validations for managed nodegroup labels

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -797,7 +797,7 @@ func ValidateNodeGroup(i int, ng *NodeGroup, cfg *ClusterConfig) error {
 		return err
 	}
 
-	if err := validateNodeGroupLabels(ng.Labels); err != nil {
+	if err := validateLabels(ng.Labels); err != nil {
 		return err
 	}
 
@@ -918,16 +918,16 @@ func validateOutpostARN(val string) error {
 	return nil
 }
 
-// validateNodeGroupLabels uses proper Kubernetes label validation,
-// it's designed to make sure users don't pass weird labels to the
-// nodes, which would prevent kubelets to startup properly
-func validateNodeGroupLabels(labels map[string]string) error {
+// validateLabels uses proper Kubernetes label validation,
+// it's designed to make sure users don't pass invalid or disallowed labels,
+// which would prevent kubelets to startup properly
+func validateLabels(labels map[string]string) error {
 	// compact version based on:
 	// - https://github.com/kubernetes/kubernetes/blob/v1.13.2/cmd/kubelet/app/options/options.go#L257-L267
 	// - https://github.com/kubernetes/kubernetes/blob/v1.13.2/pkg/kubelet/apis/well_known_labels.go
 	// we cannot import those packages because they break other dependencies
 
-	unknownKubernetesLabels := []string{}
+	disallowedKubernetesLabels := []string{}
 
 	for label := range labels {
 		labelParts := strings.Split(label, "/")
@@ -946,13 +946,13 @@ func validateNodeGroupLabels(labels map[string]string) error {
 		if len(labelParts) == 2 {
 			namespace := labelParts[0]
 			if isKubernetesLabel(namespace) && !kubeletapis.IsKubeletLabel(label) {
-				unknownKubernetesLabels = append(unknownKubernetesLabels, label)
+				disallowedKubernetesLabels = append(disallowedKubernetesLabels, label)
 			}
 		}
 	}
 
-	if len(unknownKubernetesLabels) > 0 {
-		return fmt.Errorf("unknown 'kubernetes.io' or 'k8s.io' labels were specified: %v", unknownKubernetesLabels)
+	if len(disallowedKubernetesLabels) > 0 {
+		return fmt.Errorf("the following nodegroup labels are disallowd as they have reserved prefixes [kubernetes.io/, k8s.io/]: %v", disallowedKubernetesLabels)
 	}
 	return nil
 }
@@ -1167,6 +1167,10 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 	}
 
 	if err := validateTaints(ng.Taints); err != nil {
+		return err
+	}
+
+	if err := validateLabels(ng.Labels); err != nil {
 		return err
 	}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -2086,7 +2086,19 @@ var _ = Describe("ClusterConfig validation", func() {
 		ng := newNodeGroup()
 		ng.Labels = e.labels
 		ng.Taints = e.taints
+
+		mng := api.NewManagedNodeGroup()
+		mng.Labels = e.labels
+		mng.Taints = e.taints
+
 		err := api.ValidateNodeGroup(0, ng, api.NewClusterConfig())
+		if e.valid {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+
+		err = api.ValidateManagedNodeGroup(0, mng)
 		if e.valid {
 			Expect(err).NotTo(HaveOccurred())
 		} else {


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Setting labels with the following prefixes `[kubernetes.io/, k8s.io/]` causes both managed and unmanaged nodes to fail joining clusters. For unmanaged nodegroups, validations are already in place. This PR adds the same validations for EKS managed nodegroups. Refer to [this comment](https://github.com/eksctl-io/eksctl/issues/6856#issuecomment-1674330482) for more context. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

