### PR TITLE
generate/verify schema .. had forgotten to update schema.json for neuron devices

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -31,6 +31,8 @@ jobs:
         uses: ./.github/actions/setup-build
       - name: Check go.mod and go.sum
         run: make check-gomod
+      - name: Check schema.json
+        run: make check-schema
       - name: Lint
         run: make lint
   image:

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,14 @@ check-gomod:
 	go mod tidy
 	git diff --quiet -- go.mod go.sum || (git --no-pager diff go.mod go.sum; echo "HINT: to fix this, run 'go mod tidy && git commit go.mod go.sum --message \"go mod tidy\"'"; exit 1)
 
+.PHONY: check-schema ## Generate schema.json
+generate-schema:
+	cd pkg/apis/eksctl.io/v1alpha5 && go run ../../../../cmd/schema assets/schema.json
+
+.PHONY: check-schema ## Verify schema.json is up to date
+check-schema: generate-schema
+	git diff --quiet -- pkg/apis/eksctl.io/v1alpha5/assets/schema.json || (git --no-pager diff pkg/apis/eksctl.io/v1alpha5/assets/schema.json; echo "please run 'make generate-schema' to generate schema.json"; exit 1)
+
 .PHONY: test
 test: ## Lint, generate and run unit tests. Also ensure that integration tests compile
 	$(MAKE) lint

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1241,6 +1241,11 @@
           "description": "specifies the memory The unit defaults to GiB",
           "x-intellij-html-description": "specifies the memory The unit defaults to GiB"
         },
+        "neuron_devices": {
+          "type": "integer",
+          "description": "specifies the number of Neuron device Accelerators. It can be set to 0 to select non-Accelerator instance types.",
+          "x-intellij-html-description": "specifies the number of Neuron device Accelerators. It can be set to 0 to select non-Accelerator instance types."
+        },
         "vCPUs": {
           "type": "integer",
           "description": "specifies the number of vCPUs",
@@ -1251,6 +1256,7 @@
         "vCPUs",
         "memory",
         "gpus",
+        "neuron_devices",
         "cpuArchitecture",
         "allow",
         "deny"


### PR DESCRIPTION
found via an integration test failure. we should flag this as quickly as possible, so added a generate/check make target so we don't get tripped up.

```
[0] Utils schema [It] displays the schema
[0] /__w/eksctl-ci/eksctl-ci/eksctl/integration/tests/utils/utils_test.go:30
[0] 
[0]   [FAILED] Expected
[0]       <string>: "...    "neuron..."
[0]   to equal               |
[0]       <string>: "...    "vCPUs"..."
[0]   In [It] at: /__w/eksctl-ci/eksctl-ci/eksctl/integration/tests/utils/utils_test.go:34 @ 02/26/25 19:19:50.931
```