### PR TITLE
Add support for wavelength zones

### DIFF
--- a/pkg/vpc/zone.go
+++ b/pkg/vpc/zone.go
@@ -40,7 +40,7 @@ func DiscoverZoneTypes(ctx context.Context, ec2API awsapi.EC2, region string) (m
 	zoneTypeMapping := map[string]ZoneType{}
 	for _, z := range output.AvailabilityZones {
 		switch *z.ZoneType {
-		case "availability-zone":
+		case "availability-zone", "wavelength-zone":
 			zoneTypeMapping[*z.ZoneName] = ZoneTypeAvailabilityZone
 		case "local-zone":
 			zoneTypeMapping[*z.ZoneName] = ZoneTypeLocalZone


### PR DESCRIPTION
Allows adding nodegroups with wavelength zones.

### Description
Allows the use of wavelengh zones when adding nodegroups.

### Fixes

Error: could not find public subnets: could not select subnets from subnet IDs (allSubnets=v1alpha5.AZSubnetMapping{"us-east-1b":v1alpha5.AZSubnetSpec{ID:"subnet-xxxxxxxxxxxxx", AZ:"us-east-1b", CIDR:(*ipnet.IPNet)(0xc000000000, CIDRIndex:0, OutpostARN:""}, "us-east-1f":v1alpha5.AZSubnetSpec{ID:"subnet-x", AZ:"us-east-1f", CIDR:(*ipnet.IPNet)(0x000000000), CIDRIndex:0, OutpostARN:""}} localZones=[]string(nil) subnets=[]string{"subnet-xxxxxxxxxxxxx"}): failed to select subnet subnet-xxxxxxxxxxxxx: error discovering zone types: expected zone type to be local or AZ; got wavelength-zone


