### PR TITLE
#7905 feature: Added EBS IO2 volumeType support to NodeGroup

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1531,13 +1531,14 @@
         },
         "volumeType": {
           "type": "string",
-          "description": "Valid variants are: `\"gp2\"` is General Purpose SSD, `\"gp3\"` is General Purpose SSD which can be optimised for high throughput (default), `\"io1\"` is Provisioned IOPS SSD, `\"sc1\"` is Cold HDD, `\"st1\"` is Throughput Optimized HDD.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;gp2&quot;</code> is General Purpose SSD, <code>&quot;gp3&quot;</code> is General Purpose SSD which can be optimised for high throughput (default), <code>&quot;io1&quot;</code> is Provisioned IOPS SSD, <code>&quot;sc1&quot;</code> is Cold HDD, <code>&quot;st1&quot;</code> is Throughput Optimized HDD.",
+          "description": "Valid variants are: `\"gp2\"` is General Purpose SSD, `\"gp3\"` is General Purpose SSD which can be optimised for high throughput (default), `\"io1\"` is Provisioned IOPS SSD, `\"io2\"` is Provisioned IOPS SSD, `\"sc1\"` is Cold HDD, `\"st1\"` is Throughput Optimized HDD.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;gp2&quot;</code> is General Purpose SSD, <code>&quot;gp3&quot;</code> is General Purpose SSD which can be optimised for high throughput (default), <code>&quot;io1&quot;</code> is Provisioned IOPS SSD, <code>&quot;io2&quot;</code> is Provisioned IOPS SSD, <code>&quot;sc1&quot;</code> is Cold HDD, <code>&quot;st1&quot;</code> is Throughput Optimized HDD.",
           "default": "gp3",
           "enum": [
             "gp2",
             "gp3",
             "io1",
+            "io2",
             "sc1",
             "st1"
           ]
@@ -1897,13 +1898,14 @@
         },
         "volumeType": {
           "type": "string",
-          "description": "Valid variants are: `\"gp2\"` is General Purpose SSD, `\"gp3\"` is General Purpose SSD which can be optimised for high throughput (default), `\"io1\"` is Provisioned IOPS SSD, `\"sc1\"` is Cold HDD, `\"st1\"` is Throughput Optimized HDD.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;gp2&quot;</code> is General Purpose SSD, <code>&quot;gp3&quot;</code> is General Purpose SSD which can be optimised for high throughput (default), <code>&quot;io1&quot;</code> is Provisioned IOPS SSD, <code>&quot;sc1&quot;</code> is Cold HDD, <code>&quot;st1&quot;</code> is Throughput Optimized HDD.",
+          "description": "Valid variants are: `\"gp2\"` is General Purpose SSD, `\"gp3\"` is General Purpose SSD which can be optimised for high throughput (default), `\"io1\"` is Provisioned IOPS SSD, `\"io2\"` is Provisioned IOPS SSD, `\"sc1\"` is Cold HDD, `\"st1\"` is Throughput Optimized HDD.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;gp2&quot;</code> is General Purpose SSD, <code>&quot;gp3&quot;</code> is General Purpose SSD which can be optimised for high throughput (default), <code>&quot;io1&quot;</code> is Provisioned IOPS SSD, <code>&quot;io2&quot;</code> is Provisioned IOPS SSD, <code>&quot;sc1&quot;</code> is Cold HDD, <code>&quot;st1&quot;</code> is Throughput Optimized HDD.",
           "default": "gp3",
           "enum": [
             "gp2",
             "gp3",
             "io1",
+            "io2",
             "sc1",
             "st1"
           ]
@@ -2510,13 +2512,14 @@
         },
         "volumeType": {
           "type": "string",
-          "description": "Valid variants are: `\"gp2\"` is General Purpose SSD, `\"gp3\"` is General Purpose SSD which can be optimised for high throughput (default), `\"io1\"` is Provisioned IOPS SSD, `\"sc1\"` is Cold HDD, `\"st1\"` is Throughput Optimized HDD.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;gp2&quot;</code> is General Purpose SSD, <code>&quot;gp3&quot;</code> is General Purpose SSD which can be optimised for high throughput (default), <code>&quot;io1&quot;</code> is Provisioned IOPS SSD, <code>&quot;sc1&quot;</code> is Cold HDD, <code>&quot;st1&quot;</code> is Throughput Optimized HDD.",
+          "description": "Valid variants are: `\"gp2\"` is General Purpose SSD, `\"gp3\"` is General Purpose SSD which can be optimised for high throughput (default), `\"io1\"` is Provisioned IOPS SSD, `\"io2\"` is Provisioned IOPS SSD, `\"sc1\"` is Cold HDD, `\"st1\"` is Throughput Optimized HDD.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;gp2&quot;</code> is General Purpose SSD, <code>&quot;gp3&quot;</code> is General Purpose SSD which can be optimised for high throughput (default), <code>&quot;io1&quot;</code> is Provisioned IOPS SSD, <code>&quot;io2&quot;</code> is Provisioned IOPS SSD, <code>&quot;sc1&quot;</code> is Cold HDD, <code>&quot;st1&quot;</code> is Throughput Optimized HDD.",
           "default": "gp3",
           "enum": [
             "gp2",
             "gp3",
             "io1",
+            "io2",
             "sc1",
             "st1"
           ]

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -213,6 +213,10 @@ func setVolumeDefaults(ng *NodeGroupBase, controlPlaneOnOutposts bool, template 
 		if ng.VolumeIOPS == nil {
 			ng.VolumeIOPS = aws.Int(DefaultNodeVolumeIO1IOPS)
 		}
+	case NodeVolumeTypeIO2:
+		if ng.VolumeIOPS == nil {
+			ng.VolumeIOPS = aws.Int(DefaultNodeVolumeIO2IOPS)
+		}
 	}
 
 	if ng.AMIFamily == NodeImageFamilyBottlerocket && !IsSetAndNonEmptyString(ng.VolumeName) {
@@ -239,6 +243,9 @@ func setDefaultsForAdditionalVolumes(ng *NodeGroupBase, controlPlaneOnOutposts b
 		}
 		if *av.VolumeType == NodeVolumeTypeIO1 && av.VolumeIOPS == nil {
 			ng.AdditionalVolumes[i].VolumeIOPS = aws.Int(DefaultNodeVolumeIO1IOPS)
+		}
+		if *av.VolumeType == NodeVolumeTypeIO2 && av.VolumeIOPS == nil {
+			ng.AdditionalVolumes[i].VolumeIOPS = aws.Int(DefaultNodeVolumeIO2IOPS)
 		}
 	}
 }

