### PR TITLE
Disallow passing a vpc.securityGroup with external security group rules

### DIFF
--- a/pkg/actions/nodegroup/create_test.go
+++ b/pkg/actions/nodegroup/create_test.go
@@ -144,6 +144,33 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 		expectedErr: errors.Wrapf(errors.New("VPC configuration required for creating nodegroups on clusters not owned by eksctl: vpc.subnets, vpc.id, vpc.securityGroup"), "loading VPC spec for cluster %q", "my-cluster"),
 	}),
 
+	Entry("when cluster is unowned and vpc.securityGroup contains external egress rules, it fails validation", ngEntry{
+		updateClusterConfig: makeUnownedClusterConfig,
+		mockCalls: func(k *fakes.FakeKubeProvider, f *utilFakes.FakeNodegroupFilter, p *mockprovider.MockProvider, _ *fake.Clientset) {
+			mockProviderForUnownedCluster(p, k, ec2types.SecurityGroupRule{
+				Description:         aws.String("Allow control plane to communicate with a custom nodegroup on a custom port"),
+				FromPort:            aws.Int32(8443),
+				ToPort:              aws.Int32(8443),
+				GroupId:             aws.String("sg-custom"),
+				IpProtocol:          aws.String("https"),
+				IsEgress:            aws.Bool(true),
+				SecurityGroupRuleId: aws.String("sgr-5"),
+			})
+
+		},
+		expectedErr: fmt.Errorf("loading VPC spec for cluster %q: vpc.securityGroup (sg-custom) has egress rules that were not attached by eksctl; vpc.securityGroup should not contain any external egress rules on a cluster not created by eksctl (rule ID: sgr-5)", "my-cluster"),
+	}),
+
+	Entry("when cluster is unowned and vpc.securityGroup contains no external egress rules, it passes validation but fails if DescribeImages fails", ngEntry{
+		updateClusterConfig: makeUnownedClusterConfig,
+		mockCalls: func(k *fakes.FakeKubeProvider, f *utilFakes.FakeNodegroupFilter, p *mockprovider.MockProvider, _ *fake.Clientset) {
+			mockProviderForUnownedCluster(p, k)
+			p.MockEC2().On("DescribeImages", mock.Anything, mock.Anything).Return(nil, errors.New("DescribeImages error"))
+
+		},
+		expectedErr: errors.New("DescribeImages error"),
+	}),
+
 	Entry("fails when cluster is not compatible with ng config", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, f *utilFakes.FakeNodegroupFilter, p *mockprovider.MockProvider, _ *fake.Clientset) {
 			// no shared security group will trigger a compatibility check failure later in the call chain.
@@ -586,4 +613,123 @@ func mockProviderWithConfig(p *mockprovider.MockProvider, describeStacksOutput [
 				},
 			},
 		}, nil)
