### PR TITLE
Bring Windows integration test runtime down to less than half

### DIFF
--- a/integration/main.go
+++ b/integration/main.go
@@ -123,7 +123,11 @@ func runGinkgo(ctx context.Context, wg *sync.WaitGroup, summaries chan []string,
 		}
 	}
 
-	args := []string{"--no-color", fmt.Sprintf("--timeout=%s", suiteTimeout), "-tags", "integration", "-v", "--progress"}
+	var args []string
+	if ginkgoArgs := os.Getenv("GINKGO_ARGS"); ginkgoArgs != "" {
+		args = strings.Split(ginkgoArgs, " ")
+	}
+	args = append(args, "--no-color", fmt.Sprintf("--timeout=%s", suiteTimeout), "-tags", "integration", "-v", "--progress")
 	if focus := os.Getenv("INTEGRATION_TEST_FOCUS"); focus != "" {
 		args = append(args, fmt.Sprintf(`--focus="%s"`, focus))
 	}


### PR DESCRIPTION
### Description

This changelist parallelises the Windows integration test specs by modifying the integration test runner to accept arbitrary arguments to be passed to the `ginkgo` binary, allowing the integration test GitHub workflow to pass the `-p` and `--procs` arguments to parallelise running the test specs. This has brought the total runtime of Windows integration tests down to ~55 minutes from ~2 hours and 30 minutes.

The cluster version used in the tests has been updated to the latest EKS version 1.27, and as a result, one of the tests that uses the Docker runtime has been removed as it's no longer supported.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

