### PR TITLE
Downgrade go to `1.21` due to build image version

### DIFF
--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -6,16 +6,16 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: 1.21.x
-        cache: false
+        go-version: '1.21'
+
     - name: Cache go-build and mod
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 #v4.0.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
       with:
         path: |
-          ~/.cache/go-build/
-          ~/go/pkg/mod/
-        key: go-${{ hashFiles('go.sum') }}
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          go-
+          ${{ runner.os }}-go-

--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -8,7 +8,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
       with:
-        go-version: 1.22.x
+        go-version: 1.21.x
         cache: false
     - name: Cache go-build and mod
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 #v4.0.0

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a #v5.2.0
         with:
-          go-version: 1.22.x
+          go-version: 1.21.x
           cache: false
 
       - name: Install doc dependencies

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -13,12 +13,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build
+
       - name: Unit test
         run: |
-          PATH=$PATH:$(go env GOPATH)/bin make build
-          PATH=$PATH:$(go env GOPATH)/bin make unit-test-no-generate
+          make build
+          make unit-test-no-generate
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -27,11 +29,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build
+
       - name: Lint
-        run: |
-          PATH=$PATH:$(go env GOPATH)/bin make lint
+        run: make lint
 
   image:
     name: Build and check image
@@ -41,6 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Build image
         id: push
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc #v6.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/docker/library/golang:1.22.10 AS builder
+FROM public.ecr.aws/docker/library/golang:1.21.13 AS builder
 
 WORKDIR /src
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.51.7
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.7
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.46.9
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.6
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.7
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.48.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.166.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.56.5

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/weaveworks/eksctl
 
 go 1.21
 
-toolchain go1.21.10
+toolchain go1.21.13
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@
 // you may also need to run `make push-build-image` depending on what has changed
 module github.com/weaveworks/eksctl
 
-go 1.22
+go 1.21
 
-toolchain go1.22.10
+toolchain go1.21.10
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.7 h1:TSZ9VocRtgrtZyaAM
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.7/go.mod h1:pBGwFeRfyDeLx29/IM6a2SLWpJsyhHARi+WIgXRe3uo=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.46.9 h1:5Gf6dTLBxEQ3fDIXDNaKwrJNJX3eS/Aq/umADz5q+w0=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.46.9/go.mod h1:a94+UYpsBLThABCmb23CFqY8FglQzUgMNIfOJHn/seo=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.6 h1:2oLCi90fh8JYysC+7mk7g6Zlg/lDvB5wNMC2mGbrhiA=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.6/go.mod h1:zZeYjS1D+qvIOiDrCT89Rrm6vSn4m8DNhi0kb3wwzYM=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.7 h1:DddWiL/XVT9GjMZqbYoIpJm5fFa08/CSk7fPN5neWVY=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.7/go.mod h1:zZeYjS1D+qvIOiDrCT89Rrm6vSn4m8DNhi0kb3wwzYM=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.48.4 h1:78+PSLTY1QcbesyoPKAnYRG+jFhcuZr17pGAQVxDTWw=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.48.4/go.mod h1:vPpQlrSaeqEX2s/iM5eqaSFUxVtBrpZFP9SOd25AZuY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.166.0 h1:FDZVMxzXB13cRmHs3t3tH9gme8GhvmjsQXeXFI37OHU=

