### PR TITLE
fix: Skip installing EFA if already present on the host

### DIFF
--- a/pkg/nodebootstrap/assets/scripts/efa.al2.sh
+++ b/pkg/nodebootstrap/assets/scripts/efa.al2.sh
@@ -4,9 +4,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-yum install -y wget
-wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer.tar.gz
-tar -xf /tmp/aws-efa-installer.tar.gz -C /tmp
-cd /tmp/aws-efa-installer
-./efa_installer.sh -y -g
-/opt/amazon/efa/bin/fi_info -p efa
+if [ ! -f /opt/amazon/efa/bin/fi_info ]
+then
+    yum install -y wget
+    wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer.tar.gz
+    tar -xf /tmp/aws-efa-installer.tar.gz -C /tmp
+    cd /tmp/aws-efa-installer
+    ./efa_installer.sh -y -g
+    /opt/amazon/efa/bin/fi_info -p efa
+fi


### PR DESCRIPTION
### Description

- Skip installing EFA if already present on the host
	- Closes #7339 
	- I'm not sure how https://github.com/eksctl-io/eksctl/blob/main/pkg/nodebootstrap/assets/scripts/efa.managed.boothook would be updated in a similar fashion
	
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

