### PR TITLE
Disable metrics-server default addon creation for unsupported regions

### DIFF
--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -18,7 +18,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 )
 
-func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvider, iamRoleCreator IAMRoleCreator, forceAll bool, timeout time.Duration) (*tasks.TaskTree, *tasks.TaskTree, *tasks.GenericTask, []string) {
+func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvider, iamRoleCreator IAMRoleCreator, forceAll bool, timeout time.Duration, region string) (*tasks.TaskTree, *tasks.TaskTree, *tasks.GenericTask, []string) {
 	var addons []*api.Addon
 	var autoDefaultAddonNames []string
 	if !cfg.AddonsConfig.DisableDefaultAddons {
@@ -26,7 +26,7 @@ func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvid
 		copy(addons, cfg.Addons)
 
 		for addonName, addonInfo := range api.KnownAddons {
-			if addonInfo.IsDefault && !slices.ContainsFunc(cfg.Addons, func(a *api.Addon) bool {
+			if addonInfo.IsDefault && !slices.Contains(addonInfo.ExcludedRegions, region) && !slices.ContainsFunc(cfg.Addons, func(a *api.Addon) bool {
 				return strings.EqualFold(a.Name, addonName)
 			}) {
 				if !cfg.IsAutoModeEnabled() || addonInfo.IsDefaultAutoMode {

--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -6,6 +6,7 @@ var KnownAddons = map[string]struct {
 	IsDefault             bool
 	CreateBeforeNodeGroup bool
 	IsDefaultAutoMode     bool
+	ExcludedRegions       []string
 }{
 	VPCCNIAddon: {
 		IsDefault:             true,
@@ -28,6 +29,15 @@ var KnownAddons = map[string]struct {
 		IsDefault:             true,
 		CreateBeforeNodeGroup: true,
 		IsDefaultAutoMode:     true,
+		ExcludedRegions: []string{
+			RegionCNNorthwest1,
+			RegionCNNorth1,
+			RegionUSISOEast1,
+			RegionUSISOWest1,
+			RegionUSISOBEast1,
+			RegionUSGovWest1,
+			RegionUSGovEast1,
+		},
 	},
 }
 

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -374,7 +374,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		ClusterName:  cfg.Metadata.Name,
 		StackCreator: stackManager,
 	}
-	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout)
+	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
 	if len(autoDefaultAddons) > 0 {
 		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
 	}


### PR DESCRIPTION
### Description
This change addresses bug found in https://github.com/eksctl-io/eksctl/issues/8145 . 

Metrics server addon was recently enabled for default addon creation in cluster create workflow. Cluster creation default workflow began failing in regions that do not currently support metrics-server addon
```
- cn-northwest-1
- cn-north-1
- us-iso-east-1
- us-isob-east-1
- us-iso-west-1
- us-isob-west-1
- us-gov-west-1
- us-gov-east-1
```

Until metrics-server is supported in all regions, we must disable default addon creation in the regions listed above.

### Testing
1. Manually verified default cluster creation use case in ```us-west-2``` region ```eksclt create cluster ```. Cluster is created with default addons vpc-cni, coredsn, kube-proxy, and metrics-server installed correctly
2. Manually verified default cluster creation use case in ```cn-northwest-1``` region ```./eksctl create cluster --region cn-northwest-1 ```.  Cluster is created with default addons vpc-cni, coredns, and kube-proxy installed correctly. Metrics server is skipped.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

