### PR TITLE
docs(fargate): eksctl update command is deprecated, use upgrade instead

### DIFF
--- a/userdocs/src/usage/fargate-support.md
+++ b/userdocs/src/usage/fargate-support.md
@@ -214,7 +214,7 @@ create a Fargate profile with the `eksctl create fargateprofile` command:
 ???+ note
     This operation is only supported on clusters that run on the EKS platform version `eks.5` or higher.
 
-    If the existing was created with a version of `eksctl` prior to 0.11.0, you will  need to run `eksctl update
+    If the existing was created with a version of `eksctl` prior to 0.11.0, you will  need to run `eksctl upgrade
     cluster` before creating the Fargate profile.
 
 ```console


### PR DESCRIPTION
### Description

Whilst following this guide, I ran `eksctl update cluster` which appears to be deprecated:

```shell
2024-01-30 13:33:15 [!]  This command is to be deprecated. Please use 'eksctl upgrade cluster' instead
```

There seem to be many instances of `eksctl update` throughout the docs, I just changed the one instance that I tested.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