--- a/pkg/awsapi/cloudwatchlogs.go
+++ b/pkg/awsapi/cloudwatchlogs.go
@@ -24,9 +24,9 @@ type CloudWatchLogs interface {
 	// the resourceIdentifier parameter. You can't specify both of those parameters in
 	// the same operation.
 	//
-	//   - Specify the logGroupName parameter to cause all log events stored in the log
-	//     group to be encrypted with that key. Only the log events ingested after the key
-	//     is associated are encrypted with that key.
+	//   - Specify the logGroupName parameter to cause log events ingested into that
+	//     log group to be encrypted with that key. Only the log events ingested after the
+	//     key is associated are encrypted with that key.
 	//
 	// Associating a KMS key with a log group overrides any existing associations
 	//
@@ -138,11 +138,16 @@ type CloudWatchLogs interface {
 	// same S3 bucket. To separate log data for each export task, specify a prefix to
 	// be used as the Amazon S3 key prefix for all exported objects.
 	//
+	// We recommend that you don't regularly export to Amazon S3 as a way to
+	// continuously archive your logs. For that use case, we instaed recommend that you
+	// use subscriptions. For more information about subscriptions, see [Real-time processing of log data with subscriptions].
+	//
 	// Time-based sorting on chunks of log data inside an exported file is not
 	// guaranteed. You can sort the exported log field data by using Linux utilities.
 	//
 	// [CancelExportTask]: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CancelExportTask.html
 	// [DescribeExportTasks]: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeExportTasks.html
+	// [Real-time processing of log data with subscriptions]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html
 	CreateExportTask(ctx context.Context, params *CreateExportTaskInput, optFns ...func(*Options)) (*CreateExportTaskOutput, error)
 	// Creates an anomaly detector that regularly scans one or more log groups and
 	// look for patterns and anomalies in the logs.
@@ -259,7 +264,7 @@ type CloudWatchLogs interface {
 	//
 	// [PutDataProtectionPolicy]: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDataProtectionPolicy.html
 	DeleteDataProtectionPolicy(ctx context.Context, params *DeleteDataProtectionPolicyInput, optFns ...func(*Options)) (*DeleteDataProtectionPolicyOutput, error)
-	// Deletes s delivery. A delivery is a connection between a logical delivery
+	// Deletes a delivery. A delivery is a connection between a logical delivery
 	// source and a logical delivery destination. Deleting a delivery only deletes the
 	// connection between the delivery source and delivery destination. It does not
 	// delete the delivery destination or the delivery source.
@@ -351,6 +356,21 @@ type CloudWatchLogs interface {
 	// subscription filters that relied on the transformed versions of the log events.
 	DeleteTransformer(ctx context.Context, params *DeleteTransformerInput, optFns ...func(*Options)) (*DeleteTransformerOutput, error)
 	// Returns a list of all CloudWatch Logs account policies in the account.
+	//
+	// To use this operation, you must be signed on with the correct permissions
+	// depending on the type of policy that you are retrieving information for.
+	//
+	//   - To see data protection policies, you must have the
+	//     logs:GetDataProtectionPolicy and logs:DescribeAccountPolicies permissions.
+	//
+	//   - To see subscription filter policies, you must have the
+	//     logs:DescrubeSubscriptionFilters and logs:DescribeAccountPolicies permissions.
+	//
+	//   - To see transformer policies, you must have the logs:GetTransformer and
+	//     logs:DescribeAccountPolicies permissions.
+	//
+	//   - To see field index policies, you must have the logs:DescribeIndexPolicies
+	//     and logs:DescribeAccountPolicies permissions.
 	DescribeAccountPolicies(ctx context.Context, params *DescribeAccountPoliciesInput, optFns ...func(*Options)) (*DescribeAccountPoliciesOutput, error)
 	// Use this operation to return the valid and default values that are used when
 	// creating delivery sources, delivery destinations, and deliveries. For more
@@ -425,7 +445,7 @@ type CloudWatchLogs interface {
 	// logGroupName . You must include one of these two parameters, but you can't
 	// include both.
 	//
-	// This operation has a limit of five transactions per second, after which
+	// This operation has a limit of 25 transactions per second, after which
 	// transactions are throttled.
 	//
 	// If you are using CloudWatch cross-account observability, you can use this
@@ -651,6 +671,21 @@ type CloudWatchLogs interface {
 	// field index policy that applies to all log groups or a subset of log groups in
 	// the account.
 	//
+	// To use this operation, you must be signed on with the correct permissions
+	// depending on the type of policy that you are creating.
+	//
+	//   - To create a data protection policy, you must have the
+	//     logs:PutDataProtectionPolicy and logs:PutAccountPolicy permissions.
+	//
+	//   - To create a subscription filter policy, you must have the
+	//     logs:PutSubscriptionFilter and logs:PutccountPolicy permissions.
+	//
+	//   - To create a transformer policy, you must have the logs:PutTransformer and
+	//     logs:PutAccountPolicy permissions.
+	//
+	//   - To create a field index policy, you must have the logs:PutIndexPolicy and
+	//     logs:PutAccountPolicy permissions.
+	//
 	// # Data protection policy
 	//
 	// A data protection policy can help safeguard sensitive data that's ingested by
@@ -855,8 +890,9 @@ type CloudWatchLogs interface {
 	//   - Create a delivery source, which is a logical object that represents the
 	//     resource that is actually sending the logs. For more information, see [PutDeliverySource].
 	//
-	//   - Use PutDeliveryDestination to create a delivery destination, which is a
-	//     logical object that represents the actual delivery destination.
+	//   - Use PutDeliveryDestination to create a delivery destination in the same
+	//     account of the actual delivery destination. The delivery destination that you
+	//     create is a logical object that represents the actual delivery destination.
 	//
 	//   - If you are delivering logs cross-account, you must use [PutDeliveryDestinationPolicy]in the destination
 	//     account to assign an IAM policy to the destination. This policy allows delivery
@@ -1077,11 +1113,11 @@ type CloudWatchLogs interface {
 	// The maximum number of metric filters that can be associated with a log group is
 	// 100.
 	//
-	// Using regular expressions to create metric filters is supported. For these
-	// filters, there is a quota of two regular expression patterns within a single
-	// filter pattern. There is also a quota of five regular expression patterns per
-	// log group. For more information about using regular expressions in metric
-	// filters, see [Filter pattern syntax for metric filters, subscription filters, filter log events, and Live Tail].
+	// Using regular expressions in filter patterns is supported. For these filters,
+	// there is a quota of two regular expression patterns within a single filter
+	// pattern. There is also a quota of five regular expression patterns per log
+	// group. For more information about using regular expressions in filter patterns,
+	// see [Filter pattern syntax for metric filters, subscription filters, filter log events, and Live Tail].
 	//
 	// When you create a metric filter, you can also optionally assign a unit and
 	// dimensions to the metric that is created.
@@ -1169,11 +1205,11 @@ type CloudWatchLogs interface {
 	// you are updating an existing filter, you must specify the correct name in
 	// filterName .
 	//
-	// Using regular expressions to create subscription filters is supported. For
-	// these filters, there is a quotas of quota of two regular expression patterns
-	// within a single filter pattern. There is also a quota of five regular expression
-	// patterns per log group. For more information about using regular expressions in
-	// subscription filters, see [Filter pattern syntax for metric filters, subscription filters, filter log events, and Live Tail].
+	// Using regular expressions in filter patterns is supported. For these filters,
+	// there is a quotas of quota of two regular expression patterns within a single
+	// filter pattern. There is also a quota of five regular expression patterns per
+	// log group. For more information about using regular expressions in filter
+	// patterns, see [Filter pattern syntax for metric filters, subscription filters, filter log events, and Live Tail].
 	//
 	// To perform a PutSubscriptionFilter operation for any destination except a
 	// Lambda function, you must also have the iam:PassRole permission.


### PR DESCRIPTION
### Description

- Downgrade go to `1.21` due to build image version
  - Due to these [remnants which need to be resolved first](https://github.com/eksctl-io/eksctl/blob/d1e6319a41fb923c1bb670a9f1fdd3e0e15ef71d/.github/workflows/release-candidate.yaml#L10)

On a bright note, look how few changes are required for changing a go version :tada: (was only 4 lines, but the way the CI lint check works, had to run `make build` to give it something to check 😐 ) 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

