### PR TITLE
Remove SSM install script from AL2; SSM is pre-installed on EKS AL based AMIs

### DIFF
--- a/pkg/nodebootstrap/README.md
+++ b/pkg/nodebootstrap/README.md
@@ -40,8 +40,6 @@ The call to `UserData` will also dynamically add the following:
 The bootstrap wrapper scripts will use `jq` and `sed` to get user and our config into various files,
 and then call `/etc/eks/bootstrap.sh`.
 
-For AL2, enabling SSM will add `assets/install-ssm.al2.sh`.
-
 ### AmazonLinux2023
 
 While AL2023 implements the `Bootstrapper` interface, the underlying userdata will be entirely different from other AMI families. Specifically, AL2023 introduces a new node initialization process nodeadm that uses a YAML configuration schema, dropping the use of `/etc/eks/bootstrap.sh` script. For self-managed nodes, and for EKS-managed nodes based on custom AMIs, eksctl will populate userdata in the fashion below:
@@ -72,8 +70,6 @@ spec:
 --//--
 
 ```
-
-For EKS-managed nodes based on native AMIs, the userdata above is fulfilled automatically by the AWS SSM agent.
 
 ## Troubleshooting
 
@@ -111,5 +107,4 @@ Files:
 /var/lib/cloud/scripts/eksctl/bootstrap.al2.sh
 /etc/kubernetes/kubelet/kubelet-config.json
 /etc/docker/daemon.json
-/var/lib/cloud/scripts/eksctl/install-ssm.sh
 ```

--- a/pkg/nodebootstrap/al2_test.go
+++ b/pkg/nodebootstrap/al2_test.go
@@ -31,43 +31,6 @@ var _ = Describe("AmazonLinux2 User Data", func() {
 		}
 	})
 
-	When("SSM is enabled", func() {
-		BeforeEach(func() {
-			ng.SSH.EnableSSM = api.Enabled()
-			bootstrapper = newBootstrapper(clusterConfig, ng)
-		})
-
-		It("does not add the SSM install script to the userdata", func() {
-			userData, err := bootstrapper.UserData()
-			Expect(err).NotTo(HaveOccurred())
-
-			cloudCfg := decode(userData)
-
-			var paths []string
-			for _, f := range cloudCfg.WriteFiles {
-				paths = append(paths, f.Path)
-			}
-			Expect(paths).NotTo(ContainElement("/var/lib/cloud/scripts/eksctl/install-ssm.al2.sh"))
-		})
-	})
-
-	When("EFA is enabled", func() {
-		BeforeEach(func() {
-			enabled := true
-			ng.EFAEnabled = &enabled
-			bootstrapper = newBootstrapper(clusterConfig, ng)
-		})
-
-		It("adds the ssm install script to the userdata", func() {
-			userData, err := bootstrapper.UserData()
-			Expect(err).NotTo(HaveOccurred())
-
-			cloudCfg := decode(userData)
-			Expect(cloudCfg.WriteFiles[2].Path).To(Equal("/var/lib/cloud/scripts/eksctl/bootstrap.al2.sh"))
-			Expect(cloudCfg.WriteFiles[2].Permissions).To(Equal("0755"))
-		})
-	})
-
 	type bootScriptEntry struct {
 		clusterConfig    *api.ClusterConfig
 		ng               *api.NodeGroup

--- a/pkg/nodebootstrap/assets/assets.go
+++ b/pkg/nodebootstrap/assets/assets.go
@@ -25,11 +25,6 @@ var BootstrapUbuntuSh string
 //go:embed scripts/al2023-xtables.lock.sh
 var AL2023XTablesLock string
 
-// InstallSsmAl2Sh holds the install-ssm.al2.sh contents
-//
-//go:embed scripts/install-ssm.al2.sh
-var InstallSsmAl2Sh string
-
 // KubeletYaml holds the kubelet.yaml contents
 //
 //go:embed scripts/kubelet.yaml

--- a/pkg/nodebootstrap/assets/scripts/install-ssm.al2.sh
+++ b/pkg/nodebootstrap/assets/scripts/install-ssm.al2.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-set -o pipefail
-set -o nounset
-
-yum install -y amazon-ssm-agent
-systemctl enable amazon-ssm-agent
-systemctl start amazon-ssm-agent


### PR DESCRIPTION
### Description

- Remove SSM install script from AL2; SSM is pre-installed on EKS AL based AMIs
  - Reference https://github.com/awslabs/amazon-eks-ami/blob/7fbf541d1836e4f254bd1b83f46d8501ee00d0ae/templates/al2/provisioners/install-worker.sh#L509-L519

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