+}
+
+func mockProviderForUnownedCluster(p *mockprovider.MockProvider, k *fakes.FakeKubeProvider, extraSGRules ...ec2types.SecurityGroupRule) {
+	k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
+	k.ServerVersionReturns("1.27", nil)
+	p.MockCloudFormation().On("ListStacks", mock.Anything, mock.Anything).Return(&cloudformation.ListStacksOutput{
+		StackSummaries: []cftypes.StackSummary{
+			{
+				StackName:   aws.String("eksctl-my-cluster-cluster"),
+				StackStatus: "CREATE_COMPLETE",
+			},
+		},
+	}, nil)
+	p.MockCloudFormation().On("DescribeStacks", mock.Anything, mock.Anything).Return(&cloudformation.DescribeStacksOutput{
+		Stacks: []cftypes.Stack{
+			{
+				StackName:   aws.String("eksctl-my-cluster-cluster"),
+				StackStatus: "CREATE_COMPLETE",
+			},
+		},
+	}, nil)
+
+	vpcID := aws.String("vpc-custom")
+	p.MockEC2().On("DescribeVpcs", mock.Anything, mock.Anything).Return(&ec2.DescribeVpcsOutput{
+		Vpcs: []ec2types.Vpc{
+			{
+				CidrBlock: aws.String("192.168.0.0/19"),
+				VpcId:     vpcID,
+				CidrBlockAssociationSet: []ec2types.VpcCidrBlockAssociation{
+					{
+						CidrBlock: aws.String("192.168.0.0/19"),
+					},
+				},
+			},
+		},
+	}, nil)
+	p.MockEC2().On("DescribeSubnets", mock.Anything, mock.Anything).Return(&ec2.DescribeSubnetsOutput{
+		Subnets: []ec2types.Subnet{
+			{
+				SubnetId:         aws.String("subnet-custom1"),
+				CidrBlock:        aws.String("192.168.160.0/19"),
+				AvailabilityZone: aws.String("us-west-2a"),
+				VpcId:            vpcID,
+			},
+			{
+				SubnetId:         aws.String("subnet-custom2"),
+				CidrBlock:        aws.String("192.168.96.0/19"),
+				AvailabilityZone: aws.String("us-west-2b"),
+				VpcId:            vpcID,
+			},
+		},
+	}, nil)
+
+	sgID := aws.String("sg-custom")
+	p.MockEC2().On("DescribeSecurityGroupRules", mock.Anything, mock.MatchedBy(func(input *ec2.DescribeSecurityGroupRulesInput) bool {
+		if len(input.Filters) != 1 {
+			return false
+		}
+		filter := input.Filters[0]
+		return *filter.Name == "group-id" && len(filter.Values) == 1 && filter.Values[0] == *sgID
+	})).Return(&ec2.DescribeSecurityGroupRulesOutput{
+		SecurityGroupRules: append([]ec2types.SecurityGroupRule{
+			{
+				Description:         aws.String("Allow control plane to communicate with worker nodes in group ng-1 (kubelet and workload TCP ports"),
+				FromPort:            aws.Int32(1025),
+				ToPort:              aws.Int32(65535),
+				GroupId:             sgID,
+				IpProtocol:          aws.String("tcp"),
+				IsEgress:            aws.Bool(true),
+				SecurityGroupRuleId: aws.String("sgr-1"),
+			},
+			{
+				Description:         aws.String("Allow control plane to communicate with worker nodes in group ng-1 (workload using HTTPS port, commonly used with extension API servers"),
+				FromPort:            aws.Int32(443),
+				ToPort:              aws.Int32(443),
+				GroupId:             sgID,
+				IpProtocol:          aws.String("tcp"),
+				IsEgress:            aws.Bool(true),
+				SecurityGroupRuleId: aws.String("sgr-2"),
+			},
+			{
+				Description:         aws.String("Allow control plane to receive API requests from worker nodes in group ng-1"),
+				FromPort:            aws.Int32(443),
+				ToPort:              aws.Int32(443),
+				GroupId:             sgID,
+				IpProtocol:          aws.String("tcp"),
+				IsEgress:            aws.Bool(false),
+				SecurityGroupRuleId: aws.String("sgr-3"),
+			},
+			{
+				Description:         aws.String("Allow control plane to communicate with worker nodes in group ng-2 (workload using HTTPS port, commonly used with extension API servers"),
+				FromPort:            aws.Int32(443),
+				ToPort:              aws.Int32(443),
+				GroupId:             sgID,
+				IpProtocol:          aws.String("tcp"),
+				IsEgress:            aws.Bool(true),
+				SecurityGroupRuleId: aws.String("sgr-4"),
+			},
+		}, extraSGRules...),
+	}, nil)
+}
+
+func makeUnownedClusterConfig(clusterConfig *api.ClusterConfig) {
+	clusterConfig.VPC = &api.ClusterVPC{
+		SecurityGroup: "sg-custom",
+		Network: api.Network{
+			ID: "vpc-custom",
+		},
+		Subnets: &api.ClusterSubnets{
+			Private: api.AZSubnetMapping{
+				"us-west-2a": api.AZSubnetSpec{
+					ID: "subnet-custom1",
+				},
+				"us-west-2b": api.AZSubnetSpec{
+					ID: "subnet-custom2",
+				},
+			},
+		},
+	}
 }

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -35,6 +35,16 @@ const (
 	taintsPrefix       = nodeTemplatePrefix + "taint/"
 )
 
