### PR TITLE
Skip draining managed nodegroups when deleting cluster

### DIFF
--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -178,10 +178,11 @@ func drainAllNodeGroups(ctx context.Context, cfg *api.ClusterConfig, ctl *eks.Cl
 		}
 	}
 
+	// EKS automatically drains managed nodegroups
 	logger.Info("will drain %d unmanaged nodegroup(s) in cluster %q", len(cfg.NodeGroups), cfg.Metadata.Name)
 
 	drainInput := &nodegroup.DrainInput{
-		NodeGroups:            cmdutils.ToKubeNodeGroups(cfg),
+		NodeGroups:            cmdutils.ToKubeNodeGroups(cfg.NodeGroups, []*api.ManagedNodeGroup{}),
 		MaxGracePeriod:        ctl.AWSProvider.WaitTimeout(),
 		DisableEviction:       disableEviction,
 		PodEvictionWaitPeriod: podEvictionWaitPeriod,

--- a/pkg/actions/cluster/delete_test.go
+++ b/pkg/actions/cluster/delete_test.go
@@ -59,7 +59,7 @@ var _ = Describe("DrainAllNodeGroups", func() {
 
 				nodeGroupStacks := []manager.NodeGroupStack{{NodeGroupName: "ng-1"}}
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod: ctl.AWSProvider.WaitTimeout(),
 					Parallel:       1,
 				}
@@ -87,7 +87,7 @@ var _ = Describe("DrainAllNodeGroups", func() {
 
 				nodeGroupStacks := []manager.NodeGroupStack{{NodeGroupName: "ng-1"}}
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:      cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:      cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod:  ctl.AWSProvider.WaitTimeout(),
 					DisableEviction: true,
 					Parallel:        1,
@@ -116,7 +116,7 @@ var _ = Describe("DrainAllNodeGroups", func() {
 
 				var nodeGroupStacks []manager.NodeGroupStack
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod: ctl.AWSProvider.WaitTimeout(),
 					Parallel:       1,
 				}

--- a/pkg/actions/cluster/owned_test.go
+++ b/pkg/actions/cluster/owned_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Delete", func() {
 				})
 
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod: ctl.AWSProvider.WaitTimeout(),
 					Parallel:       1,
 				}
@@ -253,7 +253,7 @@ var _ = Describe("Delete", func() {
 				})
 
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod: ctl.AWSProvider.WaitTimeout(),
 					Parallel:       1,
 				}

--- a/pkg/actions/cluster/unowned_test.go
+++ b/pkg/actions/cluster/unowned_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Delete", func() {
 				})
 
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod: ctl.AWSProvider.WaitTimeout(),
 					Parallel:       1,
 				}
@@ -348,7 +348,7 @@ var _ = Describe("Delete", func() {
 					},
 				}
 				mockedDrainInput := &nodegroup.DrainInput{
-					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg),
+					NodeGroups:     cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups),
 					MaxGracePeriod: ctl.AWSProvider.WaitTimeout(),
 					Parallel:       1,
 				}

--- a/pkg/ctl/cmdutils/cluster.go
+++ b/pkg/ctl/cmdutils/cluster.go
@@ -34,12 +34,12 @@ func ApplyFilter(clusterConfig *api.ClusterConfig, ngFilter filter.NodegroupFilt
 
 // ToKubeNodeGroups combines managed and unmanaged nodegroups and returns a slice of eks.KubeNodeGroup containing
 // both types of nodegroups
-func ToKubeNodeGroups(clusterConfig *api.ClusterConfig) []eks.KubeNodeGroup {
+func ToKubeNodeGroups(unmanagedNodeGroups []*api.NodeGroup, managedNodeGroups []*api.ManagedNodeGroup) []eks.KubeNodeGroup {
 	var kubeNodeGroups []eks.KubeNodeGroup
-	for _, ng := range clusterConfig.NodeGroups {
+	for _, ng := range unmanagedNodeGroups {
 		kubeNodeGroups = append(kubeNodeGroups, ng)
 	}
-	for _, ng := range clusterConfig.ManagedNodeGroups {
+	for _, ng := range managedNodeGroups {
 		kubeNodeGroups = append(kubeNodeGroups, ng)
 	}
 	return kubeNodeGroups

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -239,7 +239,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		}
 	}
 	logFiltered := cmdutils.ApplyFilter(cfg, ngFilter)
-	kubeNodeGroups := cmdutils.ToKubeNodeGroups(cfg)
+	kubeNodeGroups := cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups)
 
 	// Check if flux binary exists early in the process, so it doesn't fail at the end when the cluster
 	// has already been created with a missing flux binary error which should have been caught earlier.

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -136,7 +136,7 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, options deleteNodeG
 			}
 		}
 	}
