### PR TITLE
Documentation: correct version drift limits in cluster-upgrade.md

### DIFF
--- a/userdocs/src/usage/cluster-upgrade.md
+++ b/userdocs/src/usage/cluster-upgrade.md
@@ -12,11 +12,11 @@ An _`eksctl`-managed_ cluster can be upgraded in 3 easy steps:
 Please make sure to read this section in full before you proceed.
 
 ???+ info
-    Kubernetes supports version drift of up-to two minor versions during upgrade
-    process. So nodes can be up to two minor versions ahead or behind the control plane
+    Kubernetes supports version drift of up to two minor versions during the upgrade
+    process. Nodes can be up to two minor versions behind, but never ahead of the control plane
     version. You can only upgrade the control plane one minor version at a time, but
-    nodes can be upgraded more than one minor version at a time, provided the nodes stay
-    within two minor versions of the control plane.
+    nodes can be upgraded more than one minor version at a time, provided their version
+    does not become greater than the control plane version.
 
 ???+ info
     The old `eksctl update cluster` will be deprecated. Use `eksctl upgrade cluster` instead.


### PR DESCRIPTION
Correct the description of version drift during upgrade to match the current kubernetes documentation. Node version should not be newer than the cluster version.

### Description

Kubernetes requires that the version of each `kubelet` in a cluster be no newer than the oldest `kube-apiserver` in the cluster. A note in cluster-upgrade.md said that a node could be up to two minor versions ahead or behind the
cluster version during upgrade.

I encountered this while adding a nodegroup running a 1.31 AMI to a cluster running 1.30: the instance failed during network initialization and could not join the cluster. Upgrading the cluster to 1.31 fixed the problem: the failing nodes were able to join the 1.31 cluster.

### Checklist
- [n/a] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

