### PR TITLE
userdocs: fix comment for custom managed nodegroup

### DIFF
--- a/userdocs/src/usage/nodegroup-managed.md
+++ b/userdocs/src/usage/nodegroup-managed.md
@@ -116,7 +116,7 @@ managedNodeGroups:
 
 ```yaml
 # cluster.yaml
-# A cluster with an unmanaged nodegroup and two managed nodegroups.
+# A cluster with a managed nodegroup with customization.
 ---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig


### PR DESCRIPTION
### Description

Small error I found while looking through managed nodegroups documentation. The current codeblock comment is copied from [the one above giving an example of unmanaged and managed nodegroups](https://eksctl.io/usage/nodegroup-managed/#:~:text=It%27s%20possible%20to%20have%20a%20cluster%20with%20both%20managed%20and%20unmanaged%20nodegroups.%20Unmanaged%20nodegroups%20do%20not%20show%20up%20in%20the%20AWS%20EKS%20console%20but%20eksctl%20get%20nodegroup%20will%20list%20both%20types%20of%20nodegroups.) instead of referring to custom options for nodegroups. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

