### PR TITLE
Remove `xtables.lock` which should be managed by the VPC CNI

### DIFF
--- a/pkg/addons/default/assets/aws-node.yaml
+++ b/pkg/addons/default/assets/aws-node.yaml
@@ -405,7 +405,8 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      k8s-app: aws-node
+      app.kubernetes.io/name: aws-node
+      app.kubernetes.io/instance: aws-vpc-cni
   template:
     metadata:
       labels:

--- a/pkg/nodebootstrap/al2023.go
+++ b/pkg/nodebootstrap/al2023.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	"github.com/weaveworks/eksctl/pkg/nodebootstrap/assets"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap/utils"
 )
 
@@ -45,7 +44,7 @@ func newAL2023Bootstrapper(cfg *api.ClusterConfig, np api.NodePool, clusterDNS s
 		cfg:        cfg,
 		nodePool:   np,
 		clusterDNS: clusterDNS,
-		scripts:    []string{assets.AL2023XTablesLock},
+		scripts:    []string{},
 	}
 }
 

--- a/pkg/nodebootstrap/assets/assets.go
+++ b/pkg/nodebootstrap/assets/assets.go
@@ -20,11 +20,6 @@ var BootstrapHelperSh string
 //go:embed scripts/bootstrap.ubuntu.sh
 var BootstrapUbuntuSh string
 
-// AL2023XTablesLock holds the contents for creating a lock file for AL2023 AMIs.
-//
-//go:embed scripts/al2023-xtables.lock.sh
-var AL2023XTablesLock string
-
 // KubeletYaml holds the kubelet.yaml contents
 //
 //go:embed scripts/kubelet.yaml

--- a/pkg/nodebootstrap/assets/scripts/al2023-xtables.lock.sh
+++ b/pkg/nodebootstrap/assets/scripts/al2023-xtables.lock.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-set -o pipefail
-set -o nounset
-
-touch /run/xtables.lock


### PR DESCRIPTION
### Description

- Remove `xtables.lock` which should be managed by the VPC CNI
	- This is fixed in v1.18.1 of the VPC CNI https://github.com/aws/amazon-vpc-cni-k8s/pull/2841 which is the current default, but we should bump https://github.com/eksctl-io/eksctl/pull/7899 
- Update self-managed `aws-node.yaml` to latest from [here](https://github.com/aws/eks-charts/tree/master/stable/aws-vpc-cni) to ensure changes are in sync with respect to managed version of add-on (and that the xtables mount is still relevant)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

