### PR TITLE
Fix broken link to "Creating and Managing Clusters"

### DIFF
--- a/userdocs/src/getting-started.md
+++ b/userdocs/src/getting-started.md
@@ -102,7 +102,7 @@ able to use `kubectl`. You will need to make sure to use the same AWS API creden
 dependencies installed already.
 
 To learn more about how to create clusters and other features continue reading the
-[Creating and Managing Clusters section](usage/creating-and-managing-clusters).
+[Creating and Managing Clusters section](/usage/creating-and-managing-clusters).
 
 [ekskubectl]: https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html
 


### PR DESCRIPTION
### Description

This PR fixes the link to the "[Creating and Managing Clusters section](https://eksctl.io/getting-started/usage/creating-and-managing-clusters)" on the [website](https://eksctl.io/getting-started/). Currently, it returns a 404 error.

<details>
<summary>Screnshot</summary>

https://eksctl.io/getting-started/#:~:text=Creating%20and%20Managing%20Clusters%20section.

<img width="909" alt="image" src="https://github.com/user-attachments/assets/69501e22-76a3-44d9-9bbe-c9f43ca0e075" />


</details>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

