### PR TITLE
Switch default for ExecConfig api version from v1alpha1->v1beta1

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -170,7 +170,7 @@ func AppendAuthenticator(config *clientcmdapi.Config, cluster ClusterInfo, authe
 	)
 
 	execConfig := &clientcmdapi.ExecConfig{
-		APIVersion: alphaAPIVersion,
+		APIVersion: betaAPIVersion,
 		Command:    authenticatorCMD,
 		Env: []clientcmdapi.ExecEnvVar{
 			{

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -393,7 +393,7 @@ var _ = Describe("Kubeconfig", func() {
 				return exec.Command(filepath.Join("testdata", "fake-version"), `{"Version":"0.5.1","Commit":"85e50980d9d916ae95882176c18f14ae145f916f"}`)
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSIAMAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 		It("writes the right api version if aws-iam-authenticator version is above 0.5.3", func() {
 			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
@@ -414,21 +414,21 @@ var _ = Describe("Kubeconfig", func() {
 				return exec.Command(filepath.Join("testdata", "fake-version"), "fail")
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSIAMAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 		It("defaults to alpha1 if we fail to parse the output", func() {
 			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
 				return exec.Command(filepath.Join("testdata", "fake-version"), "not-json-output")
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSIAMAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 		It("defaults to alpha1 if we can't parse the version because it's a dev version", func() {
 			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
 				return exec.Command(filepath.Join("testdata", "fake-version"), `{"Version":"git-85e50980","Commit":"85e50980d9d916ae95882176c18f14ae145f916f"}`)
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSIAMAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 		It("defaults to beta1 if we detect kubectl 1.24.0 or above", func() {
 			kubeconfig.SetNewVersionManager(func() kubectl.KubernetesVersionManager {
@@ -446,7 +446,7 @@ var _ = Describe("Kubeconfig", func() {
 				return fakeClient
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSIAMAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 		It("defaults to beta1 if we detect aws-cli v1 is at or above 1.23.9", func() {
 			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
@@ -460,7 +460,7 @@ var _ = Describe("Kubeconfig", func() {
 				return exec.Command(filepath.Join("testdata", "fake-version"), `aws-cli/1.21.9 Python/3.8.8 Linux/5.4.181-109.354.amzn2int.x86_64 exe/x86_64.amzn.2 prompt/off`)
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSEKSAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 		It("defaults to beta1 if we detect aws-cli v2 is at or above 2.6.3", func() {
 			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
@@ -474,7 +474,7 @@ var _ = Describe("Kubeconfig", func() {
 				return exec.Command(filepath.Join("testdata", "fake-version"), `aws-cli/2.4.3 Python/3.8.8 Linux/5.4.181-109.354.amzn2int.x86_64 exe/x86_64.amzn.2 prompt/off`)
 			})
 			kubeconfig.AppendAuthenticator(config, clusterInfo, kubeconfig.AWSEKSAuthenticator, "", "")
-			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
 		})
 	})
 


### PR DESCRIPTION
fix for errors like these, for example from: (log)[https://productionresultssa1.blob.core.windows.net/actions-results/5e902fd4-9bd9-4c94-9585-48864642edbd/workflow-job-run-2f18dc0c-68b9-5c36-2bef-1c771ed53d83/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-02-26T14%3A10%3A12Z&sig=7N0spFARzaxDGFWIfgu03p%2B82yaGiTBBJAOdvArNi0Q%3D&ske=2025-02-26T23%3A15%3A16Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-02-26T11%3A15%3A16Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-02-26T14%3A00%3A07Z&sv=2025-01-05]

also see report in https://github.com/eksctl-io/eksctl/issues/8198#issuecomment-2684975224

```
[0]   [FAILED] Unexpected error:
[0]       <*errors.errorString | 0xc000e59b00>: 
[0]       exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
[0]       {
[0]           s: "exec plugin: invalid apiVersion \"client.authentication.k8s.io/v1alpha1\"",
[0]       }
```

`v1alpha1` was removed in k8s 1.24 per [CHANGELOG](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md):
```
The client.authentication.k8s.io/v1alpha1 ExecCredential has been removed. If you are using a client-go credential plugin 
that relies on the v1alpha1 API please contact the distributor of your plugin for instructions on how to migrate to the 
v1 API. (https://github.com/kubernetes/kubernetes/pull/108616, [@margocrawf](https://github.com/margocrawf))
```