--- a/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
@@ -312,6 +312,7 @@ var _ = Describe("Outposts validation", func() {
 	},
 		Entry(api.NodeVolumeTypeGP3, api.NodeVolumeTypeGP3, true),
 		Entry(api.NodeVolumeTypeIO1, api.NodeVolumeTypeIO1, true),
+		Entry(api.NodeVolumeTypeIO2, api.NodeVolumeTypeIO2, true),
 		Entry(api.NodeVolumeTypeSC1, api.NodeVolumeTypeSC1, true),
 		Entry(api.NodeVolumeTypeST1, api.NodeVolumeTypeST1, true),
 		Entry(api.NodeVolumeTypeGP2, api.NodeVolumeTypeGP2, false),

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -412,6 +412,8 @@ const (
 	NodeVolumeTypeGP3 = "gp3"
 	// NodeVolumeTypeIO1 is Provisioned IOPS SSD
 	NodeVolumeTypeIO1 = "io1"
+	// NodeVolumeTypeIO2 is Provisioned IOPS SSD
+	NodeVolumeTypeIO2 = "io2"
 	// NodeVolumeTypeSC1 is Cold HDD
 	NodeVolumeTypeSC1 = "sc1"
 	// NodeVolumeTypeST1 is Throughput Optimized HDD
@@ -432,6 +434,8 @@ const (
 	DefaultNodeVolumeThroughput = 125
 	// DefaultNodeVolumeIO1IOPS defines the default throughput for io1 volumes, set to the min value
 	DefaultNodeVolumeIO1IOPS = 100
+	// DefaultNodeVolumeIO2IOPS defines the default throughput for io2 volumes, set to the min value
+	DefaultNodeVolumeIO2IOPS = 100
 	// DefaultNodeVolumeGP3IOPS defines the default throughput for gp3, set to the min value
 	DefaultNodeVolumeGP3IOPS = 3000
 )
@@ -606,6 +610,7 @@ func SupportedNodeVolumeTypes() []string {
 		NodeVolumeTypeGP2,
 		NodeVolumeTypeGP3,
 		NodeVolumeTypeIO1,
+		NodeVolumeTypeIO2,
 		NodeVolumeTypeSC1,
 		NodeVolumeTypeST1,
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -31,6 +31,8 @@ const (
 	MaxThroughput = 1000
 	MinIO1Iops    = DefaultNodeVolumeIO1IOPS
 	MaxIO1Iops    = 64000
+	MinIO2Iops    = DefaultNodeVolumeIO2IOPS
+	MaxIO2Iops    = 256000
 	MinGP3Iops    = DefaultNodeVolumeGP3IOPS
 	MaxGP3Iops    = 16000
 	OneDay        = 86400
@@ -718,6 +720,12 @@ func validateVolumeOpts(ng *NodeGroupBase, path string, controlPlaneOnOutposts b
 		if volumeType == NodeVolumeTypeIO1 {
 			if ng.VolumeIOPS != nil && !(*ng.VolumeIOPS >= MinIO1Iops && *ng.VolumeIOPS <= MaxIO1Iops) {
 				return fmt.Errorf("value for %s.volumeIOPS must be within range %d-%d", path, MinIO1Iops, MaxIO1Iops)
+			}
+		}
+
+		if volumeType == NodeVolumeTypeIO2 {
+			if ng.VolumeIOPS != nil && !(*ng.VolumeIOPS >= MinIO2Iops && *ng.VolumeIOPS <= MaxIO2Iops) {
+				return fmt.Errorf("value for %s.volumeIOPS must be within range %d-%d", path, MinIO2Iops, MaxIO2Iops)
 			}
 		}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -713,8 +713,8 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 func validateVolumeOpts(ng *NodeGroupBase, path string, controlPlaneOnOutposts bool) error {
 	if ng.VolumeType != nil {
 		volumeType := *ng.VolumeType
-		if ng.VolumeIOPS != nil && !(volumeType == NodeVolumeTypeIO1 || volumeType == NodeVolumeTypeGP3) {
-			return fmt.Errorf("%s.volumeIOPS is only supported for %s and %s volume types", path, NodeVolumeTypeIO1, NodeVolumeTypeGP3)
+		if ng.VolumeIOPS != nil && !(volumeType == NodeVolumeTypeIO1 || volumeType == NodeVolumeTypeIO2 || volumeType == NodeVolumeTypeGP3) {
+			return fmt.Errorf("%s.volumeIOPS is only supported for %s, %s and %s volume types", path, NodeVolumeTypeIO1, NodeVolumeTypeIO2, NodeVolumeTypeGP3)
 		}
 
 		if volumeType == NodeVolumeTypeIO1 {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -323,6 +323,30 @@ var _ = Describe("ClusterConfig validation", func() {
 				})
 			})
 
+			When("VolumeType is io2", func() {
+				BeforeEach(func() {
+					*ng0.VolumeType = api.NodeVolumeTypeIO2
+				})
+
+				It("does not fail", func() {
+					Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(Succeed())
+				})
+
+				When(fmt.Sprintf("the value of volumeIOPS is < %d", api.MinIO2Iops), func() {
+					It("returns an error", func() {
+						ng0.VolumeIOPS = aws.Int(api.MinIO2Iops - 1)
+						Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError("value for nodeGroups[0].volumeIOPS must be within range 100-64000"))
+					})
+				})
+
+				When(fmt.Sprintf("the value of volumeIOPS is > %d", api.MaxIO2Iops), func() {
+					It("returns an error", func() {
+						ng0.VolumeIOPS = aws.Int(api.MaxIO2Iops + 1)
+						Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError("value for nodeGroups[0].volumeIOPS must be within range 100-256000"))
+					})
+				})
+			})
+
 			When("VolumeType is one for which IOPS is not supported", func() {
 				It("returns an error", func() {
 					*ng0.VolumeType = api.NodeVolumeTypeGP2

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -335,7 +335,7 @@ var _ = Describe("ClusterConfig validation", func() {
 				When(fmt.Sprintf("the value of volumeIOPS is < %d", api.MinIO2Iops), func() {
 					It("returns an error", func() {
 						ng0.VolumeIOPS = aws.Int(api.MinIO2Iops - 1)
-						Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError("value for nodeGroups[0].volumeIOPS must be within range 100-64000"))
+						Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError("value for nodeGroups[0].volumeIOPS must be within range 100-256000"))
 					})
 				})
 
@@ -350,7 +350,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			When("VolumeType is one for which IOPS is not supported", func() {
 				It("returns an error", func() {
 					*ng0.VolumeType = api.NodeVolumeTypeGP2
-					Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError("nodeGroups[0].volumeIOPS is only supported for io1 and gp3 volume types"))
+					Expect(api.ValidateNodeGroup(0, ng0, cfg)).To(MatchError("nodeGroups[0].volumeIOPS is only supported for io1, io2 and gp3 volume types"))
 				})
 			})
 		})

--- a/pkg/cfn/builder/block_device_mapping.go
+++ b/pkg/cfn/builder/block_device_mapping.go
@@ -84,7 +84,7 @@ func makeBlockDeviceMapping(vm *api.VolumeMapping) *gfnec2.LaunchTemplate_BlockD
 		mapping.Ebs.KmsKeyId = gfnt.NewString(*vm.VolumeKmsKeyID)
 	}
 
-	if (*vm.VolumeType == api.NodeVolumeTypeIO1 || *vm.VolumeType == api.NodeVolumeTypeGP3) && vm.VolumeIOPS != nil {
+	if (*vm.VolumeType == api.NodeVolumeTypeIO1 || *vm.VolumeType == api.NodeVolumeTypeIO2 || *vm.VolumeType == api.NodeVolumeTypeGP3) && vm.VolumeIOPS != nil {
 		mapping.Ebs.Iops = gfnt.NewInteger(*vm.VolumeIOPS)
 	}
 

--- a/pkg/cfn/builder/nodegroup_test.go
+++ b/pkg/cfn/builder/nodegroup_test.go
@@ -1203,6 +1203,18 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 					})
 				})
 
+				Context("ng.VolumeType is IO2", func() {
+					BeforeEach(func() {
+						ng.VolumeType = aws.String(api.NodeVolumeTypeIO1)
+						ng.VolumeIOPS = aws.Int(500)
+					})
+
+					It("IOPS are set on the block device mapping", func() {
+						mapping := ngTemplate.Resources["NodeGroupLaunchTemplate"].Properties.LaunchTemplateData.BlockDeviceMappings[0]
+						Expect(mapping.Ebs["Iops"]).To(Equal(float64(500)))
+					})
+				})
+
 				Context("ng.VolumeType is GP3", func() {
 					BeforeEach(func() {
 						ng.VolumeType = aws.String(api.NodeVolumeTypeGP3)

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -625,6 +625,10 @@ func normalizeNodeGroup(ng *api.NodeGroup, l *commonClusterConfigLoader) error {
 		return fmt.Errorf("%s volume type is not supported via flag --node-volume-type, please use a config file", api.NodeVolumeTypeIO1)
 	}
 
+	if *ng.VolumeType == api.NodeVolumeTypeIO2 {
+		return fmt.Errorf("%s volume type is not supported via flag --node-volume-type, please use a config file", api.NodeVolumeTypeIO2)
+	}
+
 	normalizeBaseNodeGroup(ng, l.CobraCommand)
 	return nil
 }


### PR DESCRIPTION
### Description
- Added EBS IO2 type to the list of supported volume types in NodeGroup
- Validation for minimum and maximum IOPS values supported by EBS IO2 (100-256000) was added.
- Default IOPS value for the IO2 volume type is 100 IOPS(minimum supported value). 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

