### PR TITLE
Documentation Update: Correct IAM Pod Identity Example Link

### DIFF
--- a/userdocs/src/usage/pod-identity-associations.md
+++ b/userdocs/src/usage/pod-identity-associations.md
@@ -54,7 +54,7 @@ iam:
     tags: {} #optional
 ```
 
-For a complete example, refer to [pod-identity-associations.yaml](https://github.com/eksctl-io/eksctl/blob/main/examples/38-cluster-subnets-sgs.yaml).
+For a complete example, refer to [pod-identity-associations.yaml](https://github.com/eksctl-io/eksctl/blob/main/examples/39-pod-identity-association.yaml).
 
 ???+ note
     Apart from `permissionPolicy` which is used as an inline policy document, all other fields have a CLI flag counterpart.


### PR DESCRIPTION
### Description

This updates a link in the Pod IAM Identity documentation to correctly reference the example provided in GitHub

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ X] Manually tested
- [ X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

