### PR TITLE
Assign EFA network interface device index 1 to additional network cards

### DIFF
--- a/pkg/cfn/builder/network_interfaces.go
+++ b/pkg/cfn/builder/network_interfaces.go
@@ -59,12 +59,10 @@ func buildNetworkInterfaces(
 
 		firstNI.InterfaceType = gfnt.NewString("efa")
 		nis := []gfnec2.LaunchTemplate_NetworkInterface{firstNI}
-		// Only one card can be on deviceIndex=0
-		// Additional cards are on deviceIndex=1
-		// Due to ASG incompatibilities, we create each network card
-		// with its own device
+		// The primary network interface (device index 0) must be assigned to network card index 0
+		// device index 1 for additional cards
 		for i := 1; i < int(numEFAs); i++ {
-			ni := defaultNetworkInterface(securityGroups, i, i)
+			ni := defaultNetworkInterface(securityGroups, 1, i)
 			ni.InterfaceType = gfnt.NewString("efa")
 			nis = append(nis, ni)
 		}


### PR DESCRIPTION
### Description

Fixes #7520 

ASG has addressed the previous limitation where we can't assign the same device index to different network cards. This PR makes the configuration to work across all instance types. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

