### PR TITLE
Remove build image reference from release workflow, consolidate go setup in GitHub actions

### DIFF
--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -6,16 +6,16 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
       with:
-        go-version: 1.22.x
-        cache: false
+        go-version: '1.22'
+
     - name: Cache go-build and mod
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 #v4.0.0
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
       with:
         path: |
-          ~/.cache/go-build/
-          ~/go/pkg/mod/
-        key: go-${{ hashFiles('go.sum') }}
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          go-
+          ${{ runner.os }}-go-

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -18,11 +18,8 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: Setup Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a #v5.2.0
-        with:
-          go-version: 1.22.x
-          cache: false
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
 
       - name: Install doc dependencies
         run: make install-site-deps

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -12,13 +12,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
-          token: ${{ secrets.EKSCTLBOT_TOKEN }}
           fetch-depth: 0
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build
+
       - name: Setup identity as eksctl-bot
         uses: ./.github/actions/setup-identity
         with:
           token: "${{ secrets.EKSCTLBOT_TOKEN }}"
+
       - name: Trigger Netlify deployment
         run: make publish-docs

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -7,25 +7,19 @@ jobs:
   rc:
     name: Push release candidate tag
     runs-on: ubuntu-latest
-    container: public.ecr.aws/eksctl/eksctl-build:833f4464e865a6398788bf6cbc5447967b8974b7
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
-          token: ${{ secrets.EKSCTLBOT_TOKEN }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
+
       - name: Setup identity as eksctl-bot
         uses: ./.github/actions/setup-identity
         with:
           token: "${{ secrets.EKSCTLBOT_TOKEN }}"
+
       - name: Push tag and open PR to default branch
         run: make prepare-release-candidate

--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -14,10 +14,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Setup identity as eksctl-bot
         uses: ./.github/actions/setup-identity
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Merge release branch into ${{env.DEFAULT_BRANCH}}
         id: merge-changes
         run: |
@@ -32,6 +34,7 @@ jobs:
           ! git diff --exit-code $DEFAULT_BRANCH...HEAD || exit 1
           git push --set-upstream origin HEAD
           echo "changes=true" >> $GITHUB_OUTPUT
+
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         name: Open PR to ${{env.DEFAULT_BRANCH}}
         if: steps.merge-changes.outputs.changes == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,25 +7,19 @@ jobs:
   rc:
     name: Push release tag
     runs-on: ubuntu-latest
-    container: public.ecr.aws/eksctl/eksctl-build:833f4464e865a6398788bf6cbc5447967b8974b7
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
-          token: ${{ secrets.EKSCTLBOT_TOKEN }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
+
       - name: Setup identity as eksctl-bot
         uses: ./.github/actions/setup-identity
         with:
           token: "${{ secrets.EKSCTLBOT_TOKEN }}"
+
       - name: Push tag and open PR to default branch
         run: make prepare-release

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -13,12 +13,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build
+
       - name: Unit test
         run: |
-          PATH=$PATH:$(go env GOPATH)/bin make build
-          PATH=$PATH:$(go env GOPATH)/bin make unit-test-no-generate
+          make build
+          make unit-test-no-generate
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -27,11 +29,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build
+
       - name: Lint
-        run: |
-          PATH=$PATH:$(go env GOPATH)/bin make lint
+        run: make lint
 
   image:
     name: Build and check image
@@ -41,6 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+
       - name: Build image
         id: push
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc #v6.11.0

--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -1,4 +1,5 @@
 name: Update generated files
+
 on:
   workflow_dispatch: {}
   schedule:
@@ -18,15 +19,17 @@ jobs:
         resource: ["coredns", "aws-node", "nvidia-device-plugin"]
     name: Update ${{ matrix.resource }} and open PR
     runs-on: ubuntu-latest
-    container: public.ecr.aws/eksctl/eksctl-build:833f4464e865a6398788bf6cbc5447967b8974b7
     env:
       GOPRIVATE: ""
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
-        token: ${{ secrets.EKSCTLBOT_TOKEN }}
         fetch-depth: 0
+
+    - name: Setup build environment
+      uses: ./.github/actions/setup-build
+
     - name: Configure AWS credentials for coredns update
       if: ${{ matrix.resource == 'coredns' }}
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
@@ -35,21 +38,15 @@ jobs:
         role-duration-seconds: 900
         role-session-name: eksctl-update-coredns-assets
         role-to-assume: ${{ secrets.UPDATE_COREDNS_ROLE_ARN }}
+
     - name: Setup identity as eksctl-bot
       uses: ./.github/actions/setup-identity
       with:
         token: "${{ secrets.EKSCTLBOT_TOKEN }}"
-    - name: Cache go-build and mod
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
-      with:
-        path: |
-          ~/.cache/go-build/
-          ~/go/pkg/mod/
-        key: go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          go-
+
     - name: Update ${{ matrix.resource }}
       run: make update-${{ matrix.resource }}
+
     - name: Upsert pull request
       uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f #v7.0.6
       with:


### PR DESCRIPTION
### Description

- Remove `container: public.ecr.aws/eksctl/eksctl-build:...` references; this image is no longer used and does not appear to have any bearing on the CI release process - the artifacts will be build directly in the GitHub runner environment
- Consolidate the misc `actions/cache` actions for caching go depdencies - this is already handled by the internal `.github/actions/setup-build` action
- Consolidate the misc `actions/setup-go` actions for installing go - this is already handled by the internal `.github/actions/setup-build` action which means less places to remember to update the go version in the future
- Remove the `secrets.EKSCTLBOT_TOKEN` usage from `actions/checkout` - this should be necessary given that the code is publicly available

:warning: this can only proceed once the changes in #8157 are added back to `main`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

