### PR TITLE
Cluster creation flexibility for default networking addons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/tj/assert v0.0.3
 	github.com/vburenin/ifacemaker v1.2.1
 	github.com/vektra/mockery/v2 v2.38.0
-	github.com/weaveworks/goformation/v4 v4.10.2-0.20231113122203-bf1ae633f95c
+	github.com/weaveworks/goformation/v4 v4.10.2-0.20240626091647-67263f64f317
 	github.com/weaveworks/schemer v0.0.0-20230525114451-47139fe25848
 	github.com/xgfone/netaddr v0.5.1
 	golang.org/x/crypto v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1815,8 +1815,8 @@ github.com/vektra/mockery/v2 v2.38.0 h1:I0LBuUzZHqAU4d1DknW0DTFBPO6n8TaD38WL2KJf
 github.com/vektra/mockery/v2 v2.38.0/go.mod h1:diB13hxXG6QrTR0ol2Rk8s2dRMftzvExSvPDKr+IYKk=
 github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 h1:txplJASvd6b/hrE0s/Ixfpp2cuwH9IO9oZBAN9iYa4A=
 github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2/go.mod h1:DGCIhurYgnLz8J9ga1fMV/fbLDyUvTyrWXVWUIyJon4=
-github.com/weaveworks/goformation/v4 v4.10.2-0.20231113122203-bf1ae633f95c h1:iejfxgm8iQ6Jr3yT7Javgk40drlL6w9B6+zgACs0fMw=
-github.com/weaveworks/goformation/v4 v4.10.2-0.20231113122203-bf1ae633f95c/go.mod h1:3c2tyJmoge5qTS4PXS0niVJxR0YzroIBsts3dQI3EdI=
+github.com/weaveworks/goformation/v4 v4.10.2-0.20240626091647-67263f64f317 h1:efLcD8csEtX1RO0444Wa4RQjO34pYuojsdPABc5QC3s=
+github.com/weaveworks/goformation/v4 v4.10.2-0.20240626091647-67263f64f317/go.mod h1:3c2tyJmoge5qTS4PXS0niVJxR0YzroIBsts3dQI3EdI=
 github.com/weaveworks/schemer v0.0.0-20230525114451-47139fe25848 h1:I7S+IHZIU49skVgTNArf9bIdy07mCn1Z0zv1r07ROws=
 github.com/weaveworks/schemer v0.0.0-20230525114451-47139fe25848/go.mod h1:y8Luzq6JDsYVoIV0QAlnvIiq8bSaap0myMjWKyzVFTY=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/integration/data/crud-podinfo.yaml
+++ b/integration/data/crud-podinfo.yaml
@@ -17,6 +17,8 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
+      nodeSelector:
+        used-for: test-pods
       containers:
       - name: podinfod
         image: stefanprodan/podinfo:1.5.1@sha256:702633d438950f3675d0763a4ca6cfcf21a4d065cd7f470446c67607b1a26750

--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -867,6 +867,7 @@ func getInitialClusterConfig() *api.ClusterConfig {
 			AttachPolicyARNs: []string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"},
 		},
 	}
