### PR TITLE
Keep "version" in ClusterConfig examples aligned

### DIFF
--- a/examples/01-simple-cluster.yaml
+++ b/examples/01-simple-cluster.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-1
   region: eu-north-1
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/02-custom-vpc-cidr-no-nodes.yaml
+++ b/examples/02-custom-vpc-cidr-no-nodes.yaml
@@ -8,6 +8,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-2
   region: eu-north-1
+  version: "1.28"
 
 vpc:
   cidr: 10.10.0.0/16

--- a/examples/03-two-nodegroups.yaml
+++ b/examples/03-two-nodegroups.yaml
@@ -1,11 +1,12 @@
 # A simple example of ClusterConfig object with two nodegroups:
---- 
+---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
   name: cluster-3
   region: eu-north-1
+  version: "1.28"
 
 nodeGroups:
   - name: ng1-public

--- a/examples/04-existing-vpc.yaml
+++ b/examples/04-existing-vpc.yaml
@@ -1,11 +1,12 @@
 # An example of ClusterConfig object using an existing VPC:
---- 
+---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
   name: cluster-4
   region: eu-north-1
+  version: "1.28"
 
 vpc:
   id: "vpc-0dd338ecf29863c55"  # (optional, must match VPC ID used for each subnet below)

--- a/examples/05-advanced-nodegroups.yaml
+++ b/examples/05-advanced-nodegroups.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-5
   region: eu-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: ng1-public

--- a/examples/06-csi-drivers.yaml
+++ b/examples/06-csi-drivers.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-6
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/07-ssh-keys.yaml
+++ b/examples/07-ssh-keys.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-7
   region: eu-north-1
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/08-spot-instances.yaml
+++ b/examples/08-spot-instances.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
     name: cluster-8
     region: eu-central-1
+    version: "1.28"
 
 nodeGroups:
     - name: ng-1

--- a/examples/09-nat-gateways.yaml
+++ b/examples/09-nat-gateways.yaml
@@ -1,11 +1,12 @@
 # An example of ClusterConfig object with highly available NAT gateways
---- 
+---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
   name: cluster-9
   region: eu-west-1
+  version: "1.28"
 
 vpc:
   nat:

--- a/examples/10-encrypted-volumes.yaml
+++ b/examples/10-encrypted-volumes.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-10
   region: eu-west-1
+  version: "1.28"
 
 nodeGroups:
   - name: ng1-encrypt-using-default-kms-key

--- a/examples/11-cloudwatch-cluster-logging.yaml
+++ b/examples/11-cloudwatch-cluster-logging.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-11
   region: eu-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/12-gitops-toolkit.yaml
+++ b/examples/12-gitops-toolkit.yaml
@@ -7,6 +7,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-12
   region: eu-north-1
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/13-iamserviceaccounts.yaml
+++ b/examples/13-iamserviceaccounts.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-13
   region: us-west-2
+  version: "1.28"
 
 iam:
   withOIDC: true

--- a/examples/14-windows-nodes.yaml
+++ b/examples/14-windows-nodes.yaml
@@ -7,6 +7,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-14
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: windows-ng

--- a/examples/15-managed-nodes.yaml
+++ b/examples/15-managed-nodes.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-15
   region: us-west-2
+  version: "1.28"
 
 managedNodeGroups:
   - name: managed-ng-public

--- a/examples/16-fargate-profile.yaml
+++ b/examples/16-fargate-profile.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-16
   region: ap-northeast-1
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/17-permissions-boundary.yaml
+++ b/examples/17-permissions-boundary.yaml
@@ -10,6 +10,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-17
   region: us-west-2
+  version: "1.28"
 
 iam:
   withOIDC: true

--- a/examples/18-node-to-pod-label-matching.yaml
+++ b/examples/18-node-to-pod-label-matching.yaml
@@ -13,13 +13,14 @@
 #
 # Setting labels could be very useful as they allow you to
 # design an infrastructure that is suited for an app's use-case.
---- 
+---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
   name: cluster-18
   region: ap-southeast-1
+  version: "1.28"
 
 nodeGroups:
   - name: std-ng

--- a/examples/19-kms-cluster.yaml
+++ b/examples/19-kms-cluster.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-19
   region: us-west-2
+  version: "1.28"
 
 managedNodeGroups:
 - name: ng-1

--- a/examples/20-bottlerocket.yaml
+++ b/examples/20-bottlerocket.yaml
@@ -9,6 +9,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-20
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: ng1-public

--- a/examples/22-managed-nodes-launch-template.yaml
+++ b/examples/22-managed-nodes-launch-template.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-22
   region: us-west-2
+  version: "1.28"
 
 managedNodeGroups:
 - name: launch-template-ng

--- a/examples/23-kubeflow-spot-instance.yaml
+++ b/examples/23-kubeflow-spot-instance.yaml
@@ -21,8 +21,8 @@ metadata:
   name: cluster-23
   # choose your region wisely, this will significantly impact the cost incurred
   region: us-east-1
