### PR TITLE
Documenting the use of kubernetesUsername while creating an access entry

### DIFF
--- a/examples/40-access-entries.yaml
+++ b/examples/40-access-entries.yaml
@@ -21,6 +21,7 @@ accessConfig:
       kubernetesGroups: # optional Kubernetes groups
         - group1 # groups can used to give permissions via RBAC
         - group2
+      kubernetesUsername: username # optional Kubernetes username
     - principalARN: arn:aws:iam::111122223333:role/role-name-1
       accessPolicies: # optional access polices
         - policyARN: arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy


### PR DESCRIPTION
### Description

The intention of this change is to document that it is possible to specify the kubernetesUsername field while creating an access entry. 

Currently there are no reference to the parameter which currently is leading to the users to believe that this capability is not available for the eksctl.

I have modified the example provided that it is given to the users to showcase that the use of the field is possible.

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [] Backfilled missing tests for code in same general area :tada:
- [] Refactored something and made the world a better place :star2:

