### PR TITLE
Fix upgrading AL2 ARM64 nodegroups

### DIFF
--- a/pkg/actions/nodegroup/upgrade.go
+++ b/pkg/actions/nodegroup/upgrade.go
@@ -266,7 +266,9 @@ func (m *Manager) upgradeUsingStack(ctx context.Context, options UpgradeOptions,
 		latestReleaseVersion, err := m.getLatestReleaseVersion(ctx, kubernetesVersion, nodegroup)
 		if err != nil {
 			return err
-		} else if latestReleaseVersion != "" {
+		}
+
+		if latestReleaseVersion != "" {
 			if err := m.updateReleaseVersion(latestReleaseVersion, options.LaunchTemplateVersion, nodegroup, ngResource); err != nil {
 				return err
 			}
@@ -337,15 +339,10 @@ func (m *Manager) requiresStackUpdate(ctx context.Context, nodeGroupName string)
 }
 
 func (m *Manager) getLatestReleaseVersion(ctx context.Context, kubernetesVersion string, nodeGroup *ekstypes.Nodegroup) (string, error) {
-	ssmParameterName, err := ami.MakeManagedSSMParameterName(kubernetesVersion, nodeGroup.AmiType)
-	if err != nil {
-		return "", err
-	}
-
+	ssmParameterName := ami.MakeManagedSSMParameterName(kubernetesVersion, nodeGroup.AmiType)
 	if ssmParameterName == "" {
 		return "", nil
 	}
-
 	ssmOutput, err := m.ctl.AWSProvider.SSM().GetParameter(ctx, &ssm.GetParameterInput{
 		Name: &ssmParameterName,
 	})

--- a/pkg/ami/ssm_resolver.go
+++ b/pkg/ami/ssm_resolver.go
@@ -84,24 +84,29 @@ func MakeSSMParameterName(version, instanceType, imageFamily string) (string, er
 }
 
 // MakeManagedSSMParameterName creates an SSM parameter name for a managed nodegroup
-func MakeManagedSSMParameterName(version string, amiType ekstypes.AMITypes) (string, error) {
+func MakeManagedSSMParameterName(version string, amiType ekstypes.AMITypes) string {
+	makeAL2ParameterName := func(imageTypeSuffix string) string {
+		imageType := utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2) + imageTypeSuffix
+		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/recommended/release_version", version, imageType)
+	}
 	switch amiType {
 	case ekstypes.AMITypesAl2023X8664Standard:
-		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/x86_64/standard/recommended/release_version", version, utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2023)), nil
+		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/x86_64/standard/recommended/release_version", version, utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2023))
 	case ekstypes.AMITypesAl2023Arm64Standard:
-		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/arm64/standard/recommended/release_version", version, utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2023)), nil
+		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/arm64/standard/recommended/release_version", version, utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2023))
 	case ekstypes.AMITypesAl2X8664:
-		imageType := utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2)
-		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/recommended/release_version", version, imageType), nil
+		return makeAL2ParameterName("")
 	case ekstypes.AMITypesAl2X8664Gpu:
-		imageType := utils.ToKebabCase(api.NodeImageFamilyAmazonLinux2) + "-gpu"
-		return fmt.Sprintf("/aws/service/eks/optimized-ami/%s/%s/recommended/release_version", version, imageType), nil
+		return makeAL2ParameterName("-gpu")
+	case ekstypes.AMITypesAl2Arm64:
+		return makeAL2ParameterName("-arm64")
 	case ekstypes.AMITypesBottlerocketArm64, ekstypes.AMITypesBottlerocketArm64Nvidia:
-		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_version", version), nil
+		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_version", version)
 	case ekstypes.AMITypesBottlerocketX8664, ekstypes.AMITypesBottlerocketX8664Nvidia:
-		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_version", version), nil
+		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_version", version)
+	default:
+		return ""
 	}
-	return "", nil
 }
 
 // instanceEC2ArchName returns the name of the architecture as used by EC2

--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -2,16 +2,19 @@ package ami_test
 
 import (
 	"context"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
 	. "github.com/weaveworks/eksctl/pkg/ami"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 )
 
@@ -395,6 +398,19 @@ var _ = Describe("AMI Auto Resolution", func() {
 					})
 				})
 			})
+		})
+	})
+
+	Context("managed SSM parameter name", func() {
+		It("should support SSM parameter generation for all AMI types but Windows", func() {
+			var eksAMIType ekstypes.AMITypes
+			for _, amiType := range eksAMIType.Values() {
+				if amiType == ekstypes.AMITypesCustom || strings.HasPrefix(string(amiType), "WINDOWS_") {
+					continue
+				}
+				ssmParameterName := MakeManagedSSMParameterName(api.LatestVersion, amiType)
+				Expect(ssmParameterName).NotTo(BeEmpty(), "expected to generate SSM parameter name for AMI type %s", amiType)
+			}
 		})
 	})
 })


### PR DESCRIPTION
### Description

Fixes upgrading AL2 ARM64 nodegroups by generating an SSM parameter name for AMI type `AL2_ARM_64`.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