+// NodeGroupOptions represents options passed to a NodeGroupResourceSet.
+type NodeGroupOptions struct {
+	ClusterConfig     *api.ClusterConfig
+	NodeGroup         *api.NodeGroup
+	Bootstrapper      nodebootstrap.Bootstrapper
+	ForceAddCNIPolicy bool
+	VPCImporter       vpc.Importer
+	SkipEgressRules   bool
+}
+
 // NodeGroupResourceSet stores the resource information of the nodegroup
 type NodeGroupResourceSet struct {
 	rs                *resourceSet
@@ -49,19 +59,21 @@ type NodeGroupResourceSet struct {
 	vpc                *gfnt.Value
 	vpcImporter        vpc.Importer
 	bootstrapper       nodebootstrap.Bootstrapper
+	skipEgressRules    bool
 }
 
 // NewNodeGroupResourceSet returns a resource set for a nodegroup embedded in a cluster config
-func NewNodeGroupResourceSet(ec2API awsapi.EC2, iamAPI awsapi.IAM, spec *api.ClusterConfig, ng *api.NodeGroup, bootstrapper nodebootstrap.Bootstrapper, forceAddCNIPolicy bool, vpcImporter vpc.Importer) *NodeGroupResourceSet {
+func NewNodeGroupResourceSet(ec2API awsapi.EC2, iamAPI awsapi.IAM, options NodeGroupOptions) *NodeGroupResourceSet {
 	return &NodeGroupResourceSet{
 		rs:                newResourceSet(),
-		forceAddCNIPolicy: forceAddCNIPolicy,
-		clusterSpec:       spec,
-		spec:              ng,
+		forceAddCNIPolicy: options.ForceAddCNIPolicy,
+		clusterSpec:       options.ClusterConfig,
+		spec:              options.NodeGroup,
 		ec2API:            ec2API,
 		iamAPI:            iamAPI,
-		vpcImporter:       vpcImporter,
-		bootstrapper:      bootstrapper,
+		vpcImporter:       options.VPCImporter,
+		bootstrapper:      options.Bootstrapper,
+		skipEgressRules:   options.SkipEgressRules,
 	}
 }
 
@@ -194,22 +206,24 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 		n.securityGroups = append(n.securityGroups, efaSG)
 	}
 
-	n.newResource("EgressInterCluster", &gfnec2.SecurityGroupEgress{
-		GroupId:                    refControlPlaneSG,
-		DestinationSecurityGroupId: refNodeGroupLocalSG,
-		Description:                gfnt.NewString(ControlPlaneEgressRuleDescriptionPrefix + desc + " (kubelet and workload TCP ports)"),
-		IpProtocol:                 gfnt.NewString(controlPlaneEgressInterCluster.IPProtocol),
-		FromPort:                   gfnt.NewInteger(controlPlaneEgressInterCluster.FromPort),
-		ToPort:                     gfnt.NewInteger(controlPlaneEgressInterCluster.ToPort),
-	})
-	n.newResource("EgressInterClusterAPI", &gfnec2.SecurityGroupEgress{
-		GroupId:                    refControlPlaneSG,
-		DestinationSecurityGroupId: refNodeGroupLocalSG,
-		Description:                gfnt.NewString(ControlPlaneEgressRuleDescriptionPrefix + desc + " (workloads using HTTPS port, commonly used with extension API servers)"),
-		IpProtocol:                 gfnt.NewString(controlPlaneEgressInterClusterAPI.IPProtocol),
-		FromPort:                   gfnt.NewInteger(controlPlaneEgressInterClusterAPI.FromPort),
-		ToPort:                     gfnt.NewInteger(controlPlaneEgressInterClusterAPI.ToPort),
-	})
+	if !n.skipEgressRules {
+		n.newResource("EgressInterCluster", &gfnec2.SecurityGroupEgress{
+			GroupId:                    refControlPlaneSG,
+			DestinationSecurityGroupId: refNodeGroupLocalSG,
+			Description:                gfnt.NewString(ControlPlaneEgressRuleDescriptionPrefix + desc + " (kubelet and workload TCP ports)"),
+			IpProtocol:                 gfnt.NewString(controlPlaneEgressInterCluster.IPProtocol),
+			FromPort:                   gfnt.NewInteger(controlPlaneEgressInterCluster.FromPort),
+			ToPort:                     gfnt.NewInteger(controlPlaneEgressInterCluster.ToPort),
+		})
+		n.newResource("EgressInterClusterAPI", &gfnec2.SecurityGroupEgress{
+			GroupId:                    refControlPlaneSG,
+			DestinationSecurityGroupId: refNodeGroupLocalSG,
+			Description:                gfnt.NewString(ControlPlaneEgressRuleDescriptionPrefix + desc + " (workloads using HTTPS port, commonly used with extension API servers)"),
+			IpProtocol:                 gfnt.NewString(controlPlaneEgressInterClusterAPI.IPProtocol),
+			FromPort:                   gfnt.NewInteger(controlPlaneEgressInterClusterAPI.FromPort),
+			ToPort:                     gfnt.NewInteger(controlPlaneEgressInterClusterAPI.ToPort),
+		})
+	}
 	n.newResource("IngressInterClusterCP", &gfnec2.SecurityGroupIngress{
 		GroupId:               refControlPlaneSG,
 		SourceSecurityGroupId: refNodeGroupLocalSG,

--- a/pkg/cfn/builder/vpc_ipv4.go
+++ b/pkg/cfn/builder/vpc_ipv4.go
@@ -335,7 +335,6 @@ var (
 	sgSourceAnywhereIPv6 = gfnt.NewString("::/0")
 
 	sgPortZero    = gfnt.NewInteger(0)
-	sgMinNodePort = gfnt.NewInteger(1025)
 	sgMaxNodePort = gfnt.NewInteger(65535)
 
 	sgPortHTTPS = gfnt.NewInteger(443)

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -42,7 +42,7 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(ctx context.Cont
 			Parallel:  true,
 			IsSubTask: true,
 		}
-		if unmanagedNodeGroupTasks := c.NewUnmanagedNodeGroupTask(ctx, nodeGroups, false, vpcImporter); unmanagedNodeGroupTasks.Len() > 0 {
+		if unmanagedNodeGroupTasks := c.NewUnmanagedNodeGroupTask(ctx, nodeGroups, false, false, vpcImporter); unmanagedNodeGroupTasks.Len() > 0 {
 			unmanagedNodeGroupTasks.IsSubTask = true
 			nodeGroupTasks.Append(unmanagedNodeGroupTasks)
 		}
@@ -72,7 +72,7 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(ctx context.Cont
 }
 
 // NewUnmanagedNodeGroupTask defines tasks required to create all of the nodegroups
-func (c *StackCollection) NewUnmanagedNodeGroupTask(ctx context.Context, nodeGroups []*api.NodeGroup, forceAddCNIPolicy bool, vpcImporter vpc.Importer) *tasks.TaskTree {
+func (c *StackCollection) NewUnmanagedNodeGroupTask(ctx context.Context, nodeGroups []*api.NodeGroup, forceAddCNIPolicy, skipEgressRules bool, vpcImporter vpc.Importer) *tasks.TaskTree {
 	taskTree := &tasks.TaskTree{Parallel: true}
 
 	for _, ng := range nodeGroups {
@@ -83,6 +83,7 @@ func (c *StackCollection) NewUnmanagedNodeGroupTask(ctx context.Context, nodeGro
 			stackCollection:   c,
 			forceAddCNIPolicy: forceAddCNIPolicy,
 			vpcImporter:       vpcImporter,
+			skipEgressRules:   skipEgressRules,
 		})
 		// TODO: move authconfigmap tasks here using kubernetesTask and kubernetes.CallbackClientSet
 	}

--- a/pkg/cfn/manager/fakes/fake_stack_manager.go
+++ b/pkg/cfn/manager/fakes/fake_stack_manager.go
@@ -733,13 +733,14 @@ type FakeStackManager struct {
 		result1 *tasks.TaskTree
 		result2 error
 	}
-	NewUnmanagedNodeGroupTaskStub        func(context.Context, []*v1alpha5.NodeGroup, bool, vpc.Importer) *tasks.TaskTree
+	NewUnmanagedNodeGroupTaskStub        func(context.Context, []*v1alpha5.NodeGroup, bool, bool, vpc.Importer) *tasks.TaskTree
 	newUnmanagedNodeGroupTaskMutex       sync.RWMutex
 	newUnmanagedNodeGroupTaskArgsForCall []struct {
 		arg1 context.Context
 		arg2 []*v1alpha5.NodeGroup
 		arg3 bool
-		arg4 vpc.Importer
+		arg4 bool
+		arg5 vpc.Importer
 	}
 	newUnmanagedNodeGroupTaskReturns struct {
 		result1 *tasks.TaskTree
@@ -4195,7 +4196,7 @@ func (fake *FakeStackManager) NewTasksToDeleteOIDCProviderWithIAMServiceAccounts
 	}{result1, result2}
 }
 
-func (fake *FakeStackManager) NewUnmanagedNodeGroupTask(arg1 context.Context, arg2 []*v1alpha5.NodeGroup, arg3 bool, arg4 vpc.Importer) *tasks.TaskTree {
+func (fake *FakeStackManager) NewUnmanagedNodeGroupTask(arg1 context.Context, arg2 []*v1alpha5.NodeGroup, arg3 bool, arg4 bool, arg5 vpc.Importer) *tasks.TaskTree {
 	var arg2Copy []*v1alpha5.NodeGroup
 	if arg2 != nil {
 		arg2Copy = make([]*v1alpha5.NodeGroup, len(arg2))
@@ -4207,14 +4208,15 @@ func (fake *FakeStackManager) NewUnmanagedNodeGroupTask(arg1 context.Context, ar
 		arg1 context.Context
 		arg2 []*v1alpha5.NodeGroup
 		arg3 bool
-		arg4 vpc.Importer
-	}{arg1, arg2Copy, arg3, arg4})
+		arg4 bool
+		arg5 vpc.Importer
+	}{arg1, arg2Copy, arg3, arg4, arg5})
 	stub := fake.NewUnmanagedNodeGroupTaskStub
 	fakeReturns := fake.newUnmanagedNodeGroupTaskReturns
-	fake.recordInvocation("NewUnmanagedNodeGroupTask", []interface{}{arg1, arg2Copy, arg3, arg4})
+	fake.recordInvocation("NewUnmanagedNodeGroupTask", []interface{}{arg1, arg2Copy, arg3, arg4, arg5})
 	fake.newUnmanagedNodeGroupTaskMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -4228,17 +4230,17 @@ func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskCallCount() int {
 	return len(fake.newUnmanagedNodeGroupTaskArgsForCall)
 }
 
-func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskCalls(stub func(context.Context, []*v1alpha5.NodeGroup, bool, vpc.Importer) *tasks.TaskTree) {
+func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskCalls(stub func(context.Context, []*v1alpha5.NodeGroup, bool, bool, vpc.Importer) *tasks.TaskTree) {
 	fake.newUnmanagedNodeGroupTaskMutex.Lock()
 	defer fake.newUnmanagedNodeGroupTaskMutex.Unlock()
 	fake.NewUnmanagedNodeGroupTaskStub = stub
 }
 
-func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskArgsForCall(i int) (context.Context, []*v1alpha5.NodeGroup, bool, vpc.Importer) {
+func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskArgsForCall(i int) (context.Context, []*v1alpha5.NodeGroup, bool, bool, vpc.Importer) {
 	fake.newUnmanagedNodeGroupTaskMutex.RLock()
 	defer fake.newUnmanagedNodeGroupTaskMutex.RUnlock()
 	argsForCall := fake.newUnmanagedNodeGroupTaskArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskReturns(result1 *tasks.TaskTree) {

--- a/pkg/cfn/manager/interface.go
+++ b/pkg/cfn/manager/interface.go
@@ -91,7 +91,7 @@ type StackManager interface {
 	NewTasksToDeleteIAMServiceAccounts(ctx context.Context, serviceAccounts []string, clientSetGetter kubernetes.ClientSetGetter, wait bool) (*tasks.TaskTree, error)
 	NewTasksToDeleteNodeGroups(stacks []NodeGroupStack, shouldDelete func(_ string) bool, wait bool, cleanup func(chan error, string) error) (*tasks.TaskTree, error)
 	NewTasksToDeleteOIDCProviderWithIAMServiceAccounts(ctx context.Context, newOIDCManager NewOIDCManager, cluster *ekstypes.Cluster, clientSetGetter kubernetes.ClientSetGetter, force bool) (*tasks.TaskTree, error)
-	NewUnmanagedNodeGroupTask(ctx context.Context, nodeGroups []*v1alpha5.NodeGroup, forceAddCNIPolicy bool, importer vpc.Importer) *tasks.TaskTree
+	NewUnmanagedNodeGroupTask(ctx context.Context, nodeGroups []*v1alpha5.NodeGroup, forceAddCNIPolicy, skipEgressRules bool, importer vpc.Importer) *tasks.TaskTree
 	PropagateManagedNodeGroupTagsToASG(ngName string, ngTags map[string]string, asgNames []string, errCh chan error) error
 	RefreshFargatePodExecutionRoleARN(ctx context.Context) error
 	StackStatusIsNotTransitional(s *Stack) bool

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -33,11 +33,12 @@ type nodeGroupTask struct {
 	forceAddCNIPolicy bool
 	vpcImporter       vpc.Importer
 	stackCollection   *StackCollection
+	skipEgressRules   bool
 }
 
 func (t *nodeGroupTask) Describe() string { return t.info }
 func (t *nodeGroupTask) Do(errs chan error) error {
-	return t.stackCollection.createNodeGroupTask(t.ctx, errs, t.nodeGroup, t.forceAddCNIPolicy, t.vpcImporter)
+	return t.stackCollection.createNodeGroupTask(t.ctx, errs, t.nodeGroup, t.forceAddCNIPolicy, t.skipEgressRules, t.vpcImporter)
 }
 
 type managedNodeGroupTask struct {

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -80,22 +80,22 @@ var _ = Describe("StackCollection Tasks", func() {
 			// The supportsManagedNodes argument has no effect on the Describe call, so the values are alternated
 			// in these tests
 			{
-				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), makeNodeGroups("bar", "foo"), false, fakeVPCImporter)
+				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), makeNodeGroups("bar", "foo"), false, false, fakeVPCImporter)
 				Expect(tasks.Describe()).To(Equal(`
 2 parallel tasks: { create nodegroup "bar", create nodegroup "foo" 
 }
 `))
 			}
 			{
-				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), makeNodeGroups("bar"), false, fakeVPCImporter)
+				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), makeNodeGroups("bar"), false, false, fakeVPCImporter)
 				Expect(tasks.Describe()).To(Equal(`1 task: { create nodegroup "bar" }`))
 			}
 			{
-				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), makeNodeGroups("foo"), false, fakeVPCImporter)
+				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), makeNodeGroups("foo"), false, false, fakeVPCImporter)
 				Expect(tasks.Describe()).To(Equal(`1 task: { create nodegroup "foo" }`))
 			}
 			{
-				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), nil, false, fakeVPCImporter)
+				tasks := stackManager.NewUnmanagedNodeGroupTask(context.Background(), nil, false, false, fakeVPCImporter)
 				Expect(tasks.Describe()).To(Equal(`no tasks`))
 			}
 			{


### PR DESCRIPTION
### Description

This changelist adds validation to disallow passing a `vpc.securityGroup` with external security group rules.

Closes #6455 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

