### PR TITLE
Remove deletion of aws-efs-csi-driver

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -647,11 +647,6 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 				)).
 				To(RunSuccessfully())
 			assertPodIDPresence("kube-system", ebsCSIControllerSA, false)
-
-			By("deleting IRSA when deleting addons")
-			Expect(makeDeleteAddonCMD(api.AWSEFSCSIDriverAddon)).To(RunSuccessfully())
-			assertPodIDPresence("kube-system", efsCSIControllerSA, false)
-			assertStackDeleted(makeIRSAStackName(api.AWSEFSCSIDriverAddon))
 		})
 
 		It("should update IAM permissions when updating or migrating addons", func() {


### PR DESCRIPTION
### Description

aws-efs-csi-driver is no longer installed. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

