### PR TITLE
Don't wait for `aws-efs-csi-driver` if cluster has no nodegroups

### DIFF
--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -39,9 +39,12 @@ func New(clusterConfig *api.ClusterConfig, eksAPI awsapi.EKS, stackManager manag
 }
 
 func (a *Manager) waitForAddonToBeActive(ctx context.Context, addon *api.Addon, waitTimeout time.Duration) error {
-	// Don't wait for coredns or aws-ebs-csi-driver if there are no nodegroups.
+	// Don't wait for coredns, aws-ebs-csi-driver or aws-efs-csi-driver if there are no nodegroups.
 	// They will be in degraded state until nodegroups are added.
-	if (addon.Name == api.CoreDNSAddon || addon.Name == api.AWSEBSCSIDriverAddon) && !a.clusterConfig.HasNodes() {
+	if (addon.Name == api.CoreDNSAddon ||
+		addon.Name == api.AWSEBSCSIDriverAddon ||
+		addon.Name == api.AWSEFSCSIDriverAddon) &&
+		!a.clusterConfig.HasNodes() {
 		return nil
 	}
 	activeWaiter := eks.NewAddonActiveWaiter(a.eksAPI)

--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -258,6 +258,10 @@ func (a *Manager) getRecommendedPolicies(addon *api.Addon) (api.InlineDocument, 
 		return nil, nil, &api.WellKnownPolicies{
 			EBSCSIController: true,
 		}
+	case api.AWSEFSCSIDriverAddon:
+		return nil, nil, &api.WellKnownPolicies{
+			EFSCSIController: true,
+		}
 	default:
 		return nil, nil, nil
 	}

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -381,7 +381,7 @@ var _ = Describe("Create", func() {
 			}
 		})
 
-		DescribeTable("addons created with a waitTimeout", func(e createAddonEntry) {
+		DescribeTable("addons created with a waitTimeout when there are no active nodes", func(e createAddonEntry) {
 			expectedDescribeCallsCount := 1
 			if e.shouldWait {
 				expectedDescribeCallsCount++
@@ -403,6 +403,9 @@ var _ = Describe("Create", func() {
 			}),
 			Entry("should not wait for Amazon EBS CSI driver to become active", createAddonEntry{
 				addonName: api.AWSEBSCSIDriverAddon,
+			}),
+			Entry("should not wait for Amazon EFS CSI driver to become active", createAddonEntry{
+				addonName: api.AWSEFSCSIDriverAddon,
 			}),
 			Entry("should wait for VPC CNI to become active", createAddonEntry{
 				addonName:  api.VPCCNIAddon,
@@ -626,6 +629,31 @@ var _ = Describe("Create", func() {
 					Expect(string(output)).To(ContainSubstring("PolicyEBSCSIController"))
 					Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
 					Expect(*createAddonInput.AddonName).To(Equal(api.AWSEBSCSIDriverAddon))
+					Expect(*createAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.1"))
+					Expect(*createAddonInput.ServiceAccountRoleArn).To(Equal("role-arn"))
+				})
+			})
+
+			When("it's the aws-efs-csi-driver addon", func() {
+				It("creates a role with the recommended policies and attaches it to the addon", func() {
+					err := manager.Create(context.Background(), &api.Addon{
+						Name:    api.AWSEFSCSIDriverAddon,
+						Version: "v1.0.0-eksbuild.1",
+					}, 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeStackManager.CreateStackCallCount()).To(Equal(1))
+					_, name, resourceSet, tags, _, _ := fakeStackManager.CreateStackArgsForCall(0)
+					Expect(name).To(Equal("eksctl-my-cluster-addon-aws-efs-csi-driver"))
+					Expect(resourceSet).NotTo(BeNil())
+					Expect(tags).To(Equal(map[string]string{
+						api.AddonNameTag: api.AWSEFSCSIDriverAddon,
+					}))
+					output, err := resourceSet.RenderJSON()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(output)).To(ContainSubstring("PolicyEFSCSIController"))
+					Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
+					Expect(*createAddonInput.AddonName).To(Equal(api.AWSEFSCSIDriverAddon))
 					Expect(*createAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.1"))
 					Expect(*createAddonInput.ServiceAccountRoleArn).To(Equal("role-arn"))
 				})

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -424,6 +424,7 @@ const (
 	KubeProxyAddon              = "kube-proxy"
 	CoreDNSAddon                = "coredns"
 	AWSEBSCSIDriverAddon        = "aws-ebs-csi-driver"
+	AWSEFSCSIDriverAddon        = "aws-efs-csi-driver"
 )
 
 // supported version of Karpenter


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Instead of cluster creation failing, the aws-efs-csi-driver should stay in degraded state until nodegroups are added.

Closes #6954

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

