### PR TITLE
Placement group should not be created when using a reservation

### DIFF
--- a/pkg/cfn/builder/managed_launch_template.go
+++ b/pkg/cfn/builder/managed_launch_template.go
@@ -81,7 +81,9 @@ func (m *ManagedNodeGroupResourceSet) makeLaunchTemplateData(ctx context.Context
 		if err := buildNetworkInterfaces(ctx, launchTemplateData, mng.InstanceTypeList(), true, securityGroupIDs, m.ec2API); err != nil {
 			return nil, fmt.Errorf("couldn't build network interfaces for launch template data: %w", err)
 		}
-		if mng.Placement == nil {
+		// A reservation should already be created with a placement group
+		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cr-cpg.html
+		if mng.Placement == nil && mng.CapacityReservation == nil {
 			groupName := m.newResource("NodeGroupPlacementGroup", &gfnec2.PlacementGroup{
 				Strategy: gfnt.NewString("cluster"),
 			})


### PR DESCRIPTION
Reservations are special cases that often can be created with placement already in mind, or have instances in different availability zones (or far enough away) so adding a placement group automatically will prevent provision of a large set of resources. Changing the default behavior to always require the user to specify a placement group for EFA is overkill, but a good balance is, in the case EFA is enabled and there is no placement group, when there is a reservation do not add the group automatically, but issue a warning to the user they can choose to respond to. TLDR: when a user deploys a cluster via a reservation they are responsible for adding the placement group.

- Fix for https://github.com/eksctl-io/eksctl/issues/7949#issuecomment-2659311029

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

