### PR TITLE
Add support for more Graviton 4th gen instance types

### DIFF
--- a/pkg/utils/instance/instance.go
+++ b/pkg/utils/instance/instance.go
@@ -16,8 +16,10 @@ func IsARMInstanceType(instanceType string) bool {
 		strings.HasPrefix(instanceType, "m8g") ||
 		strings.HasPrefix(instanceType, "c6g") ||
 		strings.HasPrefix(instanceType, "c7g") ||
+		strings.HasPrefix(instanceType, "c8g") ||
 		strings.HasPrefix(instanceType, "r6g") ||
 		strings.HasPrefix(instanceType, "r7g") ||
+		strings.HasPrefix(instanceType, "r8g") ||
 		strings.HasPrefix(instanceType, "im4g") ||
 		strings.HasPrefix(instanceType, "is4g") ||
 		strings.HasPrefix(instanceType, "g5g") ||


### PR DESCRIPTION
### Description

Adds support for c8g and r8g instance types.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

