### PR TITLE
Replace `golang.org/x/exp/slices` with `slices`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,6 @@ require (
 	github.com/weaveworks/schemer v0.0.0-20230525114451-47139fe25848
 	github.com/xgfone/netaddr v0.5.1
 	golang.org/x/crypto v0.32.0
-	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync v0.10.0
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
@@ -393,6 +392,7 @@ require (
 	go.uber.org/automaxprocs v1.5.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240314144324-c7f7c6466f7f // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.33.0 // indirect

--- a/integration/utilities/cluster/cluster.go
+++ b/integration/utilities/cluster/cluster.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/exp/slices"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/eks"

--- a/pkg/actions/podidentityassociation/iam_role_updater.go
+++ b/pkg/actions/podidentityassociation/iam_role_updater.go
@@ -3,18 +3,17 @@ package podidentityassociation
 import (
 	"context"
 	"fmt"
+	"slices"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 
-	"time"
-
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
-	"golang.org/x/exp/slices"
 )
 
 // IAMRoleUpdater updates IAM resources for pod identity associations.

--- a/pkg/ctl/cmdutils/access_entry.go
+++ b/pkg/ctl/cmdutils/access_entry.go
@@ -3,8 +3,8 @@ package cmdutils
 import (
 	"errors"
 	"fmt"
+	"slices"
 
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/exp/slices"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 

--- a/pkg/ctl/utils/vpc_helper.go
+++ b/pkg/ctl/utils/vpc_helper.go
@@ -3,12 +3,11 @@ package utils
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/kris-nova/logger"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"


### PR DESCRIPTION
### Description

The experimental functions in `golang.org/x/exp/slices` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#slices

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

