### PR TITLE
Expand Karpenter settings.aws block to settings for v0.33.0 and greater

### DIFF
--- a/pkg/karpenter/karpenter_test.go
+++ b/pkg/karpenter/karpenter_test.go
@@ -81,6 +81,21 @@ var _ = Describe("Install", func() {
 			}))
 		})
 
+		It("installs karpenter with expanded settings.aws values for version greater or equal to v0.33.0", func() {
+			installerUnderTest.Options.ClusterConfig.Karpenter.Version = "0.33.0"
+			Expect(installerUnderTest.Install(context.Background(), "dummy", "dummy")).To(Succeed())
+			_, opts := fakeHelmInstaller.InstallChartArgsForCall(0)
+			values := map[string]interface{}{
+				settings: map[string]interface{}{
+					defaultInstanceProfile: "dummy",
+					clusterName:            cfg.Metadata.Name,
+					clusterEndpoint:        cfg.Status.Endpoint,
+					interruptionQueueName:  cfg.Metadata.Name,
+				},
+			}
+			Expect(opts.Values[settings]).To(Equal(values[settings]))
+		})
+
 		When("install chart fails", func() {
 
 			BeforeEach(func() {


### PR DESCRIPTION
### Description

Fixes #7481 

Starting from Karpenter v0.33.0, `settings.aws` values are expanded to `settings`. This PR adds a check to update the values based on the version. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

