### PR TITLE
Check for empty region before invoking API in AWS SDK

### DIFF
--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -186,6 +186,10 @@ func newAWSProvider(spec *api.ProviderConfig, configurationLoader AWSConfigurati
 		return nil, err
 	}
 
+	if cfg.Region == "" {
+		return nil, fmt.Errorf("AWS Region must be set, please set the AWS Region in AWS config file or as environment variable")
+	}
+
 	if spec.Region == "" {
 		spec.Region = cfg.Region
 	}

--- a/pkg/eks/api_test.go
+++ b/pkg/eks/api_test.go
@@ -118,6 +118,14 @@ var _ = Describe("eksctl API", func() {
 			},
 			err: fmt.Sprintf("cache file %s is not private", cacheFilePath),
 		}),
+		Entry("region code is not set", newAWSProviderEntry{
+			updateFakes: func(fal *fakes.FakeAWSConfigurationLoader) {
+				fal.LoadDefaultConfigReturns(aws.Config{
+					Region: "",
+				}, nil)
+			},
+			err: "AWS Region must be set, please set the AWS Region in AWS config file or as environment variable",
+		}),
 		Entry("creates the AWS provider successfully", newAWSProviderEntry{}),
 	)
 


### PR DESCRIPTION
### Description

Currently, you will receive the following error if you **forget to set the AWS region code**.

$ eksctl create cluster
Error: checking AWS STS access – cannot get role ARN for current session: operation error STS: GetCallerIdentity, https response error StatusCode: 0, RequestID: , request send failed, Post "https://sts..amazonaws.com/": Bad Request

When you look closely, you can notice that there is something wrong with this endpoint "https://sts..amazonaws.com/".
However, it is difficult to immediately resolve the problem from this error message.

**This PR provides a more understandable error message if you run into the same situation**.
I think it helps to navigate the next action to solve the problem.
```
(demo)
$ ./eksctl create cluster
Error: no region code: please set the AWS region to ~/.aws/config file or environment variables.
```

note:
The Installation document already has "prerequisite" description about aws configs.
https://eksctl.io/installation/#prerequisite
 > You can use ~/.aws/credentials file or environment variables. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)
