### PR TITLE
copy over older coredns json if missing

### DIFF
--- a/pkg/addons/default/scripts/update_coredns_assets.go
+++ b/pkg/addons/default/scripts/update_coredns_assets.go
@@ -31,17 +31,35 @@ func main() {
 		log.Fatal(err)
 	}
 
-	for _, kubernetesVersion := range cvm.SupportedVersions() {
-		latestVersion := getLatestVersion(ctx, clusterProvider, kubernetesVersion)
+	supportedVersions := cvm.SupportedVersions()
+	for index, kubernetesVersion := range supportedVersions {
+		latestVersion := getLatestCoreDNSVersion(ctx, clusterProvider, kubernetesVersion)
 		if latestVersion == "" {
 			continue
 		}
-		replaceCurrentVersionIfOutdated(latestVersion, kubernetesVersion)
+		filePath := filepath.Join("pkg", "addons", "default", "assets",
+			fmt.Sprintf("coredns-%s.json", kubernetesVersion))
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			filePrevVersionPath := filepath.Join("pkg", "addons", "default", "assets",
+				fmt.Sprintf("coredns-%s.json", supportedVersions[index-1]))
+			copyFile(filePrevVersionPath, filePath)
+		}
+		replaceCurrentVersionIfOutdated(filePath, latestVersion, kubernetesVersion)
 	}
 
 }
 
-func getLatestVersion(ctx context.Context, clusterProvider *eks.ClusterProvider, kubernetesVersion string) string {
+func copyFile(src, dst string) {
+	content, err := os.ReadFile(src)
+	if err != nil {
+		log.Fatalf("failed to read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, content, 0644); err != nil {
+		log.Fatalf("failed to write %s: %v", dst, err)
+	}
+}
+
+func getLatestCoreDNSVersion(ctx context.Context, clusterProvider *eks.ClusterProvider, kubernetesVersion string) string {
 	output, err := clusterProvider.AWSProvider.EKS().DescribeAddonVersions(ctx, &awseks.DescribeAddonVersionsInput{
 		AddonName:         aws.String("coredns"),
 		KubernetesVersion: &kubernetesVersion,
@@ -79,8 +97,7 @@ func getLatestVersion(ctx context.Context, clusterProvider *eks.ClusterProvider,
 	return corednsVersions[0]
 }
 
-func replaceCurrentVersionIfOutdated(latestVersion string, kubernetesVersion string) {
-	filePath := filepath.Join("pkg", "addons", "default", "assets", fmt.Sprintf("coredns-%s.json", kubernetesVersion))
+func replaceCurrentVersionIfOutdated(filePath string, latestVersion string, kubernetesVersion string) {
 	coreFile, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Fatalf("failed to read coredns-%s.json: %v", kubernetesVersion, err)


### PR DESCRIPTION
fixing failure that showed up in https://github.com/eksctl-io/eksctl/actions/runs/13448101739/job/37577563227#step:6:1
```
2025/02/21 01:31:59 failed to read coredns-1.32.json: open pkg/addons/default/assets/coredns-1.32.json: no such file or directory
exit status 1
make: *** [Makefile:173: update-coredns] Error 1
```

tested locally by removing json file and ensure that it gets created during `make update-coredns`