### PR TITLE
Handle unordered public endpoint CIDRs from EKS in endpoint updates

### DIFF
--- a/pkg/ctl/utils/vpc_helper.go
+++ b/pkg/ctl/utils/vpc_helper.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/kris-nova/logger"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"golang.org/x/exp/slices"
 
@@ -176,5 +177,6 @@ func cidrsEqual(currentValues, newValues []string) bool {
 	if len(newValues) == 0 && len(currentValues) == 1 && currentValues[0] == "0.0.0.0/0" {
 		return true
 	}
-	return slices.Equal(currentValues, newValues)
+
+	return sets.NewString(currentValues...).Equal(sets.NewString(newValues...))
 }

--- a/pkg/ctl/utils/vpc_helper_test.go
+++ b/pkg/ctl/utils/vpc_helper_test.go
@@ -133,6 +133,21 @@ var _ = DescribeTable("VPCHelper", func(e vpcHelperEntry) {
 		},
 	}),
 
+	Entry("cluster public access CIDRs match desired config but out of order", vpcHelperEntry{
+		clusterVPC: &ekstypes.VpcConfigResponse{
+			EndpointPublicAccess:  true,
+			EndpointPrivateAccess: false,
+			PublicAccessCidrs:     []string{"2.2.2.2/32", "1.1.1.1/32"},
+		},
+		vpc: &api.ClusterVPC{
+			ClusterEndpoints: &api.ClusterEndpoints{
+				PublicAccess:  api.Enabled(),
+				PrivateAccess: api.Disabled(),
+			},
+			PublicAccessCIDRs: []string{"1.1.1.1/32", "2.2.2.2/32"},
+		},
+	}),
+
 	Entry("both cluster endpoint access and public access CIDRs do not match desired config", vpcHelperEntry{
 		clusterVPC: &ekstypes.VpcConfigResponse{
 			EndpointPublicAccess:  true,


### PR DESCRIPTION
### Description

For some clusters, EKS can return the list of public endpoint CIDRs out of order, and won't allow updates where the incoming and current sets have set equality (i.e. regardless of order of CIDR entries). This change restores the set equality check that was removed in commit 72605fbfb1d5b7a8f72dd58d184e7fd52a54cc88 and adds an additional test case to cover this case.

In our clusters, EKS always appears to return the CIDRs in a specific order, but not sorted - possibly due to the accumulation and removal of entries over time. Without this change, eksctl 0.167.0 will always attempt an update and get a 400 InvalidParameterException ("Cluster is already at the desired configuration with [...]") - with this applied, it correctly identifies no update is needed.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

