### PR TITLE
update faq for getting nodegroup's userdata and launch templates

### DIFF
--- a/userdocs/src/usage/faq.md
+++ b/userdocs/src/usage/faq.md
@@ -13,20 +13,11 @@
     To change the instance type, create a new nodegroup with the desired instance type, then drain it so that the workloads move to the new one. After that step is complete you can delete the old nodegroup
 
 ???+ question "How can I see the generated userdata for a nodegroup?"
-    First you'll need the name of the Cloudformation stack that manages the
-    nodegroup:
-    ```console
-    $ eksctl utils describe-stacks --region=us-west-2 --cluster NAME
-    ```
-    You'll see a name similar to `eksctl-CLUSTER_NAME-nodegroup-NODEGROUP_NAME`.
 
     You can execute the following to get the userdata. Note the final line which
     decodes from base64 and decompresses the gzipped data.
     ```bash
-    NG_STACK=eksctl-scrumptious-monster-1595247364-nodegroup-ng-29b8862f # your stack here
-    LAUNCH_TEMPLATE_ID=$(aws cloudformation describe-stack-resources --stack-name $NG_STACK \
-    | jq -r '.StackResources | map(select(.LogicalResourceId == "NodeGroupLaunchTemplate")
-    | .PhysicalResourceId)[0]')
+    LAUNCH_TEMPLATE_ID=$(aws ec2 describe-launch-templates --filters "Name=tag:eks:cluster-name,Values=CLUSTER_NAME" --filters "Name=tag:eks:nodegroup-name,Values=NODEGROUP_NAME" | jq -r '.LaunchTemplates[0].LaunchTemplateId' )
     aws ec2 describe-launch-template-versions --launch-template-id $LAUNCH_TEMPLATE_ID \
     | jq -r '.LaunchTemplateVersions[0].LaunchTemplateData.UserData' \
     | base64 -d | gunzip


### PR DESCRIPTION
### Description

When an EKS cluster is created using eksctl , it seems like the launch template created in the cloud formation stack is not used . 
When the cluster bootstraps, the `AWSServiceRoleForAmazonEKSNodegroup` will create a launch template on your behalf and will be used for the ASG attached to the nodeGroup . This launch template will have the required userdata .

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