-  # 1.14 Kubernetes version since Kubeflow 1.0 officially supports the same
-  version: '1.14'
+  # Required >= 1.14 Kubernetes version since Kubeflow 1.0 officially supports the same
+  version: "1.28"
   tags:
     # Add more cloud tags if needed for billing
     environment: staging

--- a/examples/24-nodegroup-subnets.yaml
+++ b/examples/24-nodegroup-subnets.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-24
   region: us-west-2
+  version: "1.28"
 
 vpc:
   id: vpc-0c24b1cc77da8f463

--- a/examples/25-addons.yaml
+++ b/examples/25-addons.yaml
@@ -1,9 +1,10 @@
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
+
 metadata:
   name: cluster-25
   region: us-west-2
-  version: "1.18"
+  version: "1.28"
 
 iam:
   withOIDC: true

--- a/examples/26-managed-nodegroup-spot-instances.yaml
+++ b/examples/26-managed-nodegroup-spot-instances.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-26
   region: us-west-2
+  version: "1.28"
 
 managedNodeGroups:
 - name: spot

--- a/examples/27-oidc-provider.yaml
+++ b/examples/27-oidc-provider.yaml
@@ -3,8 +3,9 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: cluster-26
+  name: cluster-27
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/28-instance-selector.yaml
+++ b/examples/28-instance-selector.yaml
@@ -5,6 +5,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-28
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
 - name: ng

--- a/examples/29-cluster-with-karpenter.yaml
+++ b/examples/29-cluster-with-karpenter.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-with-karpenter
   region: us-west-2
-  version: '1.22'
+  version: "1.28"
   tags:
     karpenter.sh/discovery: cluster-with-karpenter
 

--- a/examples/30-vpc-with-ip-family.yaml
+++ b/examples/30-vpc-with-ip-family.yaml
@@ -4,9 +4,9 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: cluster-2
+  name: cluster-30
   region: us-west-2
-  version: "1.21"
+  version: "1.28"
 
 kubernetesNetworkConfig:
   ipFamily: IPv6

--- a/examples/31-override-bootstrap-command-unmanaged-nodegroup.yaml
+++ b/examples/31-override-bootstrap-command-unmanaged-nodegroup.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: override-unmanaged-nodegroup-bootstrap
   region: us-west-2
-  version: '1.21'
+  version: "1.28"
 
 nodeGroups:
   - name: ng-1

--- a/examples/32-windows-nodes-with-containerd.yaml
+++ b/examples/32-windows-nodes-with-containerd.yaml
@@ -7,6 +7,7 @@ kind: ClusterConfig
 metadata:
   name: windows-cluster
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: windows-ng

--- a/examples/33-local-zones.yaml
+++ b/examples/33-local-zones.yaml
@@ -5,6 +5,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-33
   region: us-west-2
+  version: "1.28"
 
 localZones: ["us-west-2-lax-1a", "us-west-2-lax-1b"]
 

--- a/examples/34-taints.yaml
+++ b/examples/34-taints.yaml
@@ -5,6 +5,7 @@ kind: ClusterConfig
 metadata:
   name: taints-1
   region: us-west-1
+  version: "1.28"
 
 # Unmanaged nodegroups with and without taints.
 nodeGroups:

--- a/examples/35-iamidentitymappings.yaml
+++ b/examples/35-iamidentitymappings.yaml
@@ -5,6 +5,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-with-iamidentitymappings
   region: us-east-1
+  version: "1.28"
 
 iamIdentityMappings:
   - arn: arn:aws:iam::000000000000:role/myAdminRole

--- a/examples/35-outposts.yaml
+++ b/examples/35-outposts.yaml
@@ -10,6 +10,7 @@ kind: ClusterConfig
 metadata:
   name: outpost
   region: us-west-2
+  version: "1.28"
 
 nodeGroups:
   - name: ng

--- a/examples/36-outposts-vpc.yaml
+++ b/examples/36-outposts-vpc.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: outpost-vpc
   region: us-west-2
+  version: "1.28"
 
 vpc:
   id: vpc-1234

--- a/examples/37-outposts-fully-private.yaml
+++ b/examples/37-outposts-fully-private.yaml
@@ -10,7 +10,7 @@ kind: ClusterConfig
 metadata:
   name: outpost-fully-private
   region: us-west-2
-  version: "1.21"
+  version: "1.28"
 
 privateCluster:
   enabled: true

--- a/examples/38-cluster-subnets-sgs.yaml
+++ b/examples/38-cluster-subnets-sgs.yaml
@@ -6,6 +6,7 @@ kind: ClusterConfig
 metadata:
   name: cluster-38
   region: us-west-2
+  version: "1.28"
 
 iam:
   withOIDC: true


### PR DESCRIPTION
### Description

Existing sample ClusterConfigs under `examples/` having EOL/EOS version, should be updated.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: