### PR TITLE
Revert removing RetryMetricsHeader in presigned requests

### DIFF
--- a/pkg/eks/auth/generator.go
+++ b/pkg/eks/auth/generator.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
-	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -71,11 +69,6 @@ func (g Generator) appendPresignHeaderValuesFunc(clusterID string) func(stsOptio
 			// Add clusterId Header.
 			smithyhttp.SetHeaderValue(clusterIDHeader, clusterID),
 			// Add X-Amz-Expires query param.
-			smithyhttp.SetHeaderValue("X-Amz-Expires", "60"),
-			// Remove any extraneous headers: https://github.com/eksctl-io/eksctl/issues/7486.
-			func(stack *middleware.Stack) error {
-				_, err := stack.Finalize.Remove((&retry.MetricsHeader{}).ID())
-				return err
-			})
+			smithyhttp.SetHeaderValue("X-Amz-Expires", "60"))
 	}
 }


### PR DESCRIPTION
### Description

With the update to `aws-sdk-go-v2@1.25.0`, API server requests containing URLs presigned by `sts.PresignClient` fail with `error generating token: failed to presign caller identity: not found, RetryMetricsHeader`.

Previous issue https://github.com/eksctl-io/eksctl/issues/7486 has this `RetryMetricsHeader` header removed. This PR reverts that change. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

