### PR TITLE
Remove intermediate build image from add-on auto-update CI workflow

### DIFF
--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -18,7 +18,6 @@ jobs:
         resource: ["coredns", "aws-node", "nvidia-device-plugin"]
     name: Update ${{ matrix.resource }} and open PR
     runs-on: ubuntu-latest
-    container: public.ecr.aws/eksctl/eksctl-build:26e3c36557da8ae2db5d995cea673e05cc60cfce
     env:
       GOPRIVATE: ""
     steps:
@@ -39,15 +38,8 @@ jobs:
       uses: ./.github/actions/setup-identity
       with:
         token: "${{ secrets.EKSCTLBOT_TOKEN }}"
-    - name: Cache go-build and mod
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
-      with:
-        path: |
-          ~/.cache/go-build/
-          ~/go/pkg/mod/
-        key: go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          go-
+    - name: Setup build environment
+      uses: ./.github/actions/setup-build
     - name: Update ${{ matrix.resource }}
       run: make update-${{ matrix.resource }}
     - name: Upsert pull request


### PR DESCRIPTION
### Description

- Remove intermediate build image from add-on auto-update CI workflow

To fix errors https://github.com/eksctl-io/eksctl/actions/runs/13447980212/job/37577239833

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

