### PR TITLE
Fixes segfault when VPC CNI is disabled

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -463,7 +463,7 @@ func validateBareCluster(clusterConfig *api.ClusterConfig) error {
 		return nil
 	}
 	if clusterConfig.HasNodes() || clusterConfig.IsFargateEnabled() || clusterConfig.Karpenter != nil || clusterConfig.HasGitOpsFluxConfigured() ||
-		(clusterConfig.IAM != nil && (len(clusterConfig.IAM.ServiceAccounts) > 0) || len(clusterConfig.IAM.PodIdentityAssociations) > 0) {
+		(clusterConfig.IAM != nil && ((len(clusterConfig.IAM.ServiceAccounts) > 0) || len(clusterConfig.IAM.PodIdentityAssociations) > 0)) {
 		return errors.New("fields nodeGroups, managedNodeGroups, fargateProfiles, karpenter, gitops, iam.serviceAccounts, " +
 			"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI; please remove these fields " +
 			"and add them back after cluster creation is successful")


### PR DESCRIPTION
This PR resolves a segfault that occurs when VPC CNI is disabled and a minimal `cluster.yaml` is used:

```yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: my-calico-cluster
  region: us-east-2

addonsConfig:
  disableDefaultAddons: true

addons:
  - name: kube-proxy
  - name: coredns
```
