### PR TITLE
Re-add support for env var keys from AWS SDK

### DIFF
--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -203,7 +203,11 @@ func newAWSProvider(spec *api.ProviderConfig, configurationLoader AWSConfigurati
 	provider.asg = autoscaling.NewFromConfig(cfg)
 	provider.cloudwatchlogs = cloudwatchlogs.NewFromConfig(cfg)
 	provider.cloudtrail = cloudtrail.NewFromConfig(cfg, func(o *cloudtrail.Options) {
-		o.BaseEndpoint = getBaseEndpoint(cloudtrail.ServiceID, "AWS_CLOUDTRAIL_ENDPOINT")
+		o.BaseEndpoint = getBaseEndpoint(cloudtrail.ServiceID, []string{
+			"AWS_CLOUDTRAIL_ENDPOINT",
+			"AWS_ENDPOINT_URL_CLOUDTRAIL",
+			"AWS_ENDPOINT_URL",
+		})
 	})
 
 	return provider, nil


### PR DESCRIPTION
We dropped support for `AWS_ENDPOINT_URL` and `AWS_ENDPOINT_URL_*` environment vars that are documented here in commit e64db43bd455518d0712cff213df738a501d80ac:
- https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html#ss-endpoints-sdk-compat
- https://docs.aws.amazon.com/sdkref/latest/guide/ss-endpoints-table.html

We are not going back to honoring what is in the shared config files, but `AWS_ENDPOINT_URL` itself is a handy short-cut for sure. 

In this PR, we will explicitly list all the env vars that we support, loop through them (in a specific order) and use whichever is defined.

xref: https://github.com/eksctl-io/eksctl/pull/8231