### PR TITLE
feat: Ubuntu 24.04 support

### DIFF
--- a/integration/tests/custom_ami/custom_ami_test.go
+++ b/integration/tests/custom_ami/custom_ami_test.go
@@ -41,6 +41,7 @@ var (
 	customAMIAL2023        string
 	customAMIBottlerocket  string
 	customAMIUbuntuPro2204 string
+	customAMIUbuntuPro2404 string
 )
 
 var _ = BeforeSuite(func() {
@@ -78,6 +79,14 @@ var _ = BeforeSuite(func() {
 	output, err = ssm.GetParameter(context.Background(), input)
 	Expect(err).NotTo(HaveOccurred())
 	customAMIUbuntuPro2204 = *output.Parameter.Value
+
+	// retrieve Ubuntu Pro 24.04 AMI
+	input = &awsssm.GetParameterInput{
+		Name: aws.String(fmt.Sprintf("/aws/service/canonical/ubuntu/eks-pro/24.04/%s/stable/current/amd64/hvm/ebs-gp3/ami-id", params.Version)),
+	}
+	output, err = ssm.GetParameter(context.Background(), input)
+	Expect(err).NotTo(HaveOccurred())
+	customAMIUbuntuPro2404 = *output.Parameter.Value
 
 	cmd := params.EksctlCreateCmd.WithArgs(
 		"cluster",
@@ -166,6 +175,28 @@ var _ = Describe("(Integration) [Test Custom AMI]", func() {
 			content = bytes.ReplaceAll(content, []byte("<generated>"), []byte(params.ClusterName))
 			content = bytes.ReplaceAll(content, []byte("<generated-region>"), []byte(params.Region))
 			content = bytes.ReplaceAll(content, []byte("<generated-ami>"), []byte(customAMIUbuntuPro2204))
+			cmd := params.EksctlCreateCmd.
+				WithArgs(
+					"nodegroup",
+					"--config-file", "-",
+					"--verbose", "4",
+				).
+				WithoutArg("--region", params.Region).
+				WithStdin(bytes.NewReader(content))
+			Expect(cmd).To(RunSuccessfully())
+		})
+
+	})
+
+	Context("ubuntu-pro-2404 un-managed nodegroups", func() {
+
+		It("can create a working nodegroup which can join the cluster", func() {
+			By(fmt.Sprintf("using the following EKS optimised AMI: %s", customAMIUbuntuPro2404))
+			content, err := os.ReadFile(filepath.Join("testdata/ubuntu-pro-2404.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			content = bytes.ReplaceAll(content, []byte("<generated>"), []byte(params.ClusterName))
+			content = bytes.ReplaceAll(content, []byte("<generated-region>"), []byte(params.Region))
+			content = bytes.ReplaceAll(content, []byte("<generated-ami>"), []byte(customAMIUbuntuPro2404))
 			cmd := params.EksctlCreateCmd.
 				WithArgs(
 					"nodegroup",

--- a/integration/tests/custom_ami/testdata/ubuntu-pro-2404.yaml
+++ b/integration/tests/custom_ami/testdata/ubuntu-pro-2404.yaml
@@ -1,0 +1,17 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+# name is generated
+metadata:
+  name: <generated>
+  region: <generated-region>
+
+nodeGroups:
+  - name: unm-ubuntu-pro-2404
+    ami: <generated-ami>
+    amiFamily: UbuntuPro2404
+    desiredCapacity: 1
+    overrideBootstrapCommand: |
+      #!/bin/bash
+      source /var/lib/cloud/scripts/eksctl/bootstrap.helper.sh
+      /etc/eks/bootstrap.sh <generated> --kubelet-extra-args "--node-labels=${NODE_LABELS}"

--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -35,9 +35,17 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 			ImageClassNeuron:  fmt.Sprintf("amazon-eks-gpu-node-%s-*", version),
 			ImageClassARM:     fmt.Sprintf("amazon-eks-arm64-node-%s-*", version),
 		},
+		api.NodeImageFamilyUbuntuPro2404: {
+			ImageClassGeneral: fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*24.04-amd64*", version),
+			ImageClassARM:     fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*24.04-arm64*", version),
+		},
 		api.NodeImageFamilyUbuntuPro2204: {
 			ImageClassGeneral: fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*22.04-amd64*", version),
 			ImageClassARM:     fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*22.04-arm64*", version),
+		},
+		api.NodeImageFamilyUbuntu2404: {
+			ImageClassGeneral: fmt.Sprintf("ubuntu-eks/k8s_%s/images/*24.04-amd64*", version),
+			ImageClassARM:     fmt.Sprintf("ubuntu-eks/k8s_%s/images/*24.04-arm64*", version),
 		},
 		api.NodeImageFamilyUbuntu2204: {
 			ImageClassGeneral: fmt.Sprintf("ubuntu-eks/k8s_%s/images/*22.04-amd64*", version),
@@ -68,7 +76,7 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 // OwnerAccountID returns the AWS account ID that owns worker AMI.
 func OwnerAccountID(imageFamily, region string) (string, error) {
 	switch imageFamily {
-	case api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
+	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
 		return ownerIDUbuntuFamily, nil
 	case api.NodeImageFamilyAmazonLinux2023, api.NodeImageFamilyAmazonLinux2:
 		return api.EKSResourceAccountID(region), nil

--- a/pkg/ami/auto_resolver_test.go
+++ b/pkg/ami/auto_resolver_test.go
@@ -72,6 +72,16 @@ var _ = Describe("AMI Auto Resolution", func() {
 				Expect(ownerAccount).To(BeEquivalentTo("099720109477"))
 				Expect(err).NotTo(HaveOccurred())
 			})
+			It("should return the Ubuntu Account ID for Ubuntu images", func() {
+				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyUbuntu2404, region)
+				Expect(ownerAccount).To(BeEquivalentTo("099720109477"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should return the Ubuntu Account ID for Ubuntu images", func() {
+				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyUbuntuPro2404, region)
+				Expect(ownerAccount).To(BeEquivalentTo("099720109477"))
+				Expect(err).NotTo(HaveOccurred())
+			})
 
 			It("should return the Windows Account ID for Windows Server images", func() {
 				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyWindowsServer2022CoreContainer, region)

--- a/pkg/ami/ssm_resolver.go
+++ b/pkg/ami/ssm_resolver.go
@@ -88,6 +88,16 @@ func MakeSSMParameterName(version, instanceType, imageFamily string) (string, er
 		return fmt.Sprint("/aws/service/canonical/ubuntu/", eksProduct, "/", ubuntuReleaseName(imageFamily), "/", version, "/stable/current/", ubuntuArchName(instanceType), "/hvm/ebs-gp2/ami-id"), nil
 	default:
 		return "", fmt.Errorf("unknown image family %s", imageFamily)
+	case api.NodeImageFamilyUbuntu2404,
+		api.NodeImageFamilyUbuntuPro2404:
+		if err := validateVersionForUbuntu(version, imageFamily); err != nil {
+			return "", err
+		}
+		eksProduct := "eks"
+		if imageFamily == api.NodeImageFamilyUbuntuPro2404 {
+			eksProduct = "eks-pro"
+		}
+		return fmt.Sprint("/aws/service/canonical/ubuntu/", eksProduct, "/", ubuntuReleaseName(imageFamily), "/", version, "/stable/current/", ubuntuArchName(instanceType), "/hvm/ebs-gp3/ami-id"), nil
 	}
 }
 
@@ -177,6 +187,8 @@ func ubuntuReleaseName(imageFamily string) string {
 		return "20.04"
 	case api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204:
 		return "22.04"
+	case api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
+		return "24.04"
 	default:
 		return "18.04"
 	}
@@ -207,6 +219,17 @@ func validateVersionForUbuntu(version, imageFamily string) error {
 		var err error
 		supportsUbuntu := false
 		const minVersion = api.Version1_29
+		supportsUbuntu, err = utils.IsMinVersion(minVersion, version)
+		if err != nil {
+			return err
+		}
+		if !supportsUbuntu {
+			return &UnsupportedQueryError{msg: fmt.Sprintf("%s requires EKS version greater or equal than %s", imageFamily, minVersion)}
+		}
+	case api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
+		var err error
+		supportsUbuntu := false
+		const minVersion = api.Version1_31
 		supportsUbuntu, err = utils.IsMinVersion(minVersion, version)
 		if err != nil {
 			return err

--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -443,6 +443,118 @@ var _ = Describe("AMI Auto Resolution", func() {
 				})
 			})
 
+			Context("and Ubuntu2404 family", func() {
+				BeforeEach(func() {
+					p = mockprovider.NewMockProvider()
+					instanceType = "t2.medium"
+					imageFamily = "Ubuntu2404"
+				})
+
+				DescribeTable("should return an error",
+					func(version string) {
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("Ubuntu2404 requires EKS version greater or equal than 1.31"))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.21"),
+					Entry(nil, "1.30"),
+				)
+
+				DescribeTable("should return a valid AMI",
+					func(version string) {
+						addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks/24.04/%s/stable/current/amd64/hvm/ebs-gp3/ami-id", version), expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.31"),
+				)
+
+				Context("for arm instance type", func() {
+					BeforeEach(func() {
+						instanceType = "a1.large"
+					})
+					DescribeTable("should return a valid AMI for arm64",
+						func(version string) {
+							addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks/24.04/%s/stable/current/arm64/hvm/ebs-gp3/ami-id", version), expectedAmi)
+
+							resolver := NewSSMResolver(p.MockSSM())
+							resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+							Expect(err).NotTo(HaveOccurred())
+							Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+							Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						},
+						EntryDescription("When EKS version is %s"),
+						Entry(nil, "1.31"),
+					)
+				})
+			})
+
+			Context("and UbuntuPro2404 family", func() {
+				BeforeEach(func() {
+					p = mockprovider.NewMockProvider()
+					instanceType = "t2.medium"
+					imageFamily = "UbuntuPro2404"
+				})
+
+				DescribeTable("should return an error",
+					func(version string) {
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("UbuntuPro2404 requires EKS version greater or equal than 1.31"))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.21"),
+					Entry(nil, "1.30"),
+				)
+
+				DescribeTable("should return a valid AMI",
+					func(version string) {
+						addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks-pro/24.04/%s/stable/current/amd64/hvm/ebs-gp3/ami-id", version), expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+					},
+					EntryDescription("When EKS version is %s"),
+					Entry(nil, "1.31"),
+				)
+
+				Context("for arm instance type", func() {
+					BeforeEach(func() {
+						instanceType = "a1.large"
+					})
+					DescribeTable("should return a valid AMI for arm64",
+						func(version string) {
+							addMockGetParameter(p, fmt.Sprintf("/aws/service/canonical/ubuntu/eks-pro/24.04/%s/stable/current/arm64/hvm/ebs-gp3/ami-id", version), expectedAmi)
+
+							resolver := NewSSMResolver(p.MockSSM())
+							resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+							Expect(err).NotTo(HaveOccurred())
+							Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+							Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						},
+						EntryDescription("When EKS version is %s"),
+						Entry(nil, "1.31"),
+					)
+				})
+			})
+
 			Context("and Bottlerocket image family", func() {
 				BeforeEach(func() {
 					instanceType = "t2.medium"

--- a/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
@@ -210,6 +210,8 @@ var _ = Describe("Outposts validation", func() {
 		Entry("Ubuntu2004", api.NodeImageFamilyUbuntu2004, true),
 		Entry("Ubuntu2204", api.NodeImageFamilyUbuntu2204, true),
 		Entry("UbuntuPro2204", api.NodeImageFamilyUbuntuPro2204, true),
+		Entry("Ubuntu2404", api.NodeImageFamilyUbuntuPro2204, true),
+		Entry("UbuntuPro2404", api.NodeImageFamilyUbuntuPro2204, true),
 		Entry("Windows2019Core", api.NodeImageFamilyWindowsServer2019CoreContainer, true),
 		Entry("Windows2019Full", api.NodeImageFamilyWindowsServer2019FullContainer, true),
 		Entry("Windows2022Core", api.NodeImageFamilyWindowsServer2022CoreContainer, true),

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -231,6 +231,8 @@ const (
 	DefaultNodeImageFamily         = NodeImageFamilyAmazonLinux2
 	NodeImageFamilyAmazonLinux2023 = "AmazonLinux2023"
 	NodeImageFamilyAmazonLinux2    = "AmazonLinux2"
+	NodeImageFamilyUbuntuPro2404   = "UbuntuPro2404"
+	NodeImageFamilyUbuntu2404	   = "Ubuntu2404"
 	NodeImageFamilyUbuntuPro2204   = "UbuntuPro2204"
 	NodeImageFamilyUbuntu2204      = "Ubuntu2204"
 	NodeImageFamilyUbuntu2004      = "Ubuntu2004"
@@ -615,6 +617,8 @@ func SupportedAMIFamilies() []string {
 	return []string{
 		NodeImageFamilyAmazonLinux2023,
 		NodeImageFamilyAmazonLinux2,
+		NodeImageFamilyUbuntuPro2404,
+		NodeImageFamilyUbuntu2404,
 		NodeImageFamilyUbuntuPro2204,
 		NodeImageFamilyUbuntu2204,
 		NodeImageFamilyUbuntu2004,

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -1568,7 +1568,9 @@ func IsAmazonLinuxImage(imageFamily string) bool {
 
 func IsUbuntuImage(imageFamily string) bool {
 	switch imageFamily {
-	case NodeImageFamilyUbuntuPro2204,
+	case NodeImageFamilyUbuntuPro2404,
+		NodeImageFamilyUbuntu2404,
+		NodeImageFamilyUbuntuPro2204,
 		NodeImageFamilyUbuntu2204,
 		NodeImageFamilyUbuntu2004,
 		NodeImageFamilyUbuntu1804:

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -2183,6 +2183,14 @@ var _ = Describe("ClusterConfig validation", func() {
 			err = api.ValidateManagedNodeGroup(0, mng)
 			Expect(err).NotTo(HaveOccurred())
 
+			mng.AMIFamily = api.NodeImageFamilyUbuntu2404
+			err = api.ValidateManagedNodeGroup(0, mng)
+			Expect(err).NotTo(HaveOccurred())
+
+			mng.AMIFamily = api.NodeImageFamilyUbuntuPro2404
+			err = api.ValidateManagedNodeGroup(0, mng)
+			Expect(err).NotTo(HaveOccurred())
+
 			mng.AMIFamily = api.NodeImageFamilyBottlerocket
 			mng.OverrideBootstrapCommand = nil
 			err = api.ValidateManagedNodeGroup(0, mng)

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -48,7 +48,7 @@ func NewBootstrapper(clusterConfig *api.ClusterConfig, ng *api.NodeGroup) (Boots
 		return NewWindowsBootstrapper(clusterConfig, ng, clusterDNS), nil
 	}
 	switch ng.AMIFamily {
-	case api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
+	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
 	case api.NodeImageFamilyBottlerocket:
 		return NewBottlerocketBootstrapper(clusterConfig, ng), nil
@@ -80,7 +80,7 @@ func NewManagedBootstrapper(clusterConfig *api.ClusterConfig, ng *api.ManagedNod
 		return NewManagedAL2Bootstrapper(ng), nil
 	case api.NodeImageFamilyBottlerocket:
 		return NewManagedBottlerocketBootstrapper(clusterConfig, ng), nil
-	case api.NodeImageFamilyUbuntu1804, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204:
+	case api.NodeImageFamilyUbuntu1804, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
 	}
 	return nil, nil

--- a/userdocs/src/usage/custom-ami-support.md
+++ b/userdocs/src/usage/custom-ami-support.md
@@ -61,6 +61,8 @@ The `--node-ami-family` can take following keywords:
 | Ubuntu2004                     | Indicates that the EKS AMI image based on Ubuntu 20.04 LTS (Focal) should be used (supported for EKS <= 1.29).     |
 | Ubuntu2204                     | Indicates that the EKS AMI image based on Ubuntu 22.04 LTS (Jammy) should be used (available for EKS >= 1.29).     |
 | UbuntuPro2204                  | Indicates that the EKS AMI image based on Ubuntu Pro 22.04 LTS (Jammy) should be used (available for EKS >= 1.29). |
+| Ubuntu2404                     | Indicates that the EKS AMI image based on Ubuntu 24.04 LTS (Noble) should be used (available for EKS >= 1.31).     |
+| UbuntuPro2404                  | Indicates that the EKS AMI image based on Ubuntu Pro 24.04 LTS (Noble) should be used (available for EKS >= 1.31). |
 | Bottlerocket                   | Indicates that the EKS AMI image based on Bottlerocket should be used.                                             |
 | WindowsServer2019FullContainer | Indicates that the EKS AMI image based on Windows Server 2019 Full Container should be used.                       |
 | WindowsServer2019CoreContainer | Indicates that the EKS AMI image based on Windows Server 2019 Core Container should be used.                       |
@@ -87,7 +89,7 @@ managedNodeGroups:
 The `--node-ami-family` flag can also be used with `eksctl create nodegroup`. `eksctl` requires AMI Family to be explicitly set via config file or via `--node-ami-family` CLI flag, whenever working with a custom AMI.
 
 ???+ note
-    At the moment, EKS managed nodegroups only support the following AMI Families when working with custom AMIs: `AmazonLinux2023`, `AmazonLinux2`, `Ubuntu1804`, `Ubuntu2004` and `Ubuntu2204`
+    At the moment, EKS managed nodegroups only support the following AMI Families when working with custom AMIs: `AmazonLinux2023`, `AmazonLinux2`, `Ubuntu1804`, `Ubuntu2004`, `Ubuntu2204` and `Ubuntu2404`
 
 ## Windows custom AMI support
 Only self-managed Windows nodegroups can specify a custom AMI. `amiFamily` should be set to a valid Windows AMI family.


### PR DESCRIPTION
This adds image lookup support for Ubuntu 24.04 (using image names and ssm param resolution).

### Description

Ubuntu EKS worker nodes images are now available for EKS 1.31 based on Ubuntu 24.04 (Noble). This PR adds support to use those new images.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)
