### PR TITLE
Remove support for deprecated Ubuntu 18.04

### DIFF
--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -55,9 +55,6 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 			ImageClassGeneral: fmt.Sprintf("ubuntu-eks/k8s_%s/images/*20.04-amd64*", version),
 			ImageClassARM:     fmt.Sprintf("ubuntu-eks/k8s_%s/images/*20.04-arm64*", version),
 		},
-		api.NodeImageFamilyUbuntu1804: {
-			ImageClassGeneral: fmt.Sprintf("ubuntu-eks/k8s_%s/images/*18.04*", version),
-		},
 		api.NodeImageFamilyWindowsServer2019CoreContainer: {
 			ImageClassGeneral: fmt.Sprintf("Windows_Server-2019-English-Core-EKS_Optimized-%v-*", version),
 		},
@@ -76,7 +73,7 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 // OwnerAccountID returns the AWS account ID that owns worker AMI.
 func OwnerAccountID(imageFamily, region string) (string, error) {
 	switch imageFamily {
-	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
+	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004:
 		return ownerIDUbuntuFamily, nil
 	case api.NodeImageFamilyAmazonLinux2023, api.NodeImageFamilyAmazonLinux2:
 		return api.EKSResourceAccountID(region), nil

--- a/pkg/ami/auto_resolver_test.go
+++ b/pkg/ami/auto_resolver_test.go
@@ -52,13 +52,13 @@ var _ = Describe("AMI Auto Resolution", func() {
 			})
 
 			It("should return the AWS Account ID for Ubuntu images in ap-east-1", func() {
-				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyUbuntu1804, "ap-east-1")
+				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyUbuntu2004, "ap-east-1")
 				Expect(ownerAccount).To(BeEquivalentTo("099720109477"))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return the Ubuntu Account ID for Ubuntu images", func() {
-				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyUbuntu1804, region)
+				ownerAccount, err := OwnerAccountID(api.NodeImageFamilyUbuntu2004, region)
 				Expect(ownerAccount).To(BeEquivalentTo("099720109477"))
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -130,10 +130,10 @@ var _ = Describe("AMI Auto Resolution", func() {
 				Context("and ami is available", func() {
 					BeforeEach(func() {
 						imageState = ec2types.ImageStateAvailable
-						imageFamily = "Ubuntu1804"
+						imageFamily = "Ubuntu2204"
 
 						p = mockprovider.NewMockProvider()
-						addMockDescribeImages(p, "ubuntu-eks/k8s_1.15/images/*18.04*", expectedAmi, imageState, "2018-08-20T23:25:53.000Z", api.NodeImageFamilyUbuntu1804)
+						addMockDescribeImages(p, "ubuntu-eks/k8s_1.29/images/*22.04*", expectedAmi, imageState, "2024-12-09T00:00:26.000Z", api.NodeImageFamilyUbuntu2204)
 
 						resolver := NewAutoResolver(p.MockEC2())
 						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)

--- a/pkg/ami/auto_resolver_test.go
+++ b/pkg/ami/auto_resolver_test.go
@@ -133,7 +133,7 @@ var _ = Describe("AMI Auto Resolution", func() {
 						imageFamily = "Ubuntu2204"
 
 						p = mockprovider.NewMockProvider()
-						addMockDescribeImages(p, "ubuntu-eks/k8s_1.29/images/*22.04*", expectedAmi, imageState, "2024-12-09T00:00:26.000Z", api.NodeImageFamilyUbuntu2204)
+						addMockDescribeImages(p, "ubuntu-eks/k8s_1.15/images/*22.04*", expectedAmi, imageState, "2024-12-09T00:00:26.000Z", api.NodeImageFamilyUbuntu2204)
 
 						resolver := NewAutoResolver(p.MockEC2())
 						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)

--- a/pkg/ami/ssm_resolver.go
+++ b/pkg/ami/ssm_resolver.go
@@ -73,8 +73,6 @@ func MakeSSMParameterName(version, instanceType, imageFamily string) (string, er
 		return fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2022-English-%s-EKS_Optimized-%s/%s", windowsAmiType(imageFamily), version, fieldName), nil
 	case api.NodeImageFamilyBottlerocket:
 		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/%s", imageType(imageFamily, instanceType, version), instanceEC2ArchName(instanceType), fieldName), nil
-	case api.NodeImageFamilyUbuntu1804:
-		return "", &UnsupportedQueryError{msg: fmt.Sprintf("SSM Parameter lookups for %s AMIs is not supported", imageFamily)}
 	case api.NodeImageFamilyUbuntu2004,
 		api.NodeImageFamilyUbuntu2204,
 		api.NodeImageFamilyUbuntuPro2204:
@@ -190,7 +188,7 @@ func ubuntuReleaseName(imageFamily string) string {
 	case api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
 		return "24.04"
 	default:
-		return "18.04"
+		return "20.04"
 	}
 }
 

--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -234,23 +234,6 @@ var _ = Describe("AMI Auto Resolution", func() {
 
 			})
 
-			Context("and Ubuntu1804 family", func() {
-				BeforeEach(func() {
-					p = mockprovider.NewMockProvider()
-					instanceType = "t2.medium"
-					imageFamily = "Ubuntu1804"
-				})
-
-				It("should return an error", func() {
-					resolver := NewSSMResolver(p.MockSSM())
-					resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
-
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError("SSM Parameter lookups for Ubuntu1804 AMIs is not supported"))
-				})
-
-			})
-
 			Context("and Ubuntu2004 family", func() {
 				BeforeEach(func() {
 					p = mockprovider.NewMockProvider()

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1341,8 +1341,8 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
           "default": "AmazonLinux2",
           "enum": [
             "AmazonLinux2",
@@ -1352,7 +1352,6 @@
             "UbuntuPro2204",
             "Ubuntu2204",
             "Ubuntu2004",
-            "Ubuntu1804",
             "Bottlerocket",
             "WindowsServer2019CoreContainer",
             "WindowsServer2019FullContainer",
@@ -1684,8 +1683,8 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
           "default": "AmazonLinux2",
           "enum": [
             "AmazonLinux2",
@@ -1695,7 +1694,6 @@
             "UbuntuPro2204",
             "Ubuntu2204",
             "Ubuntu2004",
-            "Ubuntu1804",
             "Bottlerocket",
             "WindowsServer2019CoreContainer",
             "WindowsServer2019FullContainer",

--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -63,10 +63,6 @@ var _ = Describe("GPU instance support", func() {
 			gpuInstanceType: "g5.12xlarge",
 			amiFamily:       api.NodeImageFamilyAmazonLinux2,
 		}),
-		Entry("Ubuntu1804", gpuInstanceEntry{
-			amiFamily:       api.NodeImageFamilyUbuntu2004,
-			gpuInstanceType: "g4dn.xlarge",
-		}),
 		Entry("Ubuntu2004", gpuInstanceEntry{
 			amiFamily:       api.NodeImageFamilyUbuntu2004,
 			gpuInstanceType: "g4dn.xlarge",
@@ -226,11 +222,6 @@ var _ = Describe("GPU instance support", func() {
 			},
 			expectWarning: true,
 		}),
-		Entry("Ubuntu with explicit GPU instance", gpuInstanceEntry{
-			amiFamily:       api.NodeImageFamilyUbuntu1804,
-			gpuInstanceType: "g4dn.xlarge",
-			expectWarning:   true,
-		}),
 		Entry("Ubuntu with implicit GPU instance", gpuInstanceEntry{
 			amiFamily: api.NodeImageFamilyUbuntu2004,
 			instanceSelector: &api.InstanceSelector{
@@ -254,7 +245,6 @@ var _ = Describe("GPU instance support", func() {
 	},
 		Entry("AmazonLinux2", api.NodeImageFamilyAmazonLinux2, true),
 		Entry("Ubuntu2004", api.NodeImageFamilyUbuntu2004, true),
-		Entry("Ubuntu1804", api.NodeImageFamilyUbuntu1804, true),
 		Entry("Windows2019Full", api.NodeImageFamilyWindowsServer2019FullContainer, true),
 		Entry("Windows2019Core", api.NodeImageFamilyWindowsServer2019CoreContainer, true),
 		Entry("Bottlerocket", api.NodeImageFamilyBottlerocket, false),

--- a/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
@@ -206,7 +206,6 @@ var _ = Describe("Outposts validation", func() {
 	},
 		Entry("AmazonLinux2", api.NodeImageFamilyAmazonLinux2, false),
 		Entry("Bottlerocket", api.NodeImageFamilyBottlerocket, true),
-		Entry("Ubuntu1804", api.NodeImageFamilyUbuntu1804, true),
 		Entry("Ubuntu2004", api.NodeImageFamilyUbuntu2004, true),
 		Entry("Ubuntu2204", api.NodeImageFamilyUbuntu2204, true),
 		Entry("UbuntuPro2204", api.NodeImageFamilyUbuntuPro2204, true),

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -192,7 +192,6 @@ const (
 	NodeImageFamilyUbuntuPro2204   = "UbuntuPro2204"
 	NodeImageFamilyUbuntu2204      = "Ubuntu2204"
 	NodeImageFamilyUbuntu2004      = "Ubuntu2004"
-	NodeImageFamilyUbuntu1804      = "Ubuntu1804"
 	NodeImageFamilyBottlerocket    = "Bottlerocket"
 
 	NodeImageFamilyWindowsServer2019CoreContainer = "WindowsServer2019CoreContainer"
@@ -530,7 +529,6 @@ func SupportedAMIFamilies() []string {
 		NodeImageFamilyUbuntuPro2204,
 		NodeImageFamilyUbuntu2204,
 		NodeImageFamilyUbuntu2004,
-		NodeImageFamilyUbuntu1804,
 		NodeImageFamilyBottlerocket,
 		NodeImageFamilyWindowsServer2019CoreContainer,
 		NodeImageFamilyWindowsServer2019FullContainer,

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -1565,8 +1565,7 @@ func IsUbuntuImage(imageFamily string) bool {
 		NodeImageFamilyUbuntu2404,
 		NodeImageFamilyUbuntuPro2204,
 		NodeImageFamilyUbuntu2204,
-		NodeImageFamilyUbuntu2004,
-		NodeImageFamilyUbuntu1804:
+		NodeImageFamilyUbuntu2004:
 		return true
 
 	default:

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -2167,10 +2167,6 @@ var _ = Describe("ClusterConfig validation", func() {
 			err := api.ValidateManagedNodeGroup(0, mng)
 			Expect(err).NotTo(HaveOccurred())
 
-			mng.AMIFamily = api.NodeImageFamilyUbuntu1804
-			err = api.ValidateManagedNodeGroup(0, mng)
-			Expect(err).NotTo(HaveOccurred())
-
 			mng.AMIFamily = api.NodeImageFamilyUbuntu2004
 			err = api.ValidateManagedNodeGroup(0, mng)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/eks/api_test.go
+++ b/pkg/eks/api_test.go
@@ -279,14 +279,6 @@ var _ = Describe("eksctl API", func() {
 			testEnsureAMI(Equal("ami-ssm"), "1.14")
 		})
 
-		It("should fall back to auto resolution for Ubuntu1804", func() {
-			ng.AMIFamily = api.NodeImageFamilyUbuntu1804
-			mockDescribeImages(provider, "ami-ubuntu", func(input *ec2.DescribeImagesInput) bool {
-				return input.Owners[0] == "099720109477"
-			})
-			testEnsureAMI(Equal("ami-ubuntu"), "1.14")
-		})
-
 		It("should fall back to auto resolution for Ubuntu2004 on 1.14", func() {
 			ng.AMIFamily = api.NodeImageFamilyUbuntu2004
 			mockDescribeImages(provider, "ami-ubuntu", func(input *ec2.DescribeImagesInput) bool {

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -48,7 +48,7 @@ func NewBootstrapper(clusterConfig *api.ClusterConfig, ng *api.NodeGroup) (Boots
 		return NewWindowsBootstrapper(clusterConfig, ng, clusterDNS), nil
 	}
 	switch ng.AMIFamily {
-	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
+	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntu2004:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
 	case api.NodeImageFamilyBottlerocket:
 		return NewBottlerocketBootstrapper(clusterConfig, ng), nil
@@ -80,7 +80,7 @@ func NewManagedBootstrapper(clusterConfig *api.ClusterConfig, ng *api.ManagedNod
 		return NewManagedAL2Bootstrapper(ng), nil
 	case api.NodeImageFamilyBottlerocket:
 		return NewManagedBottlerocketBootstrapper(clusterConfig, ng), nil
-	case api.NodeImageFamilyUbuntu1804, api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
+	case api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
 	}
 	return nil, nil

--- a/userdocs/src/usage/custom-ami-support.md
+++ b/userdocs/src/usage/custom-ami-support.md
@@ -57,7 +57,6 @@ The `--node-ami-family` can take following keywords:
 |--------------------------------|:------------------------------------------------------------------------------------------------------------------:|
 | AmazonLinux2                   | Indicates that the EKS AMI image based on Amazon Linux 2 should be used (default).                                 |
 | AmazonLinux2023                | Indicates that the EKS AMI image based on Amazon Linux 2023 should be used.                                        |
-| Ubuntu1804                     | Indicates that the EKS AMI image based on Ubuntu 18.04 LTS (Bionic) should be used.                                |
 | Ubuntu2004                     | Indicates that the EKS AMI image based on Ubuntu 20.04 LTS (Focal) should be used (supported for EKS <= 1.29).     |
 | Ubuntu2204                     | Indicates that the EKS AMI image based on Ubuntu 22.04 LTS (Jammy) should be used (available for EKS >= 1.29).     |
 | UbuntuPro2204                  | Indicates that the EKS AMI image based on Ubuntu Pro 22.04 LTS (Jammy) should be used (available for EKS >= 1.29). |
@@ -89,7 +88,7 @@ managedNodeGroups:
 The `--node-ami-family` flag can also be used with `eksctl create nodegroup`. `eksctl` requires AMI Family to be explicitly set via config file or via `--node-ami-family` CLI flag, whenever working with a custom AMI.
 
 ???+ note
-    At the moment, EKS managed nodegroups only support the following AMI Families when working with custom AMIs: `AmazonLinux2023`, `AmazonLinux2`, `Ubuntu1804`, `Ubuntu2004`, `Ubuntu2204` and `Ubuntu2404`
+    At the moment, EKS managed nodegroups only support the following AMI Families when working with custom AMIs: `AmazonLinux2023`, `AmazonLinux2`, `Ubuntu2004`, `Ubuntu2204` and `Ubuntu2404`
 
 ## Windows custom AMI support
 Only self-managed Windows nodegroups can specify a custom AMI. `amiFamily` should be set to a valid Windows AMI family.


### PR DESCRIPTION
### Description

- Remove support for deprecated Ubuntu 18.04
  - Ubuntu 18.04, codenamed "Bionic Beaver", reached its end of life (EOL) on May 31, 2023
  - Reference https://cloud-images.ubuntu.com/docs/aws/eks/

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

