### PR TITLE
Make EKS 1.30 the default

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -769,9 +769,9 @@
         },
         "version": {
           "type": "string",
-          "description": "Valid variants are: `\"1.23\"`, `\"1.24\"`, `\"1.25\"`, `\"1.26\"`, `\"1.27\"`, `\"1.28\"`, `\"1.29\"` (default), `\"1.30\"` represents Kubernetes version 1.30.x..",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;1.23&quot;</code>, <code>&quot;1.24&quot;</code>, <code>&quot;1.25&quot;</code>, <code>&quot;1.26&quot;</code>, <code>&quot;1.27&quot;</code>, <code>&quot;1.28&quot;</code>, <code>&quot;1.29&quot;</code> (default), <code>&quot;1.30&quot;</code> represents Kubernetes version 1.30.x..",
-          "default": "1.29",
+          "description": "Valid variants are: `\"1.23\"`, `\"1.24\"`, `\"1.25\"`, `\"1.26\"`, `\"1.27\"`, `\"1.28\"`, `\"1.29\"`, `\"1.30\"` (default).",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;1.23&quot;</code>, <code>&quot;1.24&quot;</code>, <code>&quot;1.25&quot;</code>, <code>&quot;1.26&quot;</code>, <code>&quot;1.27&quot;</code>, <code>&quot;1.28&quot;</code>, <code>&quot;1.29&quot;</code>, <code>&quot;1.30&quot;</code> (default).",
+          "default": "1.30",
           "enum": [
             "1.23",
             "1.24",

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -10,6 +10,7 @@ import (
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
 	"github.com/weaveworks/eksctl/pkg/utils"
+	instanceutils "github.com/weaveworks/eksctl/pkg/utils/instance"
 )
 
 const (
@@ -134,7 +135,8 @@ func SetManagedNodeGroupDefaults(ng *ManagedNodeGroup, meta *ClusterMeta, contro
 	// When using custom AMIs, we want the user to explicitly specify AMI family.
 	// Thus, we only set up default AMI family when no custom AMI is being used.
 	if ng.AMIFamily == "" && ng.AMI == "" {
-		if isMinVer, _ := utils.IsMinVersion(Version1_30, meta.Version); isMinVer {
+		if isMinVer, _ := utils.IsMinVersion(Version1_30, meta.Version); isMinVer && !instanceutils.IsGPUInstanceType(ng.InstanceType) &&
+			!instanceutils.IsARMGPUInstanceType(ng.InstanceType) {
 			ng.AMIFamily = NodeImageFamilyAmazonLinux2023
 		} else {
 			ng.AMIFamily = NodeImageFamilyAmazonLinux2

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -43,11 +43,10 @@ const (
 
 	Version1_29 = "1.29"
 
-	// Version1_30 represents Kubernetes version 1.30.x.
 	Version1_30 = "1.30"
 
 	// DefaultVersion (default)
-	DefaultVersion = Version1_29
+	DefaultVersion = Version1_30
 
 	LatestVersion = Version1_30
 

--- a/pkg/cfn/builder/managed_nodegroup_ami_type_test.go
+++ b/pkg/cfn/builder/managed_nodegroup_ami_type_test.go
@@ -64,7 +64,7 @@ var _ = DescribeTable("Managed Nodegroup AMI type", func(e amiTypeEntry) {
 				Name: "test",
 			},
 		},
-		expectedAMIType: "AL2_x86_64",
+		expectedAMIType: "AL2023_x86_64_STANDARD",
 	}),
 
 	Entry("AL2 AMI type", amiTypeEntry{
@@ -83,7 +83,7 @@ var _ = DescribeTable("Managed Nodegroup AMI type", func(e amiTypeEntry) {
 				Name: "test",
 			},
 		},
-		expectedAMIType: "AL2_x86_64",
+		expectedAMIType: "AL2023_x86_64_STANDARD",
 	}),
 
 	Entry("default GPU instance type", amiTypeEntry{

--- a/pkg/cfn/builder/testdata/launch_template/launch_template.json
+++ b/pkg/cfn/builder/testdata/launch_template/launch_template.json
@@ -2,7 +2,7 @@
     "ManagedNodeGroup": {
         "Type": "AWS::EKS::Nodegroup",
         "Properties": {
-            "AmiType": "AL2_x86_64",
+            "AmiType": "AL2023_x86_64_STANDARD",
             "ClusterName": "lt",
             "Labels": {
                 "alpha.eksctl.io/cluster-name": "lt",

--- a/pkg/cfn/builder/testdata/launch_template/launch_template_additional_volumes.json
+++ b/pkg/cfn/builder/testdata/launch_template/launch_template_additional_volumes.json
@@ -96,7 +96,7 @@
   "ManagedNodeGroup": {
     "Type": "AWS::EKS::Nodegroup",
     "Properties": {
-      "AmiType": "AL2_x86_64",
+      "AmiType": "AL2023_x86_64_STANDARD",
       "ClusterName": "lt",
       "InstanceTypes": [
         "m5.large"

--- a/pkg/cfn/builder/testdata/launch_template/launch_template_additional_volumes_missing_size.json
+++ b/pkg/cfn/builder/testdata/launch_template/launch_template_additional_volumes_missing_size.json
@@ -95,7 +95,7 @@
   "ManagedNodeGroup": {
     "Type": "AWS::EKS::Nodegroup",
     "Properties": {
-      "AmiType": "AL2_x86_64",
+      "AmiType": "AL2023_x86_64_STANDARD",
       "ClusterName": "lt",
       "InstanceTypes": [
         "m5.large"

--- a/pkg/cfn/builder/testdata/launch_template/placement.json
+++ b/pkg/cfn/builder/testdata/launch_template/placement.json
@@ -88,7 +88,7 @@
     "ManagedNodeGroup": {
         "Type": "AWS::EKS::Nodegroup",
         "Properties": {
-            "AmiType": "AL2_x86_64",
+            "AmiType": "AL2023_x86_64_STANDARD",
             "ClusterName": "lt",
             "Labels": {
                 "alpha.eksctl.io/cluster-name": "lt",

--- a/pkg/cfn/builder/testdata/launch_template/spot.json
+++ b/pkg/cfn/builder/testdata/launch_template/spot.json
@@ -85,7 +85,7 @@
     "ManagedNodeGroup": {
         "Type": "AWS::EKS::Nodegroup",
         "Properties": {
-            "AmiType": "AL2_x86_64",
+            "AmiType": "AL2023_x86_64_STANDARD",
             "ClusterName": "lt",
             "CapacityType": "SPOT",
             "Labels": {

--- a/pkg/cfn/builder/testdata/launch_template/ssh_disabled.json
+++ b/pkg/cfn/builder/testdata/launch_template/ssh_disabled.json
@@ -87,7 +87,7 @@
   "ManagedNodeGroup": {
     "Type": "AWS::EKS::Nodegroup",
     "Properties": {
-      "AmiType": "AL2_x86_64",
+      "AmiType": "AL2023_x86_64_STANDARD",
       "ClusterName": "lt",
       "Labels": {
         "alpha.eksctl.io/cluster-name": "lt",

--- a/pkg/cfn/builder/testdata/launch_template/ssh_enabled.json
+++ b/pkg/cfn/builder/testdata/launch_template/ssh_enabled.json
@@ -90,7 +90,7 @@
     "ManagedNodeGroup": {
         "Type": "AWS::EKS::Nodegroup",
         "Properties": {
-            "AmiType": "AL2_x86_64",
+            "AmiType": "AL2023_x86_64_STANDARD",
             "ClusterName": "lt",
             "Labels": {
                 "alpha.eksctl.io/cluster-name": "lt",

--- a/pkg/cfn/builder/testdata/launch_template/standard.json
+++ b/pkg/cfn/builder/testdata/launch_template/standard.json
@@ -85,7 +85,7 @@
     "ManagedNodeGroup": {
         "Type": "AWS::EKS::Nodegroup",
         "Properties": {
-            "AmiType": "AL2_x86_64",
+            "AmiType": "AL2023_x86_64_STANDARD",
             "ClusterName": "lt",
             "Labels": {
                 "alpha.eksctl.io/cluster-name": "lt",

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
@@ -346,7 +346,7 @@ const expected = `
 		"metadata": {
 		  "name": "test-3x3-ngs",
 		  "region": "eu-central-1",
-		  "version": "1.29"
+		  "version": "1.30"
 		},
 		"kubernetesNetworkConfig": {
         	"ipFamily": "IPv4"

--- a/userdocs/src/getting-started.md
+++ b/userdocs/src/getting-started.md
@@ -2,7 +2,7 @@
 
 !!! tip "New for 2024"
     EKS Add-ons now support receiving IAM permissions via [EKS Pod Identity Associations](/usage/pod-identity-associations/#eks-add-ons-support-for-pod-identity-associations)
-    
+
     `eksctl` now supports AMIs based on AmazonLinux2023
 
 !!! tip "eksctl main features in 2023"
@@ -122,7 +122,7 @@ eksctl create cluster --name=cluster-1 --nodes=4
 
 ### Supported versions
 
-EKS supports versions `1.23` (extended), `1.24` (extended), `1.25`, `1.26`, `1.27`, `1.28`, **`1.29`** (default) and `1.30`.
+EKS supports versions `1.23` (extended), `1.24` (extended), `1.25`, `1.26`, `1.27`, `1.28`, `1.29` and **`1.30`** (default).
 With `eksctl` you can deploy any of the supported versions by passing `--version`.
 
 ```sh

--- a/userdocs/theme/home.html
+++ b/userdocs/theme/home.html
@@ -484,16 +484,16 @@
 <!-- Main site hero -->
     <section class="mdx-parallax__group tx-container" data-md-color-scheme="slate">
         <div class="mdx-hero" data-mdx-component="hero">
-            <!-- 
-            <picture class="tx-hero__image"> 
+            <!--
+            <picture class="tx-hero__image">
                 <img src="assets/images/illustration.png" draggable="false">
             </picture>
             Todo: Add a nicer illustration -->
             <div class="md-grid mdx-hero__inner">
-                <div class="mdx-hero__teaser md-typeset"> 
-                    <h1>{{ config.site_description }}.</h1> 
-                    <p>eksctl is a simple CLI tool for creating and managing clusters on EKS - Amazon's managed Kubernetes service for EC2.</p> 
-                    <a href="/getting-started/" class="md-button"> Get started </a> 
+                <div class="mdx-hero__teaser md-typeset">
+                    <h1>{{ config.site_description }}.</h1>
+                    <p>eksctl is a simple CLI tool for creating and managing clusters on EKS - Amazon's managed Kubernetes service for EC2.</p>
+                    <a href="/getting-started/" class="md-button"> Get started </a>
                     <a href="#create-cluster-in-minutes" class="md-button md-button--secondary"> Learn more </a>
                 </div>
             </div>
@@ -501,35 +501,35 @@
     </section>
 
 <!-- Highlights -->
-    <section class="mdx-parallax__group" data-md-color-scheme="default" data-md-color-primary="indigo"> 
-        <div class="md-content md-grid" data-md-component="content"> 
-            <div class="md-content__inner"> 
-                <header class="md-typeset"> 
+    <section class="mdx-parallax__group" data-md-color-scheme="default" data-md-color-primary="indigo">
+        <div class="md-content md-grid" data-md-component="content">
+            <div class="md-content__inner">
+                <header class="md-typeset">
                 <h1 id="create-cluster-in-minutes">Create a basic cluster in minutes with just one command.
                     <a href="#create-cluster-in-minutes" class="headerlink" title="Permanent link"> ¶ </a>
-                </h1> 
-                </header> 
-                <div class="mdx-spotlight"> 
-                    <figure class="mdx-spotlight__feature"> 
+                </h1>
+                </header>
+                <div class="mdx-spotlight">
+                    <figure class="mdx-spotlight__feature">
                         <a href="/getting-started/" tabindex="-1" title="Getting started"><img src="assets/images/cluster-demo.png" alt="Getting started" loading="lazy"></a>
                         <figcaption class="md-typeset">
-                            <h2><code>eksctl create cluster</code></h2> 
-                            <p>A cluster will be created with default parameters:</p> 
-                            <ul> 
-                                <li>exciting auto-generated name, e.g., <code>fabulous-mushroom-1527688624</code></li> 
-                                <li>two <code>m5.large</code> worker nodes (this instance type suits most common use-cases, and is good value for money)</li> 
-                                <li>use the official AWS <a href="https://github.com/awslabs/amazon-eks-ami">EKS AMI</a></li> 
-                                <li><code>us-west-2</code> region</li> 
-                                <li>a dedicated VPC (check your quotas)</li> 
-                            </ul> 
-                            <p><a href="/getting-started/" aria-label="Getting started"> 
-                                <span class="twemoji"> 
-                                    {% include ".icons/octicons/arrow-right-16.svg" %} 
-                                </span> Learn more </a> 
-                            </p> 
-                        </figcaption> 
+                            <h2><code>eksctl create cluster</code></h2>
+                            <p>A cluster will be created with default parameters:</p>
+                            <ul>
+                                <li>exciting auto-generated name, e.g., <code>fabulous-mushroom-1527688624</code></li>
+                                <li>two <code>m5.large</code> worker nodes (this instance type suits most common use-cases, and is good value for money)</li>
+                                <li>use the official AWS <a href="https://github.com/awslabs/amazon-eks-ami">EKS AMI</a></li>
+                                <li><code>us-west-2</code> region</li>
+                                <li>a dedicated VPC (check your quotas)</li>
+                            </ul>
+                            <p><a href="/getting-started/" aria-label="Getting started">
+                                <span class="twemoji">
+                                    {% include ".icons/octicons/arrow-right-16.svg" %}
+                                </span> Learn more </a>
+                            </p>
+                        </figcaption>
                     </figure>
-                    <figure class="mdx-spotlight__feature"> 
+                    <figure class="mdx-spotlight__feature">
                         <a href="/usage/outposts" tabindex="-1" title="Usage Outposts"><img src="assets/images/outposts.png" alt="Usage Outposts" loading="lazy"></a>
                         <figcaption class="md-typeset">
                             <h2>Check out latest eksctl features</h2>
@@ -537,21 +537,21 @@
                             <p>Support for AMIs based on AmazonLinux2023</p>
                             <p>Configuring cluster access management via <a href="/usage/access-entries">AWS EKS Access Entries</a>.</p>
                             <p>Configuring fine-grained permissions to EKS running apps via <a href="/usage/pod-identity-associations">EKS Pod Identity Associations</a>.</p>
-                            <p>Creating fully private clusters on <a href="/usage/outposts">AWS Outposts</a>.</p> 
-                            <p>Supported Regions - 
-                                Calgary - (<code>ca-west-1</code>), 
-                                US ISO and ISOB - (<code>us-iso-east-1</code> and <code>us-isob-east-1</code>), 
-                                Tel Aviv (<code>il-central-1</code>), 
-                                Melbourne (<code>ap-southeast-4</code>), 
-                                Hyderabad (<code>ap-south-2</code>), 
-                                Spain (<code>eu-south-2</code>), 
+                            <p>Creating fully private clusters on <a href="/usage/outposts">AWS Outposts</a>.</p>
+                            <p>Supported Regions -
+                                Calgary - (<code>ca-west-1</code>),
+                                US ISO and ISOB - (<code>us-iso-east-1</code> and <code>us-isob-east-1</code>),
+                                Tel Aviv (<code>il-central-1</code>),
+                                Melbourne (<code>ap-southeast-4</code>),
+                                Hyderabad (<code>ap-south-2</code>),
+                                Spain (<code>eu-south-2</code>),
                                 Zurich (<code>eu-central-2</code>)
                             </p>
-                            <p>EKS supported versions <code>1.25</code>, <code>1.26</code>, <code>1.27</code>, <code>1.28</code> and <b>1.29</b> (default).</p> 
-                            <p><a href="/usage/creating-and-managing-clusters/" aria-label="Usage"> 
-                                <span class="twemoji"> 
-                                    {% include ".icons/octicons/arrow-right-16.svg" %} 
-                                </span> Learn more </a> 
+                            <p>EKS supported versions <code>1.25</code>, <code>1.26</code>, <code>1.27</code>, <code>1.28</code>, <b>1.29</b> and <b>1.30</b> (default).</p>
+                            <p><a href="/usage/creating-and-managing-clusters/" aria-label="Usage">
+                                <span class="twemoji">
+                                    {% include ".icons/octicons/arrow-right-16.svg" %}
+                                </span> Learn more </a>
                             </p>
                         </figcaption>
                     </figure>
@@ -562,65 +562,65 @@
 
     <!-- Community -->
     <section class="mdx-parallax__group" data-md-color-scheme="slate" data-md-color-primary="indigo">
-        <div class="md-content md-grid" data-md-component="content"> 
+        <div class="md-content md-grid" data-md-component="content">
             <div class="md-content__inner">
-                <header class="md-typeset"> 
-                    <h1 id="community"> Community 
+                <header class="md-typeset">
+                    <h1 id="community"> Community
                         <span class="twemoji heart-fill-24 heart">
-                            {% include ".icons/octicons/heart-fill-24.svg" %} 
+                            {% include ".icons/octicons/heart-fill-24.svg" %}
                         </span>
                         <a href="#community" class="headerlink" title="Permanent link"> ¶ </a>
-                    </h1> 
-                </header> 
-                <div class="mdx-expect"> 
-                    <ul class="mdx-expect__list"> 
-                        <li class="mdx-expect__item md-typeset"> 
-                            <div class="mdx-expect__icon"> 
-                                <span> 
-                                    {% include ".icons/fontawesome/brands/github.svg" %} 
-                                </span>
-                            </div> 
-                            <div class="mdx-expect__description"> 
-                                <h2>Github</h2> 
-                                <p>Create an <a href="https://github.com/eksctl-io/eksctl/issues/new">issue</a> to Propose a feature request, Suggest an improvement, Report a Bug or Open a Help ticket on Github. </p> 
-                            </div> 
-                        </li> 
+                    </h1>
+                </header>
+                <div class="mdx-expect">
+                    <ul class="mdx-expect__list">
                         <li class="mdx-expect__item md-typeset">
                             <div class="mdx-expect__icon">
                                 <span>
-                                    {% include ".icons/fontawesome/brands/slack.svg" %} 
+                                    {% include ".icons/fontawesome/brands/github.svg" %}
                                 </span>
-                            </div> 
-                            <div class="mdx-expect__description"> 
-                                <h2>Slack</h2> 
+                            </div>
+                            <div class="mdx-expect__description">
+                                <h2>Github</h2>
+                                <p>Create an <a href="https://github.com/eksctl-io/eksctl/issues/new">issue</a> to Propose a feature request, Suggest an improvement, Report a Bug or Open a Help ticket on Github. </p>
+                            </div>
+                        </li>
+                        <li class="mdx-expect__item md-typeset">
+                            <div class="mdx-expect__icon">
+                                <span>
+                                    {% include ".icons/fontawesome/brands/slack.svg" %}
+                                </span>
+                            </div>
+                            <div class="mdx-expect__description">
+                                <h2>Slack</h2>
                                 <p>Have a question or need help? Ask a question on our <a href="https://slack.k8s.io/messages/eksctl/">Slack channel</a> and get in touch with our community by joining <a href="https://slack.k8s.io/">Kubernetes Slack</a>.</p>
                             </div>
                         </li>
                         <li class="mdx-expect__item md-typeset">
                             <div class="mdx-expect__icon">
                                 <span>
-                                    {% include ".icons/octicons/git-pull-request-16.svg" %} 
+                                    {% include ".icons/octicons/git-pull-request-16.svg" %}
                                 </span>
-                            </div> 
-                            <div class="mdx-expect__description"> 
-                                <h2>Contributing</h2> 
+                            </div>
+                            <div class="mdx-expect__description">
+                                <h2>Contributing</h2>
                                 <p>Read more about Contributing to eksctl repository <a href="https://github.com/eksctl-io/eksctl/blob/main/CONTRIBUTING.md">here</a>.</p>
                             </div>
                         </li>
                         <li class="mdx-expect__item md-typeset">
                             <div class="mdx-expect__icon">
-                                <span> 
-                                    {% include ".icons/octicons/people-16.svg" %} 
+                                <span>
+                                    {% include ".icons/octicons/people-16.svg" %}
                                 </span>
-                            </div> 
-                            <div class="mdx-expect__description"> 
-                                <h2>Code of Conduct</h2> 
+                            </div>
+                            <div class="mdx-expect__description">
+                                <h2>Code of Conduct</h2>
                                 <p>Find out more about eksctl Community and Code of Conduct <a href="https://github.com/eksctl-io/eksctl/blob/main/COMMUNITY.md">here</a>.</p>
                             </div>
                         </li>
                     </ul>
                 </div>
-                <header class="md-typeset"> 
+                <header class="md-typeset">
                     <h2>Eksctl Maintainers</h2>
                 </header>
                 <div class="mdx-users">
@@ -634,17 +634,17 @@
                     <h3>Thank you <a href="https://github.com/eksctl-io/eksctl/graphs/contributors">eksctl contributors</a> all your contributions.<span class="twemoji">{% include ".icons/octicons/star-16.svg" %}</span></h3>
                 </header>
                 <div class="contributors" id="contributors"></div>
-            </div> 
+            </div>
         </div>
     </section>
 
     <!-- Footer -->
     <section class="mdx-parallax__group" data-md-color-scheme="default" data-md-color-primary="indigo">
-        <div class="md-content md-grid" data-md-component="content"> 
+        <div class="md-content md-grid" data-md-component="content">
             <div class="md-content__inner">
                 <div class="md-typeset">
-                    <p>sponsored by <a href="https://www.weave.works/"><img alt="Weaveworks" src="/img/empty.svg#wwinline"></a> 
-                        and built by <a href="https://github.com/eksctl-io/eksctl/graphs/contributors">contributors <img alt="Contributors" src="/img/gophers.png#inline"></a> 
+                    <p>sponsored by <a href="https://www.weave.works/"><img alt="Weaveworks" src="/img/empty.svg#wwinline"></a>
+                        and built by <a href="https://github.com/eksctl-io/eksctl/graphs/contributors">contributors <img alt="Contributors" src="/img/gophers.png#inline"></a>
                         on <a href="https://github.com/eksctl-io/eksctl"><img alt="Github" src="/img/empty.svg#gitinline"></a>
                     </p>
                     <p>


### PR DESCRIPTION
### Description

Makes EKS 1.30 the default Kubernetes version. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

