### PR TITLE
Enable NVIDIA Plugin automatically for AL2023 GPU AMIs

### DIFF
--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -339,19 +339,21 @@ func (c *ClusterProvider) ClusterTasksForNodeGroups(cfg *api.ClusterConfig, inst
 	for _, ng := range cfg.NodeGroups {
 		clusterRequiresNeuronDevicePlugin = clusterRequiresNeuronDevicePlugin ||
 			api.HasInstanceType(ng, instanceutils.IsNeuronInstanceType)
-		// Only AL2 requires the NVIDIA device plugin
+		// Only AL2/AL2023 requires the NVIDIA device plugin
 		clusterRequiresNvidiaDevicePlugin = clusterRequiresNvidiaDevicePlugin ||
 			(api.HasInstanceType(ng, instanceutils.IsNvidiaInstanceType) &&
-				ng.GetAMIFamily() == api.NodeImageFamilyAmazonLinux2)
+				ng.GetAMIFamily() == api.NodeImageFamilyAmazonLinux2 ||
+				ng.GetAMIFamily() == api.NodeImageFamilyAmazonLinux2023)
 		efaEnabled = efaEnabled || api.IsEnabled(ng.EFAEnabled)
 	}
 	for _, ng := range cfg.ManagedNodeGroups {
 		clusterRequiresNeuronDevicePlugin = clusterRequiresNeuronDevicePlugin ||
 			api.HasInstanceTypeManaged(ng, instanceutils.IsNeuronInstanceType)
-		// Only AL2 requires the NVIDIA device plugin
+		// Only AL2/AL2023 requires the NVIDIA device plugin
 		clusterRequiresNvidiaDevicePlugin = clusterRequiresNvidiaDevicePlugin ||
 			(api.HasInstanceTypeManaged(ng, instanceutils.IsNvidiaInstanceType) &&
-				ng.GetAMIFamily() == api.NodeImageFamilyAmazonLinux2)
+				ng.GetAMIFamily() == api.NodeImageFamilyAmazonLinux2 ||
+				ng.GetAMIFamily() == api.NodeImageFamilyAmazonLinux2023)
 		efaEnabled = efaEnabled || api.IsEnabled(ng.EFAEnabled)
 	}
 	if clusterRequiresNeuronDevicePlugin {


### PR DESCRIPTION
We now have AL2023 GPU based AMI(s):
- https://aws.amazon.com/blogs/containers/amazon-eks-optimized-amazon-linux-2023-accelerated-amis-now-available/
- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html

Just like we enable nvidia device plugin for AL2 based ones, we should do the same for AL2023 as well!