### PR TITLE
Allow disabling default addons with Auto Mode

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -485,9 +485,9 @@ func validateDryRunOptions(cmd *cobra.Command, incompatibleFlags []string) error
 	return nil
 }
 
-// validateBareCluster validates a cluster for unsupported fields if VPC CNI is disabled.
+// validateBareCluster validates a cluster for unsupported fields if VPC CNI and Auto Mode is disabled.
 func validateBareCluster(clusterConfig *api.ClusterConfig) error {
-	if !clusterConfig.AddonsConfig.DisableDefaultAddons || slices.ContainsFunc(clusterConfig.Addons, func(addon *api.Addon) bool {
+	if !clusterConfig.AddonsConfig.DisableDefaultAddons || clusterConfig.IsAutoModeEnabled() || slices.ContainsFunc(clusterConfig.Addons, func(addon *api.Addon) bool {
 		return addon.Name == api.VPCCNIAddon
 	}) {
 		return nil
@@ -495,8 +495,8 @@ func validateBareCluster(clusterConfig *api.ClusterConfig) error {
 	if clusterConfig.HasNodes() || clusterConfig.IsFargateEnabled() || clusterConfig.Karpenter != nil || clusterConfig.HasGitOpsFluxConfigured() ||
 		(clusterConfig.IAM != nil && ((len(clusterConfig.IAM.ServiceAccounts) > 0) || len(clusterConfig.IAM.PodIdentityAssociations) > 0)) {
 		return errors.New("fields nodeGroups, managedNodeGroups, fargateProfiles, karpenter, gitops, iam.serviceAccounts, " +
-			"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI; please remove these fields " +
-			"and add them back after cluster creation is successful")
+			"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI if Auto Mode is disabled; " +
+			"please remove these fields and add them back after cluster creation is successful")
 	}
 	return nil
 }

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -501,8 +501,8 @@ var _ = Describe("cmdutils configfile", func() {
 			}).Load()
 			if e.expectErr {
 				Expect(err).To(MatchError("fields nodeGroups, managedNodeGroups, fargateProfiles, karpenter, gitops, iam.serviceAccounts, " +
-					"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI; please remove these fields " +
-					"and add them back after cluster creation is successful"))
+					"and iam.podIdentityAssociations are not supported during cluster creation in a cluster without VPC CNI if Auto Mode is disabled; " +
+					"please remove these fields and add them back after cluster creation is successful"))
 			} else {
 				Expect(err).NotTo(HaveOccurred())
 			}


### PR DESCRIPTION
### Description

VPC CNI is not needed in Auto Mode for IRSA/IAM pod identity to function, and it's not installed as "default addon" with Auto Mode either way.

Fixes #8164

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

