### PR TITLE
Add auto-ssm ami resolution for ubuntu

### DIFF
--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -2,6 +2,7 @@ package ami_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -233,10 +234,11 @@ var _ = Describe("AMI Auto Resolution", func() {
 
 			})
 
-			Context("and Ubuntu family", func() {
+			Context("and Ubuntu1804 family", func() {
 				BeforeEach(func() {
 					p = mockprovider.NewMockProvider()
-					imageFamily = "Ubuntu2004"
+					instanceType = "t2.medium"
+					imageFamily = "Ubuntu1804"
 				})
 
 				It("should return an error", func() {
@@ -244,6 +246,200 @@ var _ = Describe("AMI Auto Resolution", func() {
 					resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
 
 					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("SSM Parameter lookups for Ubuntu1804 AMIs is not supported"))
+				})
+
+			})
+
+			Context("and Ubuntu2004 family", func() {
+				BeforeEach(func() {
+					p = mockprovider.NewMockProvider()
+					instanceType = "t2.medium"
+					imageFamily = "Ubuntu2004"
+				})
+
+				DescribeTable("should return an error",
+					func(version string) {
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("Ubuntu2004 requires EKS version greater or equal than 1.21 and lower than 1.29"))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.20"),
+					Entry(nil, "1.30"),
+				)
+
+				DescribeTable("should return a valid AMI",
+					func(version string) {
+						addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/amd64/hvm/ebs-gp2/ami-id", version), expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.21"),
+					Entry(nil, "1.22"),
+					Entry(nil, "1.23"),
+					Entry(nil, "1.24"),
+					Entry(nil, "1.25"),
+					Entry(nil, "1.26"),
+					Entry(nil, "1.27"),
+					Entry(nil, "1.28"),
+					Entry(nil, "1.29"),
+				)
+
+				Context("for arm instance type", func() {
+					BeforeEach(func() {
+						instanceType = "a1.large"
+					})
+					DescribeTable("should return a valid AMI for arm64",
+						func(version string) {
+							addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version), expectedAmi)
+
+							resolver := NewSSMResolver(p.MockSSM())
+							resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+							Expect(err).NotTo(HaveOccurred())
+							Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+							Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						},
+						EntryDescription("When EKS version is %s"),
+						Entry(nil, "1.21"),
+						Entry(nil, "1.22"),
+						Entry(nil, "1.23"),
+						Entry(nil, "1.24"),
+						Entry(nil, "1.25"),
+						Entry(nil, "1.26"),
+						Entry(nil, "1.27"),
+						Entry(nil, "1.28"),
+						Entry(nil, "1.29"),
+					)
+				})
+			})
+
+			Context("and Ubuntu2204 family", func() {
+				BeforeEach(func() {
+					p = mockprovider.NewMockProvider()
+					instanceType = "t2.medium"
+					imageFamily = "Ubuntu2204"
+				})
+
+				DescribeTable("should return an error",
+					func(version string) {
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("Ubuntu2204 requires EKS version greater or equal than 1.29"))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.21"),
+					Entry(nil, "1.28"),
+				)
+
+				DescribeTable("should return a valid AMI",
+					func(version string) {
+						addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks/22.04/%s/stable/current/amd64/hvm/ebs-gp2/ami-id", version), expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.29"),
+					Entry(nil, "1.30"),
+					Entry(nil, "1.31"),
+				)
+
+				Context("for arm instance type", func() {
+					BeforeEach(func() {
+						instanceType = "a1.large"
+					})
+					DescribeTable("should return a valid AMI for arm64",
+						func(version string) {
+							addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks/22.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version), expectedAmi)
+
+							resolver := NewSSMResolver(p.MockSSM())
+							resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+							Expect(err).NotTo(HaveOccurred())
+							Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+							Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						},
+						EntryDescription("When EKS version is %s"),
+						Entry(nil, "1.29"),
+						Entry(nil, "1.30"),
+						Entry(nil, "1.31"),
+					)
+				})
+			})
+
+			Context("and UbuntuPro2204 family", func() {
+				BeforeEach(func() {
+					p = mockprovider.NewMockProvider()
+					instanceType = "t2.medium"
+					imageFamily = "UbuntuPro2204"
+				})
+
+				DescribeTable("should return an error",
+					func(version string) {
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("UbuntuPro2204 requires EKS version greater or equal than 1.29"))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.21"),
+					Entry(nil, "1.28"),
+				)
+
+				DescribeTable("should return a valid AMI",
+					func(version string) {
+						addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks-pro/22.04/%s/stable/current/amd64/hvm/ebs-gp2/ami-id", version), expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.29"),
+					Entry(nil, "1.30"),
+					Entry(nil, "1.31"),
+				)
+
+				Context("for arm instance type", func() {
+					BeforeEach(func() {
+						instanceType = "a1.large"
+					})
+					DescribeTable("should return a valid AMI for arm64",
+						func(version string) {
+							addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks-pro/22.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version), expectedAmi)
+
+							resolver := NewSSMResolver(p.MockSSM())
+							resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+							Expect(err).NotTo(HaveOccurred())
+							Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+							Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						},
+						EntryDescription("When EKS version is %s"),
+						Entry(nil, "1.29"),
+						Entry(nil, "1.30"),
+						Entry(nil, "1.31"),
+					)
 				})
 			})
 


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Add auto-ssm ami resolution for ubuntu

Issue #3224

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

### Manual tests

```sh
EKSCTL=eksctl
CLUSTER_NAME=my-cluster
COMMON_ARGS=( --verbose 5 )

${EKSCTL} "${COMMON_ARGS[@]}" create cluster -f - << EOF
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: ${CLUSTER_NAME}
  region: eu-south-2
  version: '1.30'

nodeGroups:
  - name: ng-ubuntu
    instanceType: t3.micro
    desiredCapacity: 1
    amiFamily: Ubuntu2204
    ami: auto-ssm
    ssh:
        allow: true
    overrideBootstrapCommand: |
      #!/bin/bash
      /etc/eks/bootstrap.sh ${CLUSTER_NAME} >> /var/log/bootstrap.log
EOF
} 2>&1 >/tmp/eksctl.log

$ grep -i ssm /tmp/eksctl.log
265:2024-07-05 12:55:26 [▶]  resolving AMI using SSM Parameter resolver for region eu-south-2, instanceType t3.micro and imageFamily Ubuntu2204
```

