### PR TITLE
Remove archived github.com/bxcodec/faker dependency

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -45,7 +45,6 @@ License version 2.0, we include the full text of the package's License below.
 * `github.com/awslabs/goformation/v4`
 * `github.com/benjamintf1/unmarshalledmatchers`
 * `github.com/blang/semver`
-* `github.com/bxcodec/faker`
 * `github.com/cenk/backoff`
 * `github.com/cloudflare/cfssl`
 * `github.com/dave/dst`
@@ -2555,32 +2554,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-### github.com/bxcodec/faker
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2017 Iman Tumorang
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ### github.com/cenk/backoff
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20250219002025-c3b5cd3d2fd9
 	github.com/benjamintf1/unmarshalledmatchers v1.0.0
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/bxcodec/faker v2.0.1+incompatible
 	github.com/cenk/backoff v2.2.1+incompatible
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/dave/jennifer v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,6 @@ github.com/butuzov/ireturn v0.3.1 h1:mFgbEI6m+9W8oP/oDdfA34dLisRFCj2G6o/yiI1yZrY
 github.com/butuzov/ireturn v0.3.1/go.mod h1:ZfRp+E7eJLC0NQmk1Nrm1LOrn/gQlOykv+cVPdiXH5M=
 github.com/butuzov/mirror v1.3.0 h1:HdWCXzmwlQHdVhwvsfBb2Au0r3HyINry3bDWLYXiKoc=
 github.com/butuzov/mirror v1.3.0/go.mod h1:AEij0Z8YMALaq4yQj9CPPVYOyJQyiexpQEQgihajRfI=
-github.com/bxcodec/faker v2.0.1+incompatible h1:P0KUpUw5w6WJXwrPfv35oc91i4d8nf40Nwln+M/+faA=
-github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6rHShT+veBxNCnjCx5XM=
 github.com/catenacyber/perfsprint v0.8.1 h1:bGOHuzHe0IkoGeY831RW4aSlt1lPRd3WRAScSWOaV7E=
 github.com/catenacyber/perfsprint v0.8.1/go.mod h1:/wclWYompEyjUD2FuIIDVKNkqz7IgBIWXIH3V0Zol50=
 github.com/ccojocar/zxcvbn-go v1.0.2 h1:na/czXU8RrhXO4EZme6eQJLR4PzcGsahsBOAwU6I3Vg=

--- a/pkg/actions/accessentry/remover.go
+++ b/pkg/actions/accessentry/remover.go
@@ -3,8 +3,8 @@ package accessentry
 import (
 	"context"
 	"fmt"
+	"slices"
 
-	"github.com/bxcodec/faker/support/slice"
 	"github.com/kris-nova/logger"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -65,7 +65,7 @@ func (aer Remover) DeleteTasks(ctx context.Context, accessEntries []api.AccessEn
 
 	for _, e := range accessEntries {
 		stackName := MakeStackName(aer.clusterName, e)
-		if !slice.Contains(stacks, stackName) {
+		if !slices.Contains(stacks, stackName) {
 			tasks.Append(&deleteUnownedAccessEntryTask{
 				info:         fmt.Sprintf("delete access entry for principal ARN %s", e.PrincipalARN.String()),
 				clusterName:  aer.clusterName,

--- a/pkg/fargate/options_test.go
+++ b/pkg/fargate/options_test.go
@@ -1,10 +1,10 @@
 package fargate_test
 
 import (
-	"github.com/bxcodec/faker"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/eksctl/pkg/fargate"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 var _ = Describe("fargate", func() {
@@ -26,10 +26,10 @@ var _ = Describe("fargate", func() {
 			})
 
 			It("passes on randomly generated input", func() {
-				options := fargate.Options{}
-				err := faker.FakeData(&options)
-				Expect(err).To(Not(HaveOccurred()))
-				err = options.Validate()
+				options := fargate.Options{
+					ProfileName: rand.String(25),
+				}
+				err := options.Validate()
 				Expect(err).To(Not(HaveOccurred()))
 			})
 		})
@@ -63,10 +63,17 @@ var _ = Describe("fargate", func() {
 			})
 
 			It("passes on randomly generated input", func() {
-				options := fargate.CreateOptions{}
-				err := faker.FakeData(&options)
-				Expect(err).To(Not(HaveOccurred()))
-				err = options.Validate()
+				options := fargate.CreateOptions{
+					ProfileName:              rand.String(25),
+					ProfileSelectorNamespace: rand.String(25),
+					ProfileSelectorLabels: map[string]string{
+						rand.String(25): rand.String(25),
+					},
+					Tags: map[string]string{
+						rand.String(25): rand.String(25),
+					},
+				}
+				err := options.Validate()
 				Expect(err).To(Not(HaveOccurred()))
 			})
 		})

--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
-	"github.com/bxcodec/faker/support/slice"
 	"github.com/kris-nova/logger"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -840,8 +839,8 @@ func SelectNodeGroupSubnets(ctx context.Context, np api.NodePool, clusterConfig 
 		}
 		// only validate instance support for availability zones
 		if zoneType == ZoneTypeAvailabilityZone &&
-			slice.Contains(clusterConfig.AvailabilityZones, zone) && // for now, we won't validate support for user specified new zones
-			!slice.Contains(*supportedZones, zone) {
+			slices.Contains(clusterConfig.AvailabilityZones, zone) && // for now, we won't validate support for user specified new zones
+			!slices.Contains(*supportedZones, zone) {
 			return fmt.Errorf("cannot create nodegroup %s in availability zone %s as it does not support all required instance types",
 				np.BaseNodeGroup().Name, zone)
 		}


### PR DESCRIPTION
### Description

Remove the `github.com/bxcodec/faker` dependency because it's archived and we can easily avoid usage of it:

- Replace `slice.Contains` with `slices.Contains`.
- Replace `faker.FakeData` with `rand.String` from `k8s.io/apimachinery`. This package is already used in other places. (Another possible way to fix this is by removing the `passes on randomly generated input` tests.)

https://github.com/bxcodec/faker has been archived by the owner on Dec 8, 2022

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

