### PR TITLE
Fix failure when VPC CNI is configured to use both iam.withOIDC and useDefaultPodIdentityAssociations

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -352,7 +352,19 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		ClusterName:  cfg.Metadata.Name,
 		StackCreator: stackManager,
 	}
-	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
+	piaUpdater := &addon.PodIdentityAssociationUpdater{
+		ClusterName: cmd.ClusterConfig.Metadata.Name,
+		IAMRoleCreator: &podidentityassociation.IAMRoleCreator{
+			ClusterName:  cmd.ClusterConfig.Metadata.Name,
+			StackCreator: stackManager,
+		},
+		IAMRoleUpdater: &podidentityassociation.IAMRoleUpdater{
+			StackUpdater: stackManager,
+		},
+		EKSPodIdentityDescriber: ctl.AWSProvider.EKS(),
+		StackDeleter:            stackManager,
+	}
+	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, piaUpdater, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
 	if len(autoDefaultAddons) > 0 {
 		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
 	}


### PR DESCRIPTION
xref: https://github.com/eksctl-io/eksctl/issues/8147

This explicit check comes at a time when the OIDC endpoint is getting created (and may not have been yet!), so we end up getting `but since OIDC is disabled on the cluster` message which is not really true, because we did ask the cluster to be created with `cfg.IAM.WithOIDC` set to true!

xref: https://github.com/eksctl-io/eksctl/issues/8141

During create, we were passing `podIdentityIAMUpdater` to be nil which caused the panic. 
