### PR TITLE
Re-allow use of the `cnn1-az4` availability zone

### DIFF
--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -19,7 +19,6 @@ import (
 )
 
 var zoneIDsToAvoid = map[string][]string{
-	api.RegionCNNorth1:   {"cnn1-az4"}, // https://github.com/eksctl-io/eksctl/issues/3916
 	api.RegionUSEast1:    {"use1-az3"},
 	api.RegionUSWest1:    {"usw1-az2"},
 	api.RegionCACentral1: {"cac1-az3"},

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -389,15 +389,6 @@ var _ = Describe("AZ", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(zones).To(ConsistOf(e.expectedZones))
 	},
-		Entry(api.RegionCNNorth1, unsupportedZoneEntry{
-			region: api.RegionCNNorth1,
-			zoneNameToIDs: map[string]string{
-				"zone1": "cnn1-az1",
-				"zone2": "cnn1-az2",
-				"zone4": "cnn1-az4",
-			},
-			expectedZones: []string{"zone1", "zone2"},
-		}),
 		Entry(api.RegionUSEast1, unsupportedZoneEntry{
 			region: api.RegionUSEast1,
 			zoneNameToIDs: map[string]string{
@@ -428,7 +419,7 @@ var _ = Describe("AZ", func() {
 	)
 	When("the region contains zones that are denylisted", func() {
 		BeforeEach(func() {
-			region = api.RegionCNNorth1
+			region = api.RegionUSEast1
 
 			p.MockEC2().On("DescribeAvailabilityZones", mock.Anything, &ec2.DescribeAvailabilityZonesInput{
 				Filters: []ec2types.Filter{
@@ -449,7 +440,7 @@ var _ = Describe("AZ", func() {
 				AvailabilityZones: []ec2types.AvailabilityZone{
 					createAvailabilityZone(region, ec2types.AvailabilityZoneStateAvailable, "zone1"),
 					createAvailabilityZone(region, ec2types.AvailabilityZoneStateAvailable, "zone2"),
-					createAvailabilityZoneWithID(region, ec2types.AvailabilityZoneStateAvailable, "zone3", "cnn1-az4"),
+					createAvailabilityZoneWithID(region, ec2types.AvailabilityZoneStateAvailable, "zone3", "use1-az3"),
 				},
 			}, nil)
 		})


### PR DESCRIPTION
Context:

Once upon a time there was a problem:
https://github.com/eksctl-io/eksctl/issues/3916

For which this zone was excluded in:
https://github.com/eksctl-io/eksctl/issues/3916

We have known for a while that the problem went away:
Resolves: #5783

So we should remove the restriction!