### PR TITLE
Add support for creating access entries of type `EC2` for EKS Auto Mode

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/access_entry.go
+++ b/pkg/apis/eksctl.io/v1alpha5/access_entry.go
@@ -47,6 +47,8 @@ type AccessScope struct {
 type AccessEntryType string
 
 const (
+	// AccessEntryTypeEc2 specifies the EC2 (Auto Mode) access entry type.
+	AccessEntryTypeEC2 AccessEntryType = "EC2"
 	// AccessEntryTypeLinux specifies the EC2 Linux access entry type.
 	AccessEntryTypeLinux AccessEntryType = "EC2_LINUX"
 	// AccessEntryTypeWindows specifies the Windows access entry type.
@@ -145,7 +147,7 @@ func validateAccessEntries(accessEntries []AccessEntry) error {
 		}
 
 		switch AccessEntryType(ae.Type) {
-		case "", AccessEntryTypeStandard:
+		case "", AccessEntryTypeStandard, AccessEntryTypeEC2:
 		case AccessEntryTypeLinux, AccessEntryTypeWindows, AccessEntryTypeFargateLinux, AccessEntryTypeHybridLinux:
 			if len(ae.KubernetesGroups) > 0 || ae.KubernetesUsername != "" {
 				return fmt.Errorf("cannot specify %s.kubernetesGroups nor %s.kubernetesUsername when type is set to %s", path, path, ae.Type)

--- a/pkg/apis/eksctl.io/v1alpha5/access_entry_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/access_entry_validation_test.go
@@ -329,6 +329,18 @@ var _ = DescribeTable("Access Entry validation", func(aet accessEntryTest) {
 					},
 				},
 			},
+			{
+				PrincipalARN: api.MustParseARN("arn:aws:iam::111122223333:role/role-7"),
+				Type:         "EC2",
+				AccessPolicies: []api.AccessPolicy{
+					{
+						PolicyARN: api.MustParseARN("arn:aws:eks::aws:cluster-access-policy/AmazonEKSAutoNodePolicy"),
+						AccessScope: api.AccessScope{
+							Type: ekstypes.AccessScopeTypeCluster,
+						},
+					},
+				},
+			},
 		},
 	}),
 )


### PR DESCRIPTION
### Description

- Add support for creating access entries of type `EC2` for EKS Auto Mode

Resolves #8098

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