-	allNodeGroups := cmdutils.ToKubeNodeGroups(cfg)
+	allNodeGroups := cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups)
 
 	if options.deleteNodeGroupDrain {
 		cmdutils.LogIntendedAction(cmd.Plan, "drain %d nodegroup(s) in cluster %q", len(allNodeGroups), cfg.Metadata.Name)

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -127,7 +127,7 @@ func doDrainNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bo
 	if cmd.Plan {
 		return nil
 	}
-	allNodeGroups := cmdutils.ToKubeNodeGroups(cfg)
+	allNodeGroups := cmdutils.ToKubeNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups)
 
 	drainInput := &nodegroup.DrainInput{
 		NodeGroups:            allNodeGroups,

--- a/userdocs/mkdocs.yml
+++ b/userdocs/mkdocs.yml
@@ -154,13 +154,13 @@ nav:
       - usage/cluster-upgrade.md
       - usage/addon-upgrade.md
     - Nodegroups:
-      - usage/managing-nodegroups.md
-      - usage/nodegroup-upgrade.md
+      - usage/nodegroups.md
+      - usage/nodegroup-unmanaged.md
+      - usage/nodegroup-managed.md
+      - usage/launch-template-support.md
       - usage/nodegroup-with-custom-subnet.md
       - usage/nodegroup-customize-dns.md
       - usage/nodegroup-taints.md
-      - usage/eks-managed-nodes.md
-      - usage/launch-template-support.md
       - usage/instance-selector.md
       - usage/spot-instances.md
       - usage/gpu-support.md

--- a/userdocs/src/usage/iamserviceaccounts.md
+++ b/userdocs/src/usage/iamserviceaccounts.md
@@ -94,7 +94,7 @@ To manage `iamserviceaccounts` using config file, you will be looking to set `ia
 
 All of the commands support `--config-file`, you can manage _iamserviceaccounts_ the same way as _nodegroups_.
 The `eksctl create iamserviceaccount` command supports `--include` and `--exclude` flags (see
-[this section](/usage/managing-nodegroups#include-and-exclude-rules) for more details about how these work).
+[this section](/usage/nodegroups#include-and-exclude-rules) for more details about how these work).
 And the `eksctl delete iamserviceaccount` command supports `--only-missing` as well, so you can perform deletions the same way as nodegroups.
 
 ???+ note

--- a/userdocs/src/usage/nodegroup-customize-dns.md
+++ b/userdocs/src/usage/nodegroup-customize-dns.md
@@ -1,4 +1,4 @@
-# Nodegroups with custom DNS
+# Custom DNS
 
 There are two ways of overwriting the DNS server IP address used for all the internal and external DNS lookups. This
 is the equivalent of the `--cluster-dns` flag for the `kubelet`.

--- a/userdocs/src/usage/nodegroup-managed.md
+++ b/userdocs/src/usage/nodegroup-managed.md
@@ -1,4 +1,4 @@
-# EKS Managed Nodegroups
+# EKS managed nodegroups
 
 [Amazon EKS managed nodegroups][eks-user-guide] is a feature that automates the provisioning and lifecycle management of nodes (EC2 instances) for Amazon EKS Kubernetes clusters. Customers can provision optimized groups of nodes for their clusters and EKS will keep their nodes up to date with the latest Kubernetes and host OS versions. 
 
@@ -250,7 +250,7 @@ This section defines two fields. `MaxUnavailable` and `MaxUnavailablePercentage`
 the update, thus downtime shouldn't be expected.
 
 The command `update nodegroup` should be used with a config file using the `--config-file` flag. The nodegroup should
-contain an `nodeGroup.updateConfig` section. More information can be found [here](https://eksctl.io/usage/schema/#nodeGroups-updateConfig).
+contain an `nodeGroup.updateConfig` section. More information can be found [here](/usage/schema/#nodeGroups-updateConfig).
 
 ## Nodegroup Health issues
 EKS Managed Nodegroups automatically checks the configuration of your nodegroup and nodes for health issues and reports
@@ -302,17 +302,6 @@ The unsupported options are noted below.
 - Full control over the node bootstrapping process and customization of the kubelet are not supported. This includes the
 following fields: `classicLoadBalancerNames`, `targetGroupARNs`, `clusterDNS` and `kubeletExtraConfig`.
 - No support for enabling metrics on AutoScalingGroups using `asgMetricsCollection`
-
-## Note for eksctl versions below 0.12.0
-- For clusters upgraded from EKS 1.13 to EKS 1.14, managed nodegroups will not be able to communicate with unmanaged
-nodegroups. As a result, pods in a managed nodegroup will be unable to reach pods in an unmanaged
-nodegroup, and vice versa.
-To fix this, use eksctl 0.12.0 or above and run `eksctl upgrade cluster`.
-To fix this manually, add ingress rules to the shared security group and the default cluster
-security group to allow traffic from each other. The shared security group and the default cluster security groups have
-the naming convention `eksctl-<cluster>-cluster-ClusterSharedNodeSecurityGroup-<id>` and
-`eks-cluster-sg-<cluster>-<id>-<id>` respectively.
-
 
 ## Further information
 

--- a/userdocs/src/usage/nodegroup-unmanaged.md
+++ b/userdocs/src/usage/nodegroup-unmanaged.md
@@ -1,4 +1,4 @@
-# Unmanaged nodegroup upgrades
+# Unmanaged nodegroups
 
 In `eksctl`, setting `--managed=false` or using the `nodeGroups` field creates an unmanaged nodegroup. Bear in mind that
 unmanaged nodegroups do not appear in the EKS console, which as a general rule only knows about EKS-managed nodegroups.
@@ -7,31 +7,31 @@ You should be upgrading nodegroups only after you ran `eksctl upgrade cluster`.
 (See [Upgrading clusters](/usage/cluster-upgrade).)
 
 If you have a simple cluster with just an initial nodegroup (i.e. created with
-`eksctl create cluster`), the process is very simple.
+`eksctl create cluster`), the process is very simple:
 
-Get the name of old nodegroup:
+1. Get the name of old nodegroup:
 
-```
-eksctl get nodegroups --cluster=<clusterName> --region=<region>
-```
+    ```shell
+    eksctl get nodegroups --cluster=<clusterName> --region=<region>
+    ```
 
-???+ note
-    You should see only one nodegroup here, if you see more - read the next section.
+    ???+ note
+        You should see only one nodegroup here, if you see more - read the next section.
 
-Create new nodegroup:
+2. Create a new nodegroup:
 
-```
-eksctl create nodegroup --cluster=<clusterName> --region=<region> --managed=false
-```
+    ```shell
+    eksctl create nodegroup --cluster=<clusterName> --region=<region> --name=<newNodeGroupName> --managed=false
+    ```
 
-Delete old nodegroup:
+3. Delete the old nodegroup:
 
-```
-eksctl delete nodegroup --cluster=<clusterName> --region=<region> --name=<oldNodeGroupName>
-```
+    ```shell
+    eksctl delete nodegroup --cluster=<clusterName> --region=<region> --name=<oldNodeGroupName>
+    ```
 
-???+ note
-    This will drain all pods from that nodegroup before the instances are deleted.
+    ???+ note
+        This will drain all pods from that nodegroup before the instances are deleted. In some scenarios, Pod Disruption Budget (PDB) policies can prevent pods to be evicted. To delete the nodegroup regardless of PDB, one should use the `--disable-eviction` flag, will bypass checking PDB policies.
 
 ## Updating multiple nodegroups
 
@@ -44,19 +44,7 @@ In general terms, you are looking to:
 - review which nodegroups you have and which ones can be deleted or must be replaced for the new version
 - note down configuration of each nodegroup, consider using config file to ease upgrades next time
 
-To create a new nodegroup:
-
-```
-eksctl create nodegroup --cluster=<clusterName> --region=<region> --name=<newNodeGroupName> --managed=false
-```
-
-To delete old nodegroup:
-
-```
-eksctl delete nodegroup --cluster=<clusterName> --region=<region> --name=<oldNodeGroupName>
-```
-
-## Updating multiple nodegroups with config file
+### Updating with config file
 
 If you are using config file, you will need to do the following.
 

--- a/userdocs/src/usage/nodegroup-with-custom-subnet.md
+++ b/userdocs/src/usage/nodegroup-with-custom-subnet.md
@@ -1,4 +1,4 @@
-# Nodegroups with custom subnet(s)
+# Custom subnets
 
 It's possible to extend an existing VPC with a new subnet and add a Nodegroup to that subnet.
 

--- a/userdocs/src/usage/nodegroups.md
+++ b/userdocs/src/usage/nodegroups.md
@@ -1,4 +1,4 @@
-# Managing nodegroups
+# Nodegroups
 
 ## Creating nodegroups
 You can add one or more nodegroups in addition to the initial nodegroup created along with the cluster.


### PR DESCRIPTION
### Description

As pointed out in #4205, the code intended to only drain unmanaged nodegroups since EKS should take care of managed nodegroups. However, `cmdutils.ToKubeNodeGroups` function has been populating the `DrainInput` with both unmanaged and managed nodegroups. This causes an inconsistency where when using `eksctl delete cluster --config-file` with a config that specify the managed nodegroup config, that managed nodegroup get drained; but `eksctl delete cluster --name` deleting the same cluster will skip draining the same managed nodegroup, because https://github.com/yuxiang-zhang/eksctl/blob/1d9cd7dc8370716d711e45bf17e2967434eb88f4/pkg/actions/cluster/delete.go#L174-L179 only populates the unmanaged nodegroups. 

Regardless of using `--config-file`, the behaviour for deleting a cluster should be consistent: either drain managed nodegroups, or skip draining managed nodegroups. This change sticks with the original intent from #4205, that is to skip draining managed nodegroups. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

