### PR TITLE
Enable default addon creation for auto mode clusters

### DIFF
--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -29,8 +29,14 @@ func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvid
 			if addonInfo.IsDefault && !slices.ContainsFunc(cfg.Addons, func(a *api.Addon) bool {
 				return strings.EqualFold(a.Name, addonName)
 			}) {
-				addons = append(addons, &api.Addon{Name: addonName})
-				autoDefaultAddonNames = append(autoDefaultAddonNames, addonName)
+				if !cfg.IsAutoModeEnabled() {
+					addons = append(addons, &api.Addon{Name: addonName})
+					autoDefaultAddonNames = append(autoDefaultAddonNames, addonName)
+				} else if addonInfo.IsDefaultAutoMode {
+					addons = append(addons, &api.Addon{Name: addonName})
+					autoDefaultAddonNames = append(autoDefaultAddonNames, addonName)
+				}
+
 			}
 		}
 	} else {

--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -29,10 +29,7 @@ func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvid
 			if addonInfo.IsDefault && !slices.ContainsFunc(cfg.Addons, func(a *api.Addon) bool {
 				return strings.EqualFold(a.Name, addonName)
 			}) {
-				if !cfg.IsAutoModeEnabled() {
-					addons = append(addons, &api.Addon{Name: addonName})
-					autoDefaultAddonNames = append(autoDefaultAddonNames, addonName)
-				} else if addonInfo.IsDefaultAutoMode {
+				if !cfg.IsAutoModeEnabled() || addonInfo.IsDefaultAutoMode {
 					addons = append(addons, &api.Addon{Name: addonName})
 					autoDefaultAddonNames = append(autoDefaultAddonNames, addonName)
 				}

--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -5,6 +5,7 @@ import "slices"
 var KnownAddons = map[string]struct {
 	IsDefault             bool
 	CreateBeforeNodeGroup bool
+	IsDefaultAutoMode     bool
 }{
 	VPCCNIAddon: {
 		IsDefault:             true,
@@ -26,6 +27,7 @@ var KnownAddons = map[string]struct {
 	MetricsServerAddon: {
 		IsDefault:             true,
 		CreateBeforeNodeGroup: true,
+		IsDefaultAutoMode:     true,
 	},
 }
 

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -369,20 +369,17 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		postNodeGroupAddons      *tasks.TaskTree
 		postClusterCreationTasks *tasks.TaskTree
 	)
-	if cfg.IsAutoModeEnabled() {
-		postClusterCreationTasks = ctl.CreateExtraClusterConfigTasks(ctx, cfg, nil, nil)
-	} else {
-		iamRoleCreator := &podidentityassociation.IAMRoleCreator{
-			ClusterName:  cfg.Metadata.Name,
-			StackCreator: stackManager,
-		}
-		preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout)
-		if len(autoDefaultAddons) > 0 {
-			logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
-		}
-		postNodeGroupAddons = postAddons
-		postClusterCreationTasks = ctl.CreateExtraClusterConfigTasks(ctx, cfg, preNodegroupAddons, updateVPCCNITask)
+
+	iamRoleCreator := &podidentityassociation.IAMRoleCreator{
+		ClusterName:  cfg.Metadata.Name,
+		StackCreator: stackManager,
 	}
+	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout)
+	if len(autoDefaultAddons) > 0 {
+		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
+	}
+	postNodeGroupAddons = postAddons
+	postClusterCreationTasks = ctl.CreateExtraClusterConfigTasks(ctx, cfg, preNodegroupAddons, updateVPCCNITask)
 
 	taskTree := stackManager.NewTasksToCreateCluster(ctx, cfg.NodeGroups, cfg.ManagedNodeGroups, cfg.AccessConfig, makeAccessEntryCreator(cfg.Metadata.Name, stackManager), params.NodeGroupParallelism, postClusterCreationTasks)
 


### PR DESCRIPTION
### Description

This change enables the default addon creation workflow for auto mode clusters. Importantly though this change does not install networking addons by default. To start with only metrics-server addon will be installed by default. This will align EKSCTL experience with the default AWS EKS console experience, where by default auto mode clusters come with metrics-server enabled. 

<!--


-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

