### PR TITLE
[Release drafter] Treat RCs as full releases when drafting notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,6 +32,7 @@ template: |
 
   The eksctl maintainers would like to sincerely thank $CONTRIBUTORS.
 
+include-pre-releases: true
 exclude-labels:
   - 'skip-release-notes'
 exclude-contributors:


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Release notes PR is currently displaying wrong release version when a RC that hasn't been yet graduated to full release exists. e.g.  https://github.com/eksctl-io/eksctl/pull/7721

Manually tested the fix against my eksctl fork.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

