### PR TITLE
use string in logging instead of wrapping error

### DIFF
--- a/pkg/actions/nodegroup/drain.go
+++ b/pkg/actions/nodegroup/drain.go
@@ -58,6 +58,6 @@ func (d *Drainer) Drain(ctx context.Context, input *DrainInput) error {
 
 func waitForAllRoutinesToFinish(ctx context.Context, sem *semaphore.Weighted, size int64) {
 	if err := sem.Acquire(ctx, size); err != nil {
-		logger.Critical("failed to acquire semaphore while waiting for all routines to finish: %w", err)
+		logger.Critical("failed to acquire semaphore while waiting for all routines to finish: %v", err)
 	}
 }


### PR DESCRIPTION
Using %w outside of fmt.Errorf is not appropriate because %w is intended specifically for error wrapping.