### PR TITLE
add missing CIDR parameter in example

### DIFF
--- a/userdocs/src/usage/vpc-cluster-access.md
+++ b/userdocs/src/usage/vpc-cluster-access.md
@@ -63,7 +63,7 @@ vpc:
 To update the restrictions on an existing cluster, use:
 
 ```console
-eksctl utils update-cluster-vpc-config --cluster=<cluster> 1.1.1.1/32,2.2.2.0/24
+eksctl utils update-cluster-vpc-config --cluster=<cluster> --public-access-cidrs 1.1.1.1/32,2.2.2.0/24
 ```
 
 !!! warning


### PR DESCRIPTION
The example needs to include the parameter, otherwise the following error is shown when which is confusing.

```
Error: --cluster=<cluster name> and argument <CIDRs> cannot be used at the same time
```