### PR TITLE
Enable auto-update of ec2 info

### DIFF
--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        resource: ["coredns", "aws-node", "nvidia-device-plugin"]
+        resource: ["coredns", "aws-node", "nvidia-device-plugin", "ec2-info"]
     name: Update ${{ matrix.resource }} and open PR
     runs-on: ubuntu-latest
     container: public.ecr.aws/eksctl/eksctl-build:26e3c36557da8ae2db5d995cea673e05cc60cfce
@@ -35,6 +35,14 @@ jobs:
         role-duration-seconds: 900
         role-session-name: eksctl-update-coredns-assets
         role-to-assume: ${{ secrets.UPDATE_COREDNS_ROLE_ARN }}
+    - name: Configure AWS credentials for ec2 info update
+      if: ${{ matrix.resource == 'ec2-info' }}
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      with:
+        aws-region: us-west-2
+        role-duration-seconds: 900
+        role-session-name: eksctl-update-ec2-info-assets
+        role-to-assume: ${{ secrets.UPDATE_EC2_INFO_ROLE_ARN }}
     - name: Setup identity as eksctl-bot
       uses: ./.github/actions/setup-identity
       with:

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,10 @@ update-aws-node: ## Re-download the aws-node manifests from AWS
 update-coredns: ## get latest coredns builds for each available eks version
 	@go run pkg/addons/default/scripts/update_coredns_assets.go
 
+.PHONY:
+update-ec2-info: ## get latest info on ec2 instance types
+	@go run cmd/ec2geninfo/main.go
+
 deep_copy_helper_input = $(shell $(call godeps_cmd,./pkg/apis/...) | sed 's|$(generated_code_deep_copy_helper)||' )
 $(generated_code_deep_copy_helper): $(deep_copy_helper_input) ## Generate Kubernetes API helpers
 	build/scripts/update-codegen.sh

--- a/cmd/ec2geninfo/main.go
+++ b/cmd/ec2geninfo/main.go
@@ -91,7 +91,7 @@ func updateEC2Instances() error {
 		return err
 	}
 
-	file, err := os.Create("../../pkg/utils/instance/instance_types.go")
+	file, err := os.Create("pkg/utils/instance/instance_types.go")
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/instance/instance_types.go
+++ b/pkg/utils/instance/instance_types.go
@@ -5242,7 +5242,7 @@ var InstanceTypes = []InstanceInfo{
 		InstanceStorageSupported: true,
 		EFASupported:             true,
 		NvidiaGPUSupported:       true,
-		NvidiaGPUType:            "NVIDIA",
+		NvidiaGPUType:            "H200",
 		NeuronSupported:          false,
 		NeuronDeviceType:         "",
 		CBRSupported:             true,


### PR DESCRIPTION
- Add a new target for make `update-ec2-info`
- fix path of the file to update to match the fact that we are running from root of the repository
- updating the github action to call this new make target in addition to the other things it already does
- EC2 API data for `"p5en.48xlarge"` was wrong before when we ran this automation, when we run it now, they corrected the Nvidia GPU type.

TODO:
- need to setup a secret `UPDATE_EC2_INFO_ROLE_ARN`, the role should allow using `DescribeInstanceTypes` API