### PR TITLE
Fix e2e integration tests

### DIFF
--- a/integration/tests/accessentries/accessentries_test.go
+++ b/integration/tests/accessentries/accessentries_test.go
@@ -236,8 +236,6 @@ var _ = Describe("(Integration) [AccessEntries Test]", func() {
 				).Run()
 			Expect(session.ExitCode()).To(Equal(0))
 			Expect(json.Unmarshal(session.Out.Contents(), &output)).To(Succeed())
-			// taking into account the cluster creator admin permission access entry
-			Expect(output).To(HaveLen(4))
 			Expect(output).To(ContainElements(cfg.AccessConfig.AccessEntries))
 		})
 


### PR DESCRIPTION
### Description

This PR fixes the currently failing e2e tests. Specifically:

* Skip checking the exact amount of access entries on a cluster
  * Previously, we were checking for exactly 4, because the tests created 3, and assumed 1 was created by default. Now, there has been a change in EKS which causes 2 access entries to be created by default. We could explicitly check for 5 now, but this may break again in the future if this behavior changes again. We already validate the elements we expect are in the slice, so this PR just removes the check for exact length of access entries entirely
* Update auto-mode tests to check for _at least_ 1 node to be created (instead of exactly 1).
  * Now that metrics-server addon is being created by default, auto-mode clusters typically come up with 2 nodes now. Instead of validating the exact amount of nodes, just assert there's more than 0, and perform the same checks as before across all the nodes.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

