### PR TITLE
Do not run ci jobs in forks

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    if: github.event.repository.fork == false
     permissions:
       # write permission is required to create a github release
       contents: write
@@ -49,7 +50,7 @@ jobs:
             <blockquote>
 
             ${{ steps.draft.outputs.body }}
-            
+
             </blockquote>
             </details>
             <br />

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 #v9.1.0

--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   update_generated_file:
+    if: github.event.repository.fork == false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Just adds noise in a fork when these actions run unnecessarily.