### PR TITLE
Fix for #7450 sigsegv error when trying to clean up the stacks with missing eks cluster

### DIFF
--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -135,6 +135,9 @@ func (c *OwnedCluster) Delete(ctx context.Context, _, podEvictionWaitPeriod time
 			DeleteTasks(ctx, []podidentityassociation.Identifier{})
 	}
 
+	if !clusterOperable {
+		c.ctl.Status.ClusterInfo = &eks.ClusterInfo{}
+	}
 	tasks, err := c.stackManager.NewTasksToDeleteClusterWithNodeGroups(ctx, c.clusterStack, allStacks, clusterOperable, newOIDCManager, newTasksToDeleteAddonIAM, newTasksToDeletePodIdentityRoles, c.ctl.Status.ClusterInfo.Cluster, kubernetes.NewCachedClientSet(clientSet), wait, force, func(errs chan error, _ string) error {
 		logger.Info("trying to cleanup dangling network interfaces")
 		stack, err := c.stackManager.DescribeClusterStack(ctx)


### PR DESCRIPTION
### Description
This PR is to fix the issue #7450 encountered when using `eksctl delete cluster --force` command to delete the stacks after manually deleting the eks cluster resource. 

When a cluster is inoperable (clusterOperable=false), the `c.ctl.Status.ClusterInfo` value is `nil`, and therefore passing `c.ctl.Status.ClusterInfo.Cluster` to the `NewTasksToDeleteClusterWithNodeGroups` function ([owned.go#L138](https://github.com/eksctl-io/eksctl/blob/02294680c0d7fb5843383c1aff654bf07729870d/pkg/actions/cluster/owned.go#L138)) is causing the nil pointer exception. 

I'm setting the `c.ctl.Status.ClusterInfo` to an empty struct so that the function signature is respected. The actual value is never used in the function anyway because of `clusterOperable=false`.
 
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

