### PR TITLE
Ignore google docs domains for link checker

### DIFF
--- a/.github/workflows/exclude-file.txt
+++ b/.github/workflows/exclude-file.txt
@@ -19,3 +19,5 @@ schema.js
 weave-community.slack.com
 netlify.com
 slack.k8s.io
+docs.google.com
+groups.google.com


### PR DESCRIPTION
### Description
Ignore Google Docs domains for link checker

Greetings action is also failing but looks like it is an upstream issue https://github.com/actions/first-interaction/issues/286

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

