### PR TITLE
Add addon name to some logging lines

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -252,7 +252,7 @@ func (a *Manager) Create(ctx context.Context, addon *api.Addon, iamRoleCreator I
 		}
 	}
 
-	logger.Info("creating addon")
+	logger.Info("creating addon: %s", addon.Name)
 	output, err := a.eksAPI.CreateAddon(ctx, createAddonInput)
 	if err != nil {
 		var resourceInUse *ekstypes.ResourceInUseException
@@ -283,7 +283,7 @@ func (a *Manager) Create(ctx context.Context, addon *api.Addon, iamRoleCreator I
 	if waitTimeout > 0 {
 		return a.waitForAddonToBeActive(ctx, addon, waitTimeout)
 	}
-	logger.Info("successfully created addon")
+	logger.Info("successfully created addon: %s", addon.Name)
 	return nil
 }
 


### PR DESCRIPTION
Tiny change in 2 lines, print the addon name as well we are currently displaying the following

```
2025-02-07 15:22:15 [ℹ]  creating addon
2025-02-07 15:22:15 [ℹ]  successfully created addon
2025-02-07 15:22:16 [ℹ]  creating addon
2025-02-07 15:22:16 [ℹ]  successfully created addon
2025-02-07 15:22:17 [ℹ]  creating addon
2025-02-07 15:22:17 [ℹ]  successfully created addon
2025-02-07 15:22:18 [ℹ]  creating addon
2025-02-07 15:22:18 [ℹ]  successfully created addon
```