### PR TITLE
Fix Github workflow for updating generated files for default addons

### DIFF
--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -50,33 +50,12 @@ jobs:
             go-
       - name: Update ${{ matrix.resource }}
         run: make update-${{ matrix.resource }}
-      - name: Commit changes
-        id: commit
-        run: |
-          git checkout $DEFAULT_BRANCH
-          git checkout -B update-${{ matrix.resource }}
-          git add -u
-          if ! EDITOR=true git commit -m "Update ${{ matrix.resource }}"; then
-            echo "changes=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          echo "changes=true" >> $GITHUB_OUTPUT
-          ! git diff --exit-code $DEFAULT_BRANCH HEAD
-          git push --force-with-lease origin HEAD
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        name: Open PR to ${{env.DEFAULT_BRANCH}}
-        if: steps.commit.outputs.changes == 'true'
+      - name: Upsert pull request
+        uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e #v6.0.2
         with:
-          github-token: ${{ secrets.EKSCTLBOT_TOKEN }}
-          script: |
-            const { data: pr } = await github.rest.pulls.create({
-              ...context.repo,
-              title: "Update ${{ matrix.resource }}",
-              head: "update-${{ matrix.resource }}",
-              base: "${{ env.DEFAULT_BRANCH }}",
-            });
-            await github.rest.issues.addLabels({
-              ...context.repo,
-              issue_number: pr.number,
-              labels: ["kind/improvement"],
-            });
+          token: ${{ secrets.EKSCTLBOT_TOKEN }}
+          commit-message: update ${{ matrix.resource }}
+          committer: eksctl-bot <eksctl-bot@users.noreply.github.com>
+          title: 'Update ${{ matrix.resource }}'
+          branch: update-${{ matrix.resource }}
+          labels: area/tech-debt

--- a/Makefile
+++ b/Makefile
@@ -160,13 +160,10 @@ generate-all: generate-always $(conditionally_generated_files) ## Re-generate al
 check-all-generated-files-up-to-date: generate-all ## Run the generate all command and verify there is no new diff
 	git diff --quiet -- $(conditionally_generated_files) || (git --no-pager diff $(conditionally_generated_files); echo "HINT: to fix this, run 'git commit $(conditionally_generated_files) --message \"Update generated files\"'"; exit 1)
 
-### Update aws-node addon manifests from AWS
-pkg/addons/default/assets/aws-node.yaml:
-	go generate ./pkg/addons/default/aws_node_generate.go
 
 .PHONY: update-aws-node
 update-aws-node: ## Re-download the aws-node manifests from AWS
-	go generate ./pkg/addons/default/aws_node_generate.go
+	pkg/addons/default/scripts/update_aws_node.sh
 
 .PHONY:
 update-coredns: ## get latest coredns builds for each available eks version

--- a/pkg/addons/default/aws_node_generate.go
+++ b/pkg/addons/default/aws_node_generate.go
@@ -1,4 +1,0 @@
-package defaultaddons
-
-// Please refer to https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-//go:generate curl --silent --location https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.18.1/config/master/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml

--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -2,6 +2,7 @@ package defaultaddons_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -60,6 +61,7 @@ var _ = Describe("AWS Node", func() {
 
 	Describe("UpdateAWSNode", func() {
 		var preUpdateAwsNode *v1.DaemonSet
+		const expectedVersion = "v1.18.1"
 		BeforeEach(func() {
 			loadSamples(rawClient, "testdata/sample-1.15.json")
 
@@ -79,11 +81,11 @@ var _ = Describe("AWS Node", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(2))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
-					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.18.1"),
+					Equal(fmt.Sprintf("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:%s", expectedVersion)),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
-					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.18.1"),
+					Equal(fmt.Sprintf("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:%s", expectedVersion)),
 				)
 			})
 		})
@@ -99,11 +101,11 @@ var _ = Describe("AWS Node", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(2))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
-					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.18.1"),
+					Equal(fmt.Sprintf("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:%s", expectedVersion)),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
-					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.18.1"),
+					Equal(fmt.Sprintf("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:%s", expectedVersion)),
 				)
 			})
 		})

--- a/pkg/addons/default/scripts/update_aws_node.sh
+++ b/pkg/addons/default/scripts/update_aws_node.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Set base URL for VPC CNI releases on GitHub
+base_url="https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/"
+
+get_latest_release_tag() {
+  curl -sL https://api.github.com/repos/aws/amazon-vpc-cni-k8s/releases/latest | jq -r '.tag_name'
+}
+
+latest_release_tag=$(get_latest_release_tag)
+
+default_addons_dir="pkg/addons/default"
+
+# Download the latest aws-k8s-cni.yaml file
+curl -sL "$base_url$latest_release_tag/config/master/aws-k8s-cni.yaml?raw=1" --output "$default_addons_dir/assets/aws-node.yaml"
+
+echo "found latest release tag:" $latest_release_tag
+
+# Update the unit test file
+sed -i "s/expectedVersion = \"\(.*\)\"/expectedVersion = \"$latest_release_tag\"/g" "$default_addons_dir/aws_node_test.go"


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

The Github workflow responsible for upgrading the manifests for default `aws-node` and `coredns` addons has been broken for a while.
https://github.com/eksctl-io/eksctl/actions/workflows/update-generated.yaml

This PR aims to provide a fix for that. People have been experiencing issues with `eksctl utils update` commands since the generated files were out of date for long period of time. e.g. https://github.com/eksctl-io/eksctl/issues/7755

Additionally, the PR includes a fix for the `update coredns` PR, as in, it excludes `preview` versions when trying to resolve the latest. Manual test for that https://github.com/eksctl-io/eksctl/pull/7767
 
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

