### PR TITLE
Fix checks for updated addon versions

### DIFF
--- a/pkg/actions/addon/get.go
+++ b/pkg/actions/addon/get.go
@@ -115,9 +115,6 @@ func (a *Manager) findNewerVersions(ctx context.Context, addon *api.Addon) (stri
 		logger.Debug("could not parse version %q, skipping finding newer versions: %v", addon.Version, err)
 		return "-", nil
 	}
-	//trim off anything after x.y.z so its not used in comparison, e.g. 1.7.5-eksbuild.1 > 1.7.5
-	currentVersion.Build = []string{}
-	currentVersion.Pre = []semver.PRVersion{}
 
 	versions, err := a.describeVersions(ctx, addon)
 	if err != nil {
@@ -133,9 +130,6 @@ func (a *Manager) findNewerVersions(ctx context.Context, addon *api.Addon) (stri
 		if err != nil {
 			logger.Debug("could not parse version %q, skipping version comparison: %v", addon.Version, err)
 		} else {
-			//trim off anything after x.y.z and don't use in comparison, e.g. v1.7.5-eksbuild.1 > v1.7.5
-			version.Build = []string{}
-			version.Pre = []semver.PRVersion{}
 			if currentVersion.LT(version) {
 				newerVersions = append(newerVersions, *versionInfo.AddonVersion)
 			}

--- a/pkg/actions/addon/get_test.go
+++ b/pkg/actions/addon/get_test.go
@@ -45,14 +45,16 @@ var _ = Describe("Get", func() {
 						Type:      aws.String("type"),
 						AddonVersions: []ekstypes.AddonVersionInfo{
 							{
-								AddonVersion: aws.String("1.0.0"),
+								AddonVersion: aws.String("v1.0.0-eksbuild.1"),
 							},
 							{
-								//not sure if all versions come with v prefix or not, so test a mix
-								AddonVersion: aws.String("v1.1.0"),
+								AddonVersion: aws.String("v1.1.0-eksbuild.1"),
 							},
 							{
-								AddonVersion: aws.String("1.2.0"),
+								AddonVersion: aws.String("v1.1.0-eksbuild.4"),
+							},
+							{
+								AddonVersion: aws.String("v1.2.0-eksbuild.1"),
 							},
 						},
 					},
@@ -66,7 +68,7 @@ var _ = Describe("Get", func() {
 			}).Return(&awseks.DescribeAddonOutput{
 				Addon: &ekstypes.Addon{
 					AddonName:             aws.String("my-addon"),
-					AddonVersion:          aws.String("v1.0.0"),
+					AddonVersion:          aws.String("v1.1.0-eksbuild.1"),
 					ServiceAccountRoleArn: aws.String("foo"),
 					Status:                "created",
 					Health: &ekstypes.AddonHealth{
@@ -87,8 +89,8 @@ var _ = Describe("Get", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(summary).To(Equal(addon.Summary{
 				Name:         "my-addon",
-				Version:      "v1.0.0",
-				NewerVersion: "v1.1.0,1.2.0",
+				Version:      "v1.1.0-eksbuild.1",
+				NewerVersion: "v1.1.0-eksbuild.4,v1.2.0-eksbuild.1",
 				IAMRole:      "foo",
 				Status:       "created",
 				Issues: []addon.Issue{
@@ -135,14 +137,16 @@ var _ = Describe("Get", func() {
 						Type:      aws.String("type"),
 						AddonVersions: []ekstypes.AddonVersionInfo{
 							{
-								AddonVersion: aws.String("1.0.0"),
+								AddonVersion: aws.String("v1.0.0-eksbuild.1"),
 							},
 							{
-								//not sure if all versions come with v prefix or not, so test a mix
-								AddonVersion: aws.String("v1.1.0"),
+								AddonVersion: aws.String("v1.1.0-eksbuild.1"),
 							},
 							{
-								AddonVersion: aws.String("1.2.0"),
+								AddonVersion: aws.String("v1.1.0-eksbuild.4"),
+							},
+							{
+								AddonVersion: aws.String("v1.2.0-eksbuild.1"),
 							},
 						},
 					},
@@ -164,7 +168,7 @@ var _ = Describe("Get", func() {
 			}).Return(&awseks.DescribeAddonOutput{
 				Addon: &ekstypes.Addon{
 					AddonName:             aws.String("my-addon"),
-					AddonVersion:          aws.String("1.0.0"),
+					AddonVersion:          aws.String("v1.1.0-eksbuild.1"),
 					ServiceAccountRoleArn: aws.String("foo"),
 					Status:                "created",
 					ConfigurationValues:   aws.String("{\"replicaCount\":3}"),
@@ -176,8 +180,8 @@ var _ = Describe("Get", func() {
 			Expect(summary).To(Equal([]addon.Summary{
 				{
 					Name:                "my-addon",
-					Version:             "1.0.0",
-					NewerVersion:        "v1.1.0,1.2.0",
+					Version:             "v1.1.0-eksbuild.1",
+					NewerVersion:        "v1.1.0-eksbuild.4,v1.2.0-eksbuild.1",
 					IAMRole:             "foo",
 					Status:              "created",
 					ConfigurationValues: "{\"replicaCount\":3}",


### PR DESCRIPTION
### Description

Fixes #7229 

When executing `eksctl get addons` an available update is not shown if the only change to the version string is the `eksbuild` number, e.g. `v1.0.0-eksbuild.2` is not shown as an update of `v1.0.0-eksbuild.1`.

The `findNewerVersions` func in `pkg/actions/get.go` had code to explicitly ignore anything after the patch number. So `v1.1.0-eksbuild.1` and `v1.1.0-eksbuild.4` were both converted to `1.1.0` and considered equal. This fix removes the code that explicitly ignores the `-eksbuild.x` portion of the version and allows the `semver` package to compare the full version information.

Tests have also been updated to better match the version strings used by AWS addons.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