+	clusterConfig.AddonsConfig.DisableDefaultAddons = true
 
 	ng := &api.ManagedNodeGroup{
 		NodeGroupBase: &api.NodeGroupBase{

--- a/integration/tests/bare_cluster/bare_cluster_test.go
+++ b/integration/tests/bare_cluster/bare_cluster_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+// +build integration
+
+//revive:disable Not changing package name
+package bare_cluster
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/integration/tests"
+	clusterutils "github.com/weaveworks/eksctl/integration/utilities/cluster"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+var params *tests.Params
+
+func init() {
+	testing.Init()
+	params = tests.NewParams("bare-cluster")
+}
+
+func TestBareCluster(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("Bare Clusters", Ordered, func() {
+	var clusterConfig *api.ClusterConfig
+
+	BeforeAll(func() {
+		By("creating a cluster with only VPC CNI and no other default networking addons")
+		clusterConfig = api.NewClusterConfig()
+		clusterConfig.Metadata.Name = params.ClusterName
+		clusterConfig.Metadata.Region = params.Region
+		clusterConfig.AddonsConfig.DisableDefaultAddons = true
+		clusterConfig.Addons = []*api.Addon{
+			{
+				Name:                              "vpc-cni",
+				UseDefaultPodIdentityAssociations: true,
+			},
+			{
+				Name: "eks-pod-identity-agent",
+			},
+		}
+		cmd := params.EksctlCreateCmd.
+			WithArgs(
+				"cluster",
+				"--config-file=-",
+				"--kubeconfig="+params.KubeconfigPath,
+			).
+			WithoutArg("--region", params.Region).
+			WithStdin(clusterutils.Reader(clusterConfig))
+
+		Expect(cmd).To(RunSuccessfully())
+	})
+
+	It("should have only VPC CNI installed", func() {
+		config, err := clientcmd.BuildConfigFromFlags("", params.KubeconfigPath)
+		Expect(err).NotTo(HaveOccurred())
+		clientset, err := kubernetes.NewForConfig(config)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = clientset.AppsV1().Deployments(metav1.NamespaceSystem).Get(context.Background(), "coredns", metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected coredns to not exist")
+		daemonSets := clientset.AppsV1().DaemonSets(metav1.NamespaceSystem)
+		_, err = daemonSets.Get(context.Background(), "kube-proxy", metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected kube-proxy to not exist")
+		_, err = daemonSets.Get(context.Background(), "aws-node", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "expected aws-node to exist")
+	})
+})
+
+var _ = AfterSuite(func() {
+	params.DeleteClusters()
+})

--- a/integration/tests/bare_cluster/bare_cluster_test.go
+++ b/integration/tests/bare_cluster/bare_cluster_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Bare Clusters", Ordered, func() {
 			WithArgs(
 				"cluster",
 				"--config-file=-",
+				"--verbose", "4",
 				"--kubeconfig="+params.KubeconfigPath,
 			).
 			WithoutArg("--region", params.Region).

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -274,7 +274,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 		})
 
 		It("should deploy podinfo service to the cluster and access it via proxy", func() {
-			d := test.CreateDeploymentFromFile(test.Namespace, "../../data/podinfo.yaml")
+			d := test.CreateDeploymentFromFile(test.Namespace, "../../data/crud-podinfo.yaml")
 			test.WaitForDeploymentReady(d, commonTimeout)
 
 			pods := test.ListPodsFromDeployment(d)

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -533,7 +533,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				"1.1.1.1/32,2.2.2.0/24",
 				"--approve",
 			)).To(RunSuccessfully())
-			Expect(k8sAPICall()).Should(HaveOccurred())
+			Eventually(k8sAPICall, "5m", "20s").Should(HaveOccurred())
 		})
 
 		It("should re-enable public access", func() {

--- a/integration/tests/update/update_cluster_test.go
+++ b/integration/tests/update/update_cluster_test.go
@@ -223,12 +223,15 @@ var _ = Describe("(Integration) Upgrading cluster", func() {
 
 	Context("addons", func() {
 		It("should upgrade kube-proxy", func() {
-			cmd := params.EksctlUtilsCmd.WithArgs(
-				"update-kube-proxy",
-				"--cluster", params.ClusterName,
-				"--verbose", "4",
-				"--approve",
-			)
+			cmd := params.EksctlUpdateCmd.
+				WithArgs(
+					"addon",
+					"--name", "kube-proxy",
+					"--cluster", params.ClusterName,
+					"--version", "latest",
+					"--wait",
+					"--verbose", "4",
+				)
 			Expect(cmd).To(RunSuccessfully())
 
 			rawClient := getRawClient(clusterProvider)
@@ -256,24 +259,29 @@ var _ = Describe("(Integration) Upgrading cluster", func() {
 			}
 			preUpdateAWSNodeVersion := getAWSNodeVersion()
 
-			cmd := params.EksctlUtilsCmd.WithArgs(
-				"update-aws-node",
-				"--cluster", params.ClusterName,
-				"--verbose", "4",
-				"--approve",
-			)
+			cmd := params.EksctlUpdateCmd.
+				WithArgs(
+					"addon",
+					"--name", "vpc-cni",
+					"--cluster", params.ClusterName,
+					"--version", "latest",
+					"--wait",
+					"--verbose", "4",
+				)
 			Expect(cmd).To(RunSuccessfully())
-
 			Eventually(getAWSNodeVersion, k8sUpdatePollTimeout, k8sUpdatePollInterval).ShouldNot(Equal(preUpdateAWSNodeVersion))
 		})
 
 		It("should upgrade coredns", func() {
-			cmd := params.EksctlUtilsCmd.WithArgs(
-				"update-coredns",
-				"--cluster", params.ClusterName,
-				"--verbose", "4",
-				"--approve",
-			)
+			cmd := params.EksctlUpdateCmd.
+				WithArgs(
+					"addon",
+					"--name", "coredns",
+					"--cluster", params.ClusterName,
+					"--version", "latest",
+					"--wait",
+					"--verbose", "4",
+				)
 			Expect(cmd).To(RunSuccessfully())
 		})
 

--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -37,12 +37,13 @@ type StackManager interface {
 type CreateClientSet func() (kubeclient.Interface, error)
 
 type Manager struct {
-	clusterConfig   *api.ClusterConfig
-	eksAPI          awsapi.EKS
-	withOIDC        bool
-	oidcManager     *iamoidc.OpenIDConnectManager
-	stackManager    StackManager
-	createClientSet CreateClientSet
+	clusterConfig       *api.ClusterConfig
+	eksAPI              awsapi.EKS
+	withOIDC            bool
+	oidcManager         *iamoidc.OpenIDConnectManager
+	stackManager        StackManager
+	createClientSet     CreateClientSet
+	DisableAWSNodePatch bool
 }
 
 func New(clusterConfig *api.ClusterConfig, eksAPI awsapi.EKS, stackManager StackManager, withOIDC bool, oidcManager *iamoidc.OpenIDConnectManager, createClientSet CreateClientSet) (*Manager, error) {

--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -242,7 +242,7 @@ func (a *Manager) Create(ctx context.Context, addon *api.Addon, iamRoleCreator I
 		logger.Warning(IAMPermissionsNotRequiredWarning(addon.Name))
 	}
 
-	if addon.CanonicalName() == api.VPCCNIAddon {
+	if !a.DisableAWSNodePatch && addon.CanonicalName() == api.VPCCNIAddon {
 		logger.Debug("patching AWS node")
 		err := a.patchAWSNodeSA(ctx)
 		if err != nil {

--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -26,10 +26,12 @@ var knownAddons = map[string]struct {
 		CreateBeforeNodeGroup: true,
 	},
 	api.KubeProxyAddon: {
-		IsDefault: true,
+		IsDefault:             true,
+		CreateBeforeNodeGroup: true,
 	},
 	api.CoreDNSAddon: {
-		IsDefault: true,
+		IsDefault:             true,
+		CreateBeforeNodeGroup: true,
 	},
 	api.PodIdentityAgentAddon: {
 		CreateBeforeNodeGroup: true,
@@ -138,6 +140,9 @@ func (t *createAddonTask) Do(errorCh chan error) error {
 		if t.forceAll {
 			a.Force = true
 		}
+		if !t.wait {
+			t.timeout = 0
+		}
 		err := addonManager.Create(t.ctx, a, t.iamRoleCreator, t.timeout)
 		if err != nil {
 			go func() {
@@ -153,6 +158,9 @@ func (t *createAddonTask) Do(errorCh chan error) error {
 		}
 		if t.forceAll {
 			a.Force = true
+		}
+		if !t.wait {
+			t.timeout = 0
 		}
 		err := addonManager.Create(t.ctx, a, t.iamRoleCreator, t.timeout)
 		if err != nil {

--- a/pkg/addons/default/addons.go
+++ b/pkg/addons/default/addons.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,15 +13,20 @@ import (
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 
-	"github.com/weaveworks/eksctl/pkg/awsapi"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 )
 
 type AddonInput struct {
-	RawClient           kubernetes.RawClientInterface
-	EKSAPI              awsapi.EKS
-	ControlPlaneVersion string
-	Region              string
+	RawClient             kubernetes.RawClientInterface
+	AddonVersionDescriber AddonVersionDescriber
+	ControlPlaneVersion   string
+	Region                string
+}
+
+// AddonVersionDescriber describes the versions for an addon.
+type AddonVersionDescriber interface {
+	// DescribeAddonVersions describes the versions for an addon.
+	DescribeAddonVersions(ctx context.Context, params *eks.DescribeAddonVersionsInput, optFns ...func(options *eks.Options)) (*eks.DescribeAddonVersionsOutput, error)
 }
 
 // DoAddonsSupportMultiArch checks if the coredns/kubeproxy/awsnode support multi arch nodegroups

--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -16,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/weaveworks/eksctl/pkg/awsapi"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 	"github.com/weaveworks/eksctl/pkg/printers"
 )
@@ -117,7 +116,7 @@ func addArm64NodeSelector(daemonSet *v1.DaemonSet) error {
 
 func getLatestKubeProxyImage(ctx context.Context, input AddonInput) (string, error) {
 	defaultClusterVersion := generateImageVersionFromClusterVersion(input.ControlPlaneVersion)
-	latestEKSReportedVersion, err := getLatestImageVersionFromEKS(ctx, input.EKSAPI, input.ControlPlaneVersion)
+	latestEKSReportedVersion, err := getLatestImageVersionFromEKS(ctx, input.AddonVersionDescriber, input.ControlPlaneVersion)
 	if err != nil {
 		return "", err
 	}
@@ -151,7 +150,7 @@ func generateImageVersionFromClusterVersion(controlPlaneVersion string) string {
 	return fmt.Sprintf("v%s-eksbuild.1", controlPlaneVersion)
 }
 
-func getLatestImageVersionFromEKS(ctx context.Context, eksAPI awsapi.EKS, controlPlaneVersion string) (string, error) {
+func getLatestImageVersionFromEKS(ctx context.Context, addonDescriber AddonVersionDescriber, controlPlaneVersion string) (string, error) {
 	controlPlaneMajorMinor, err := versionWithOnlyMajorAndMinor(controlPlaneVersion)
 	if err != nil {
 		return "", err
@@ -161,7 +160,7 @@ func getLatestImageVersionFromEKS(ctx context.Context, eksAPI awsapi.EKS, contro
 		AddonName:         aws.String(KubeProxy),
 	}
 
-	addonInfos, err := eksAPI.DescribeAddonVersions(ctx, input)
+	addonInfos, err := addonDescriber.DescribeAddonVersions(ctx, input)
 	if err != nil {
 		return "", fmt.Errorf("failed to describe addon versions: %v", err)
 	}

--- a/pkg/addons/default/kube_proxy_test.go
+++ b/pkg/addons/default/kube_proxy_test.go
@@ -36,10 +36,10 @@ var _ = Describe("KubeProxy", func() {
 			clientSet = rawClient.ClientSet()
 			mockProvider = mockprovider.NewMockProvider()
 			input = da.AddonInput{
-				RawClient:           rawClient,
-				Region:              "eu-west-1",
-				EKSAPI:              mockProvider.EKS(),
-				ControlPlaneVersion: controlPlaneVersion,
+				RawClient:             rawClient,
+				Region:                "eu-west-1",
+				AddonVersionDescriber: mockProvider.EKS(),
+				ControlPlaneVersion:   controlPlaneVersion,
 			}
 		})
 

--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -9,6 +9,18 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Values for core addons
+const (
+	minimumVPCCNIVersionForIPv6 = "1.10.0"
+
+	VPCCNIAddon           = "vpc-cni"
+	KubeProxyAddon        = "kube-proxy"
+	CoreDNSAddon          = "coredns"
+	PodIdentityAgentAddon = "eks-pod-identity-agent"
+	AWSEBSCSIDriverAddon  = "aws-ebs-csi-driver"
+	AWSEFSCSIDriverAddon  = "aws-efs-csi-driver"
+)
+
 // Addon holds the EKS addon configuration
 type Addon struct {
 	// +required

--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -64,6 +64,12 @@ type AddonsConfig struct {
 	// for supported addons that require IAM permissions.
 	// +optional
 	AutoApplyPodIdentityAssociations bool `json:"autoApplyPodIdentityAssociations,omitempty"`
+
+	// DisableDefaultAddons enables or disables creation of default networking addons when the cluster
+	// is created.
+	// By default, all default addons are installed as EKS addons.
+	// +optional
+	DisableDefaultAddons bool `json:"disableDefaultAddons,omitempty"`
 }
 
 func (a Addon) CanonicalName() string {

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -269,10 +269,17 @@
           "description": "specifies whether to automatically apply pod identity associations for supported addons that require IAM permissions.",
           "x-intellij-html-description": "specifies whether to automatically apply pod identity associations for supported addons that require IAM permissions.",
           "default": "false"
+        },
+        "disableDefaultAddons": {
+          "type": "boolean",
+          "description": "enables or disables creation of default networking addons when the cluster is created. By default, all default addons are installed as EKS addons.",
+          "x-intellij-html-description": "enables or disables creation of default networking addons when the cluster is created. By default, all default addons are installed as EKS addons.",
+          "default": "false"
         }
       },
       "preferredOrder": [
-        "autoApplyPodIdentityAssociations"
+        "autoApplyPodIdentityAssociations",
+        "disableDefaultAddons"
       ],
       "additionalProperties": false,
       "description": "holds the addons config.",

--- a/pkg/apis/eksctl.io/v1alpha5/bare_cluster.go
+++ b/pkg/apis/eksctl.io/v1alpha5/bare_cluster.go
@@ -1,0 +1,22 @@
+package v1alpha5
+
+import (
+	"errors"
+	"slices"
+)
+
+// validateBareCluster validates a cluster for unsupported fields if VPC CNI is disabled.
+func validateBareCluster(clusterConfig *ClusterConfig) error {
+	if !clusterConfig.AddonsConfig.DisableDefaultAddons || slices.ContainsFunc(clusterConfig.Addons, func(addon *Addon) bool {
+		return addon.Name == VPCCNIAddon
+	}) {
+		return nil
+	}
+	if clusterConfig.HasNodes() || clusterConfig.IsFargateEnabled() || clusterConfig.Karpenter != nil || clusterConfig.HasGitOpsFluxConfigured() ||
+		(clusterConfig.IAM != nil && (len(clusterConfig.IAM.ServiceAccounts) > 0) || len(clusterConfig.IAM.PodIdentityAssociations) > 0) {
+		return errors.New("fields nodeGroups, managedNodeGroups, fargateProfiles, karpenter, gitops, iam.serviceAccounts, " +
+			"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI; please remove these fields " +
+			"and add them back after cluster creation is successful")
+	}
+	return nil
+}

--- a/pkg/apis/eksctl.io/v1alpha5/bare_cluster_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/bare_cluster_validation_test.go
@@ -1,0 +1,112 @@
+package v1alpha5_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+)
+
+type bareClusterEntry struct {
+	updateClusterConfig func(*api.ClusterConfig)
+	expectErr           bool
+}
+
+var _ = DescribeTable("Bare cluster validation", func(e bareClusterEntry) {
+	clusterConfig := api.NewClusterConfig()
+	clusterConfig.AddonsConfig.DisableDefaultAddons = true
+	clusterConfig.Addons = []*api.Addon{
+		{
+			Name: api.CoreDNSAddon,
+		},
+	}
+	e.updateClusterConfig(clusterConfig)
+	err := api.ValidateClusterConfig(clusterConfig)
+	if e.expectErr {
+		Expect(err).To(MatchError("fields nodeGroups, managedNodeGroups, fargateProfiles, karpenter, gitops, iam.serviceAccounts, " +
+			"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI; please remove these fields " +
+			"and add them back after cluster creation is successful"))
+	} else {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+},
+	Entry("nodeGroups", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			ng := api.NewNodeGroup()
+			ng.Name = "ng"
+			ng.DesiredCapacity = aws.Int(1)
+			c.NodeGroups = []*api.NodeGroup{ng}
+		},
+		expectErr: true,
+	}),
+	Entry("managedNodeGroups", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			ng := api.NewManagedNodeGroup()
+			ng.Name = "mng"
+			ng.DesiredCapacity = aws.Int(1)
+			c.ManagedNodeGroups = []*api.ManagedNodeGroup{ng}
+		},
+		expectErr: true,
+	}),
+	Entry("fargateProfiles", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			c.FargateProfiles = []*api.FargateProfile{
+				{
+					Name: "test",
+					Selectors: []api.FargateProfileSelector{
+						{
+							Namespace: "default",
+						},
+					},
+				},
+			}
+		},
+		expectErr: true,
+	}),
+	Entry("gitops", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			c.GitOps = &api.GitOps{
+				Flux: &api.Flux{},
+			}
+		},
+		expectErr: true,
+	}),
+	Entry("karpenter", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			c.Karpenter = &api.Karpenter{}
+		},
+		expectErr: true,
+	}),
+	Entry("iam.serviceAccounts", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			c.IAM.WithOIDC = api.Enabled()
+			c.IAM.ServiceAccounts = []*api.ClusterIAMServiceAccount{
+				{
+					ClusterIAMMeta: api.ClusterIAMMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					AttachPolicyARNs: []string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"},
+				},
+			}
+		},
+		expectErr: true,
+	}),
+	Entry("iam.podIdentityAssociations", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {
+			c.IAM.PodIdentityAssociations = []api.PodIdentityAssociation{
+				{
+					Namespace:            "test",
+					PermissionPolicyARNs: []string{"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"},
+				},
+			}
+		},
+		expectErr: true,
+	}),
+	Entry("no unsupported field set", bareClusterEntry{
+		updateClusterConfig: func(c *api.ClusterConfig) {},
+	}),
+)

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -80,7 +80,7 @@ func SetClusterConfigDefaults(cfg *ClusterConfig) {
 // IAM SAs that need to be explicitly deleted.
 func IAMServiceAccountsWithImplicitServiceAccounts(cfg *ClusterConfig) []*ClusterIAMServiceAccount {
 	serviceAccounts := cfg.IAM.ServiceAccounts
-	if IsEnabled(cfg.IAM.WithOIDC) && !vpcCNIAddonSpecified(cfg) {
+	if IsEnabled(cfg.IAM.WithOIDC) && !vpcCNIAddonSpecified(cfg) && !cfg.AddonsConfig.DisableDefaultAddons {
 		var found bool
 		for _, sa := range cfg.IAM.ServiceAccounts {
 			found = found || (sa.Name == AWSNodeMeta.Name && sa.Namespace == AWSNodeMeta.Namespace)

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -435,17 +435,6 @@ const (
 	IPV6Family = "IPv6"
 )
 
-// Values for core addons
-const (
-	minimumVPCCNIVersionForIPv6 = "1.10.0"
-	VPCCNIAddon                 = "vpc-cni"
-	KubeProxyAddon              = "kube-proxy"
-	CoreDNSAddon                = "coredns"
-	PodIdentityAgentAddon       = "eks-pod-identity-agent"
-	AWSEBSCSIDriverAddon        = "aws-ebs-csi-driver"
-	AWSEFSCSIDriverAddon        = "aws-efs-csi-driver"
-)
-
 // supported version of Karpenter
 const (
 	supportedKarpenterVersion = "v0.20.0"

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -84,6 +84,9 @@ func setNonEmpty(field string) error {
 
 // ValidateClusterConfig checks compatible fields of a given ClusterConfig
 func ValidateClusterConfig(cfg *ClusterConfig) error {
+	if err := validateBareCluster(cfg); err != nil {
+		return err
+	}
 	if IsDisabled(cfg.IAM.WithOIDC) && len(cfg.IAM.ServiceAccounts) > 0 {
 		return fmt.Errorf("iam.withOIDC must be enabled explicitly for iam.serviceAccounts to be created")
 	}

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -296,11 +296,12 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(subnetDetails *SubnetDe
 	}
 
 	cluster := gfneks.Cluster{
-		EncryptionConfig:   encryptionConfigs,
-		Logging:            makeClusterLogging(c.spec),
-		Name:               gfnt.NewString(c.spec.Metadata.Name),
-		ResourcesVpcConfig: clusterVPC,
-		RoleArn:            serviceRoleARN,
+		EncryptionConfig:           encryptionConfigs,
+		Logging:                    makeClusterLogging(c.spec),
+		Name:                       gfnt.NewString(c.spec.Metadata.Name),
+		ResourcesVpcConfig:         clusterVPC,
+		RoleArn:                    serviceRoleARN,
+		BootstrapSelfManagedAddons: gfnt.NewBoolean(false),
 		AccessConfig: &gfneks.Cluster_AccessConfig{
 			AuthenticationMode:                      gfnt.NewString(string(c.spec.AccessConfig.AuthenticationMode)),
 			BootstrapClusterCreatorAdminPermissions: gfnt.NewBoolean(!api.IsDisabled(c.spec.AccessConfig.BootstrapClusterCreatorAdminPermissions)),

--- a/pkg/cfn/builder/cluster_test.go
+++ b/pkg/cfn/builder/cluster_test.go
@@ -2,6 +2,7 @@ package builder_test
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"reflect"
 
@@ -20,8 +21,6 @@ import (
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder/fakes"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
-
-	_ "embed"
 )
 
 var _ = Describe("Cluster Template Builder", func() {
@@ -667,6 +666,12 @@ var _ = Describe("Cluster Template Builder", func() {
 				accessConfig := clusterTemplate.Resources["ControlPlane"].Properties.AccessConfig
 				Expect(accessConfig.AuthenticationMode).To(Equal(string(ekstypes.AuthenticationModeApi)))
 				Expect(accessConfig.BootstrapClusterCreatorAdminPermissions).To(BeFalse())
+			})
+		})
+
+		Context("bootstrapSelfManagedAddons in default config", func() {
+			It("should disable default addons", func() {
+				Expect(clusterTemplate.Resources["ControlPlane"].Properties.BootstrapSelfManagedAddons).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/cfn/builder/fakes/fake_cfn_template.go
+++ b/pkg/cfn/builder/fakes/fake_cfn_template.go
@@ -25,6 +25,7 @@ type Properties struct {
 	Description                          string
 	Tags                                 []Tag
 	SecurityGroupIngress                 []SGIngress
+	BootstrapSelfManagedAddons           bool
 	GroupID                              interface{}
 	SourceSecurityGroupID                interface{}
 	DestinationSecurityGroupID           interface{}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -353,8 +353,6 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	logger.Info("if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=%s --cluster=%s'", meta.Region, meta.Name)
 
 	eks.LogEnabledFeatures(cfg)
-	postClusterCreationTasks := ctl.CreateExtraClusterConfigTasks(ctx, cfg)
-
 	iamRoleCreator := &podidentityassociation.IAMRoleCreator{
 		ClusterName:  cfg.Metadata.Name,
 		StackCreator: stackManager,
@@ -363,7 +361,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	if len(autoDefaultAddons) > 0 {
 		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
 	}
-	postClusterCreationTasks.Append(preNodegroupAddons)
+	postClusterCreationTasks := ctl.CreateExtraClusterConfigTasks(ctx, cfg, preNodegroupAddons)
 
 	taskTree := stackManager.NewTasksToCreateCluster(ctx, cfg.NodeGroups, cfg.ManagedNodeGroups, cfg.AccessConfig, makeAccessEntryCreator(cfg.Metadata.Name, stackManager), postClusterCreationTasks)
 

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -357,11 +357,11 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		ClusterName:  cfg.Metadata.Name,
 		StackCreator: stackManager,
 	}
-	preNodegroupAddons, postNodegroupAddons, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout)
+	preNodegroupAddons, postNodegroupAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout)
 	if len(autoDefaultAddons) > 0 {
 		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
 	}
-	postClusterCreationTasks := ctl.CreateExtraClusterConfigTasks(ctx, cfg, preNodegroupAddons)
+	postClusterCreationTasks := ctl.CreateExtraClusterConfigTasks(ctx, cfg, preNodegroupAddons, updateVPCCNITask)
 
 	taskTree := stackManager.NewTasksToCreateCluster(ctx, cfg.NodeGroups, cfg.ManagedNodeGroups, cfg.AccessConfig, makeAccessEntryCreator(cfg.Metadata.Name, stackManager), postClusterCreationTasks)
 

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -273,6 +273,7 @@ var _ = Describe("create cluster", func() {
 
 		clusterConfig := api.NewClusterConfig()
 		clusterConfig.Metadata.Name = clusterName
+		clusterConfig.DisableDefaultAddons = true
 		clusterConfig.VPC.ClusterEndpoints = api.ClusterEndpointAccessDefaults()
 		clusterConfig.AccessConfig.AuthenticationMode = ekstypes.AuthenticationModeApiAndConfigMap
 

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -273,7 +273,7 @@ var _ = Describe("create cluster", func() {
 
 		clusterConfig := api.NewClusterConfig()
 		clusterConfig.Metadata.Name = clusterName
-		clusterConfig.DisableDefaultAddons = true
+		clusterConfig.AddonsConfig.DisableDefaultAddons = true
 		clusterConfig.VPC.ClusterEndpoints = api.ClusterEndpointAccessDefaults()
 		clusterConfig.AccessConfig.AuthenticationMode = ekstypes.AuthenticationModeApiAndConfigMap
 

--- a/pkg/ctl/utils/update_addon.go
+++ b/pkg/ctl/utils/update_addon.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+
+	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/kubernetes"
+	"github.com/weaveworks/eksctl/pkg/utils/apierrors"
+)
+
+type handleAddonUpdate func(*kubernetes.RawClient, defaultaddons.AddonVersionDescriber) (updateRequired bool, err error)
+
+func updateAddon(ctx context.Context, cmd *cmdutils.Cmd, addonName string, handleUpdate handleAddonUpdate) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
+		return err
+	}
+	ctl, err := cmd.NewProviderForExistingCluster(ctx)
+	if err != nil {
+		return err
+	}
+	if ok, err := ctl.CanUpdate(cmd.ClusterConfig); !ok {
+		return err
+	}
+
+	eksAPI := ctl.AWSProvider.EKS()
+	switch _, err := eksAPI.DescribeAddon(ctx, &eks.DescribeAddonInput{
+		AddonName:   aws.String(addonName),
+		ClusterName: aws.String(cmd.ClusterConfig.Metadata.Name),
+	}); {
+	case err == nil:
+		return fmt.Errorf("addon %s is installed as a managed EKS addon; to update it, use `eksctl update addon` instead", addonName)
+	case apierrors.IsNotFoundError(err):
+
+	default:
+		return fmt.Errorf("error describing addon %s: %w", addonName, err)
+	}
+
+	rawClient, err := ctl.NewRawClient(cmd.ClusterConfig)
+	if err != nil {
+		return err
+	}
+	updateRequired, err := handleUpdate(rawClient, eksAPI)
+	if err != nil {
+		return err
+	}
+	cmdutils.LogPlanModeWarning(cmd.Plan && updateRequired)
+	return nil
+}

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -183,6 +183,7 @@ func (c *ClusterProvider) CreateExtraClusterConfigTasks(ctx context.Context, cfg
 	newTasks := &tasks.TaskTree{
 		Parallel:  false,
 		IsSubTask: true,
+		Tasks:     []tasks.Task{preNodeGroupAddons},
 	}
 
 	newTasks.Append(&tasks.GenericTask{
@@ -207,9 +208,6 @@ func (c *ClusterProvider) CreateExtraClusterConfigTasks(ctx context.Context, cfg
 		if updateVPCCNITask != nil {
 			newTasks.Append(updateVPCCNITask)
 		}
-	}
-	if preNodeGroupAddons.Len() > 0 {
-		newTasks.Append(preNodeGroupAddons)
 	}
 
 	if cfg.HasClusterCloudWatchLogging() {

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -181,10 +181,11 @@ func newEFADevicePluginTask(
 }
 
 // CreateExtraClusterConfigTasks returns all tasks for updating cluster configuration
-func (c *ClusterProvider) CreateExtraClusterConfigTasks(ctx context.Context, cfg *api.ClusterConfig) *tasks.TaskTree {
+func (c *ClusterProvider) CreateExtraClusterConfigTasks(ctx context.Context, cfg *api.ClusterConfig, preNodeGroupAddons *tasks.TaskTree) *tasks.TaskTree {
 	newTasks := &tasks.TaskTree{
 		Parallel:  false,
 		IsSubTask: true,
+		Tasks:     []tasks.Task{preNodeGroupAddons},
 	}
 
 	newTasks.Append(&tasks.GenericTask{

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -16,10 +15,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/weaveworks/eksctl/pkg/actions/irsa"
@@ -182,43 +178,6 @@ func newEFADevicePluginTask(
 		logMessage:      "as you have enabled EFA, the EFA device plugin was automatically installed.",
 	}
 	return &t
-}
-
-type restartDaemonsetTask struct {
-	name            string
-	namespace       string
-	clusterProvider *ClusterProvider
-	spec            *api.ClusterConfig
-}
-
-func (t *restartDaemonsetTask) Describe() string {
-	return fmt.Sprintf(`restart daemonset "%s/%s"`, t.namespace, t.name)
-}
-
-func (t *restartDaemonsetTask) Do(errCh chan error) error {
-	defer close(errCh)
-	clientSet, err := t.clusterProvider.NewStdClientSet(t.spec)
-	if err != nil {
-		return err
-	}
-	ds := clientSet.AppsV1().DaemonSets(t.namespace)
-	dep, err := ds.Get(context.TODO(), t.name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	if dep.Spec.Template.Annotations == nil {
-		dep.Spec.Template.Annotations = make(map[string]string)
-	}
-	dep.Spec.Template.Annotations["eksctl.io/restartedAt"] = time.Now().Format(time.RFC3339)
-	bytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, dep)
-	if err != nil {
-		return errors.Wrapf(err, "failed to marshal %q deployment", t.name)
-	}
-	if _, err := ds.Patch(context.TODO(), t.name, types.MergePatchType, bytes, metav1.PatchOptions{}); err != nil {
-		return errors.Wrap(err, "failed to patch deployment")
-	}
-	logger.Info(`daemonset "%s/%s" restarted`, t.namespace, t.name)
-	return nil
 }
 
 // CreateExtraClusterConfigTasks returns all tasks for updating cluster configuration
@@ -464,10 +423,4 @@ func (c *ClusterProvider) appendCreateTasksForIAMServiceAccounts(ctx context.Con
 	)
 	newTasks.IsSubTask = true
 	tasks.Append(newTasks)
-	tasks.Append(&restartDaemonsetTask{
-		namespace:       "kube-system",
-		name:            "aws-node",
-		clusterProvider: c,
-		spec:            cfg,
-	})
 }

--- a/pkg/nodebootstrap/al2023.go
+++ b/pkg/nodebootstrap/al2023.go
@@ -49,6 +49,7 @@ func newAL2023Bootstrapper(cfg *api.ClusterConfig, np api.NodePool, clusterDNS s
 		cfg:        cfg,
 		nodePool:   np,
 		clusterDNS: clusterDNS,
+		scripts:    []string{assets.AL2023XTablesLock},
 	}
 }
 

--- a/pkg/nodebootstrap/al2023_test.go
+++ b/pkg/nodebootstrap/al2023_test.go
@@ -48,13 +48,13 @@ var _ = DescribeTable("Unmanaged AL2023", func(e al2023Entry) {
 	Expect(actual).To(Equal(e.expectedUserData))
 },
 	Entry("default", al2023Entry{
-		expectedUserData: wrapMIMEParts(nodeConfig),
+		expectedUserData: wrapMIMEParts(xTablesLock + nodeConfig),
 	}),
 	Entry("efa enabled", al2023Entry{
 		overrideNodegroupSettings: func(np api.NodePool) {
 			np.BaseNodeGroup().EFAEnabled = aws.Bool(true)
 		},
-		expectedUserData: wrapMIMEParts(efaScript + nodeConfig),
+		expectedUserData: wrapMIMEParts(xTablesLock + efaScript + nodeConfig),
 	}),
 )
 
@@ -83,26 +83,26 @@ var _ = DescribeTable("Managed AL2023", func(e al2023Entry) {
 	Expect(actual).To(Equal(e.expectedUserData))
 },
 	Entry("native AMI", al2023Entry{
-		expectedUserData: "",
+		expectedUserData: wrapMIMEParts(xTablesLock),
 	}),
 	Entry("native AMI && EFA enabled", al2023Entry{
 		overrideNodegroupSettings: func(np api.NodePool) {
 			np.BaseNodeGroup().EFAEnabled = aws.Bool(true)
 		},
-		expectedUserData: wrapMIMEParts(efaCloudhook),
+		expectedUserData: wrapMIMEParts(xTablesLock + efaCloudhook),
 	}),
 	Entry("custom AMI", al2023Entry{
 		overrideNodegroupSettings: func(np api.NodePool) {
 			np.BaseNodeGroup().AMI = "ami-xxxx"
 		},
-		expectedUserData: wrapMIMEParts(managedNodeConfig),
+		expectedUserData: wrapMIMEParts(xTablesLock + managedNodeConfig),
 	}),
 	Entry("custom AMI && EFA enabled", al2023Entry{
 		overrideNodegroupSettings: func(np api.NodePool) {
 			np.BaseNodeGroup().AMI = "ami-xxxx"
 			np.BaseNodeGroup().EFAEnabled = aws.Bool(true)
 		},
-		expectedUserData: wrapMIMEParts(efaCloudhook + managedNodeConfig),
+		expectedUserData: wrapMIMEParts(xTablesLock + efaCloudhook + managedNodeConfig),
 	}),
 )
 
@@ -273,6 +273,13 @@ Content-Type: multipart/mixed; boundary=//
 ` + parts + `--//--
 `
 	}
+
+	xTablesLock = fmt.Sprintf(`--//
+Content-Type: text/x-shellscript
+Content-Type: charset="us-ascii"
+
+%s
+`, assets.AL2023XTablesLock)
 
 	efaCloudhook = fmt.Sprintf(`--//
 Content-Type: text/cloud-boothook

--- a/pkg/nodebootstrap/assets/assets.go
+++ b/pkg/nodebootstrap/assets/assets.go
@@ -21,9 +21,9 @@ var BootstrapHelperSh string
 var BootstrapUbuntuSh string
 
 // AL2023XTablesLock holds the contents for creating a lock file for AL2023 AMIs.
+//
 //go:embed scripts/al2023-xtables.lock.sh
 var AL2023XTablesLock string
-
 
 // EfaAl2Sh holds the efa.al2.sh contents
 //

--- a/pkg/nodebootstrap/assets/assets.go
+++ b/pkg/nodebootstrap/assets/assets.go
@@ -20,6 +20,11 @@ var BootstrapHelperSh string
 //go:embed scripts/bootstrap.ubuntu.sh
 var BootstrapUbuntuSh string
 
+// AL2023XTablesLock holds the contents for creating a lock file for AL2023 AMIs.
+//go:embed scripts/al2023-xtables.lock.sh
+var AL2023XTablesLock string
+
+
 // EfaAl2Sh holds the efa.al2.sh contents
 //
 //go:embed scripts/efa.al2.sh

--- a/pkg/nodebootstrap/assets/scripts/al2023-xtables.lock.sh
+++ b/pkg/nodebootstrap/assets/scripts/al2023-xtables.lock.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+touch /run/xtables.lock

--- a/userdocs/src/usage/addon-upgrade.md
+++ b/userdocs/src/usage/addon-upgrade.md
@@ -1,5 +1,12 @@
 # Default add-on updates
 
+!!! warning "New for 2024"
+    eksctl now installs default addons as EKS addons instead of self-managed addons. Read more about its implications in [Cluster creation flexibility for default networking addons](#cluster-creation-flexibility-for-default-networking-addons).
+
+!!! warning "New for 2024"
+    For updating addons, `eksctl utils update-*` cannot be used for clusters created with eksctl v0.184.0 and above.
+    This guide is only valid for clusters created before this change.
+
 There are 3 default add-ons that get included in each EKS cluster:
 - `kube-proxy`
 - `aws-node`

--- a/userdocs/theme/main.html
+++ b/userdocs/theme/main.html
@@ -6,6 +6,13 @@
     <code>eksctl</code> is now fully maintained by AWS. For more details check out
     <a class="announce" href="https://github.com/aws/containers-roadmap/issues/2280">eksctl Support Status Update</a>.
   </p>
+  <p style="text-align: center;">
+    <code>eksctl</code> now supports <a href="/usage/addons/#cluster-creation-flexibility-for-default-networking-addons">Cluster creation flexibility for networking add-ons</a>.
+  </p>
+  <p style="text-align: center;">
+    <code>eksctl</code> now installs default addons as EKS addons instead of self-managed addons. To understand its implications, check out
+    <a href="/usage/addons/#cluster-creation-flexibility-for-default-networking-addons">Cluster creation flexibility for networking add-ons</a>.
+  </p>
 {% endblock %}
 
 


### PR DESCRIPTION
### Description

Allows cluster creation without default networking addons.

More details: https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-eks-cluster-creation-flexibility-networking-add-ons/

Fixes https://github.com/eksctl-io/eksctl/issues/7862 as well. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

