### PR TITLE
missing parameter in VPC configuration example

### DIFF
--- a/pkg/actions/nodegroup/drain.go
+++ b/pkg/actions/nodegroup/drain.go
@@ -58,6 +58,6 @@ func (d *Drainer) Drain(ctx context.Context, input *DrainInput) error {
 
 func waitForAllRoutinesToFinish(ctx context.Context, sem *semaphore.Weighted, size int64) {
 	if err := sem.Acquire(ctx, size); err != nil {
-		logger.Critical("failed to acquire semaphore while waiting for all routines to finish: %w", err)
+		logger.Critical("failed to acquire semaphore while waiting for all routines to finish: %v", err)
 	}
 }

--- a/userdocs/src/usage/vpc-cluster-access.md
+++ b/userdocs/src/usage/vpc-cluster-access.md
@@ -63,7 +63,7 @@ vpc:
 To update the restrictions on an existing cluster, use:
 
 ```console
-eksctl utils update-cluster-vpc-config --cluster=<cluster> 1.1.1.1/32,2.2.2.0/24
+eksctl utils update-cluster-vpc-config --cluster=<cluster> --public-access-cidrs 1.1.1.1/32,2.2.2.0/24
 ```
 
 !!! warning


### PR DESCRIPTION
The example needs to include the parameter, otherwise the following error is shown and it is confusing.

```
Error: --cluster=<cluster name> and argument <CIDR> cannot be used at the same time
```