### PR TITLE
Fix outdated links

### DIFF
--- a/pkg/addons/default/aws_node_generate.go
+++ b/pkg/addons/default/aws_node_generate.go
@@ -1,4 +1,4 @@
 package defaultaddons
 
-// Please refer to https://docs.aws.amazon.com/eks/latest/userguide/cni-upgrades.html
+// Please refer to https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 //go:generate curl --silent --location https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.12.6/config/master/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1548,8 +1548,8 @@
         "metrics"
       ],
       "additionalProperties": false,
-      "description": "used by the scaling config, see [cloudformation docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-metricscollection.html)",
-      "x-intellij-html-description": "used by the scaling config, see <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-metricscollection.html\">cloudformation docs</a>"
+      "description": "used by the scaling config, see [cloudformation docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-metricscollection.html)",
+      "x-intellij-html-description": "used by the scaling config, see <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-metricscollection.html\">cloudformation docs</a>"
     },
     "NodeGroup": {
       "required": [
@@ -2465,8 +2465,8 @@
       "properties": {
         "autoScaler": {
           "type": "boolean",
-          "description": "adds policies for cluster-autoscaler. See [autoscaler AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html).",
-          "x-intellij-html-description": "adds policies for cluster-autoscaler. See <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html\">autoscaler AWS docs</a>.",
+          "description": "adds policies for cluster-autoscaler. See [autoscaler AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html#cluster-autoscaler).",
+          "x-intellij-html-description": "adds policies for cluster-autoscaler. See <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html#cluster-autoscaler\">autoscaler AWS docs</a>.",
           "default": "false"
         },
         "awsLoadBalancerController": {
@@ -2483,8 +2483,8 @@
         },
         "ebsCSIController": {
           "type": "boolean",
-          "description": "adds policies for using the ebs-csi-controller. See [aws-ebs-csi-driver docs](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#set-up-driver-permission).",
-          "x-intellij-html-description": "adds policies for using the ebs-csi-controller. See <a href=\"https://github.com/kubernetes-sigs/aws-ebs-csi-driver#set-up-driver-permission\">aws-ebs-csi-driver docs</a>.",
+          "description": "adds policies for using the ebs-csi-controller. See [aws-ebs-csi-driver docs](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#set-up-driver-permissions).",
+          "x-intellij-html-description": "adds policies for using the ebs-csi-controller. See <a href=\"https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#set-up-driver-permissions\">aws-ebs-csi-driver docs</a>.",
           "default": "false"
         },
         "efsCSIController": {

--- a/userdocs/src/usage/security.md
+++ b/userdocs/src/usage/security.md
@@ -7,7 +7,7 @@
 Enable [`withOIDC`](/usage/schema/#iam-withOIDC) to automatically create an [IRSA](/usage/iamserviceaccounts/) for the amazon CNI plugin and
 limit permissions granted to nodes in your cluster, instead granting the necessary permissions
 only to the CNI service account. The background is described in [this AWS
-documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-cni-walkthrough.html).
+documentation](https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html).
 
 ## `disablePodIMDS`
 


### PR DESCRIPTION
### Description

Some legacy Amazon EKS doc links need update as upstream doc changed location.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

