### PR TITLE
Update GPU ec2 instance types in integration tests

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -924,7 +924,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				"--timeout=45m",
 				"--cluster", params.ClusterName,
 				"--nodes", "1",
-				"--instance-types", "p3.2xlarge,p3.8xlarge,g3s.xlarge,g4ad.xlarge,g4ad.2xlarge",
+				"--instance-types", "g6.xlarge,g6.2xlarge",
 				"--node-private-networking",
 				"--node-zones", "us-west-2b,us-west-2c",
 				GPUMng,


### PR DESCRIPTION
### Description

This PR updates the instance types used in the integration tests to stop using P3 or G4ad instances which are much older. P3 instances are scheduled for retiring at some point, so we should stop using them.

Replaced with more modern equivalents.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

