### PR TITLE
Replace 'github.com/pkg/errors' with 'errors'

### DIFF
--- a/docs/guidelines/design-conventions.md
+++ b/docs/guidelines/design-conventions.md
@@ -25,7 +25,7 @@ General conventions followed when developing in eksctl:
     - i.e. no dots, ellipsis or semicolons
   - do not write long log messages, try to break up into two if extra information is needed
 
-- use `errors.Wrapf` to wrap errors
+- use `fmt.Errorf` with `%w` to wrap errors
   - avoid wrapping errors that are already meaningful
 
 - we use Kris Nova's logger, this may change in the future and we should probably abstract it

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/otiai10/copy v1.14.1
 	github.com/pelletier/go-toml v1.9.5
-	github.com/pkg/errors v0.9.1
 	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 	github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522
 	github.com/sethvargo/go-password v0.3.1
@@ -335,6 +334,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.7 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polyfloyd/go-errorlint v1.7.1 // indirect

--- a/pkg/actions/podidentityassociation/iam_role_updater.go
+++ b/pkg/actions/podidentityassociation/iam_role_updater.go
@@ -2,6 +2,7 @@ package podidentityassociation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"

--- a/pkg/addons/default/addons.go
+++ b/pkg/addons/default/addons.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 )
@@ -93,7 +92,7 @@ func makeGetError[T any](resource *T, err error, resourceName string) (*T, error
 func newList(data []byte) (*metav1.List, error) {
 	list, err := kubernetes.NewList(data)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading individual resources from manifest")
+		return nil, fmt.Errorf("loading individual resources from manifest: %w", err)
 	}
 	return list, nil
 }

--- a/pkg/addons/default/coredns.go
+++ b/pkg/addons/default/coredns.go
@@ -3,12 +3,12 @@ package defaultaddons
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +42,7 @@ func UpdateCoreDNS(ctx context.Context, input AddonInput, plan bool) (bool, erro
 			logger.Warning("%q service was not found", KubeDNS)
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "getting %q service", KubeDNS)
+		return false, fmt.Errorf("getting %q service: %w", KubeDNS, err)
 	}
 
 	kubeDNSDeployment, err := input.RawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Get(ctx, CoreDNS, metav1.GetOptions{})
@@ -51,7 +51,7 @@ func UpdateCoreDNS(ctx context.Context, input AddonInput, plan bool) (bool, erro
 			logger.Warning("%q was not found", CoreDNS)
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "getting %q", CoreDNS)
+		return false, fmt.Errorf("getting %q: %w", CoreDNS, err)
 	}
 
 	// if Deployment is present, go through our list of assets

--- a/pkg/addons/irsa_helper.go
+++ b/pkg/addons/irsa_helper.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/weaveworks/eksctl/pkg/actions/irsa"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
@@ -40,7 +38,7 @@ func NewIRSAHelper(oidc *iamoidc.OpenIDConnectManager, stackManager manager.Stac
 func (h *irsaHelper) IsSupported(ctx context.Context) (bool, error) {
 	exists, err := h.oidc.CheckProviderExists(ctx)
 	if err != nil {
-		return false, errors.Wrapf(err, "error checking OIDC provider")
+		return false, fmt.Errorf("error checking OIDC provider: %w", err)
 	}
 	return exists, nil
 }
@@ -52,7 +50,7 @@ func (h *irsaHelper) CreateOrUpdate(ctx context.Context, sa *api.ClusterIAMServi
 	stack, err := h.stackManager.DescribeStack(ctx, &manager.Stack{StackName: &name})
 	if err != nil {
 		if !manager.IsStackDoesNotExistError(err) {
-			return errors.Wrapf(err, "error checking if iamserviceaccount %s/%s exists", sa.Namespace, sa.Name)
+			return fmt.Errorf("error checking if iamserviceaccount %s/%s exists: %w", sa.Namespace, sa.Name, err)
 		}
 	}
 	if stack == nil {

--- a/pkg/apis/eksctl.io/v1alpha5/identity_provider.go
+++ b/pkg/apis/eksctl.io/v1alpha5/identity_provider.go
@@ -2,9 +2,8 @@ package v1alpha5
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 type IdentityProviderType string

--- a/pkg/apis/eksctl.io/v1alpha5/identitymapping.go
+++ b/pkg/apis/eksctl.io/v1alpha5/identitymapping.go
@@ -1,7 +1,7 @@
 package v1alpha5
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // IAMIdentityMapping contains IAM accounts, users, roles and services that will be added to the

--- a/pkg/apis/eksctl.io/v1alpha5/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha5/vpc.go
@@ -2,6 +2,7 @@ package v1alpha5
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -9,7 +10,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/utils/ipnet"
 )

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -18,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/awsapi"
@@ -157,7 +157,7 @@ func (c *StackCollection) DoCreateStackRequest(ctx context.Context, i *Stack, te
 	logger.Debug("CreateStackInput = %#v", input)
 	s, err := c.cloudformationAPI.CreateStack(ctx, input)
 	if err != nil {
-		return errors.Wrapf(err, "creating CloudFormation stack %q", *i.StackName)
+		return fmt.Errorf("creating CloudFormation stack %q: %w", *i.StackName, err)
 	}
 	i.StackId = s.StackId
 	return nil
@@ -213,7 +213,7 @@ func (c *StackCollection) createClusterStack(ctx context.Context, stackName stri
 		}
 
 		if err := resourceSet.GetAllOutputs(*stack); err != nil {
-			errCh <- errors.Wrapf(err, "getting stack %q outputs", *stack.StackName)
+			errCh <- fmt.Errorf("getting stack %q outputs: %w", *stack.StackName, err)
 			return
 		}
 
@@ -227,7 +227,7 @@ func (c *StackCollection) createStackRequest(ctx context.Context, stackName stri
 	stack := &Stack{StackName: &stackName}
 	templateBody, err := resourceSet.RenderJSON()
 	if err != nil {
-		return nil, errors.Wrapf(err, "rendering template for %q stack", *stack.StackName)
+		return nil, fmt.Errorf("rendering template for %q stack: %w", *stack.StackName, err)
 	}
 
 	if err := c.DoCreateStackRequest(ctx, stack, TemplateBody(templateBody), tags, parameters, resourceSet.WithIAM(), resourceSet.WithNamedIAM()); err != nil {
@@ -282,7 +282,7 @@ func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTa
 		for _, asgTags := range chunkedASGTags {
 			input := &autoscaling.CreateOrUpdateTagsInput{Tags: asgTags}
 			if _, err := c.asgAPI.CreateOrUpdateTags(context.Background(), input); err != nil {
-				errCh <- errors.Wrapf(err, "creating or updating asg tags for managed nodegroup %q", ngName)
+				errCh <- fmt.Errorf("creating or updating asg tags for managed nodegroup %q: %w", ngName, err)
 				return
 			}
 		}
@@ -303,7 +303,7 @@ func (c *StackCollection) checkASGTagsNumber(ngName, asgName string, propagatedT
 	}
 	output, err := c.asgAPI.DescribeTags(context.Background(), tagsFilter)
 	if err != nil {
-		return errors.Wrapf(err, "describing asg %q tags for managed nodegroup %q", asgName, ngName)
+		return fmt.Errorf("describing asg %q tags for managed nodegroup %q: %w", asgName, ngName, err)
 	}
 	asgTags := output.Tags
 	// intersection of key tags to consider the number of tags going
@@ -447,7 +447,7 @@ func (c *StackCollection) ListStacksMatching(ctx context.Context, nameRegex stri
 
 	re, err := regexp.Compile(nameRegex)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot list stacks")
+		return nil, fmt.Errorf("cannot list stacks: %w", err)
 	}
 	input := &cloudformation.ListStacksInput{
 		StackStatusFilter: defaultStackStatusFilter(),
@@ -587,7 +587,7 @@ func (c *StackCollection) DeleteStackBySpec(ctx context.Context, s *Stack) (*Sta
 	}
 
 	if _, err := c.cloudformationAPI.DeleteStack(ctx, input); err != nil {
-		return nil, errors.Wrapf(err, "not able to delete stack %q", *s.StackName)
+		return nil, fmt.Errorf("not able to delete stack %q: %w", *s.StackName, err)
 	}
 	logger.Info("will delete stack %q", *s.StackName)
 	return s, nil
@@ -640,7 +640,7 @@ func fmtStacksRegexForCluster(name string) string {
 func (c *StackCollection) ListStacks(ctx context.Context) ([]*Stack, error) {
 	stacks, err := c.ListStacksWithStatuses(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "describing CloudFormation stacks for %q", c.spec.Metadata.Name)
+		return nil, fmt.Errorf("describing CloudFormation stacks for %q: %w", c.spec.Metadata.Name, err)
 	}
 	if len(stacks) == 0 {
 		logger.Debug("No stacks found for %s", c.spec.Metadata.Name)
@@ -693,7 +693,7 @@ func (c *StackCollection) DescribeStackEvents(ctx context.Context, i *Stack) ([]
 
 	stackEvents, err := c.cloudformationAPI.DescribeStackEvents(ctx, input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "describing CloudFormation stack %q events", *i.StackName)
+		return nil, fmt.Errorf("describing CloudFormation stack %q events: %w", *i.StackName, err)
 	}
 
 	return stackEvents.StackEvents, nil
@@ -712,7 +712,7 @@ func (c *StackCollection) LookupCloudTrailEvents(ctx context.Context, i *Stack) 
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "looking up CloudTrail events for stack %q", *i.StackName)
+			return nil, fmt.Errorf("looking up CloudTrail events for stack %q: %w", *i.StackName, err)
 		}
 		events = append(events, out.Events...)
 	}
@@ -755,7 +755,7 @@ func (c *StackCollection) doCreateChangeSetRequest(ctx context.Context, stackNam
 	logger.Debug("creating changeSet, input = %#v", input)
 	s, err := c.cloudformationAPI.CreateChangeSet(ctx, input)
 	if err != nil {
-		return errors.Wrapf(err, "creating ChangeSet %q for stack %q", changeSetName, stackName)
+		return fmt.Errorf("creating ChangeSet %q for stack %q: %w", changeSetName, stackName, err)
 	}
 	logger.Debug("changeSet = %#v", s)
 	return nil
@@ -770,7 +770,7 @@ func (c *StackCollection) doExecuteChangeSet(ctx context.Context, stackName stri
 	logger.Debug("executing changeSet, input = %#v", input)
 
 	if _, err := c.cloudformationAPI.ExecuteChangeSet(ctx, input); err != nil {
-		return errors.Wrapf(err, "executing CloudFormation ChangeSet %q for stack %q", changeSetName, stackName)
+		return fmt.Errorf("executing CloudFormation ChangeSet %q for stack %q: %w", changeSetName, stackName, err)
 	}
 	return nil
 }
@@ -786,7 +786,7 @@ func (c *StackCollection) DescribeStackChangeSet(ctx context.Context, i *Stack, 
 	}
 	resp, err := c.cloudformationAPI.DescribeChangeSet(ctx, input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "describing CloudFormation ChangeSet %s for stack %s", changeSetName, *i.StackName)
+		return nil, fmt.Errorf("describing CloudFormation ChangeSet %s for stack %s: %w", changeSetName, *i.StackName, err)
 	}
 	return resp, nil
 }

--- a/pkg/cfn/manager/delete_tasks.go
+++ b/pkg/cfn/manager/delete_tasks.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/actions/accessentry"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"

--- a/pkg/cfn/manager/deprecated.go
+++ b/pkg/cfn/manager/deprecated.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kris-nova/logger"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
-	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 )
@@ -30,7 +29,7 @@ func fmtDeprecatedStacksRegexForCluster(name string) string {
 func (c *StackCollection) DeleteTasksForDeprecatedStacks(ctx context.Context) (*tasks.TaskTree, error) {
 	stacks, err := c.ListStacksMatching(ctx, fmtDeprecatedStacksRegexForCluster(c.spec.Metadata.Name))
 	if err != nil {
-		return nil, errors.Wrapf(err, "describing deprecated CloudFormation stacks for %q", c.spec.Metadata.Name)
+		return nil, fmt.Errorf("describing deprecated CloudFormation stacks for %q: %w", c.spec.Metadata.Name, err)
 	}
 	if len(stacks) == 0 {
 		return nil, nil

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -2,6 +2,7 @@ package cmdutils
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -117,7 +117,7 @@ func (l *commonClusterConfigLoader) Load() error {
 
 	if l.ClusterConfigFile == "" {
 		if flagName, found := findChangedFlag(l.CobraCommand, sets.List(l.flagsIncompatibleWithoutConfigFile)); found {
-			return errors.Errorf("cannot use --%s unless a config file is specified via --config-file/-f", flagName)
+			return fmt.Errorf("cannot use --%s unless a config file is specified via --config-file/-f", flagName)
 		}
 		return l.validateWithoutConfigFile()
 	}
@@ -628,7 +628,7 @@ func validateManagedNGFlags(cmd *cobra.Command, managed bool) error {
 	}
 	flagsValidOnlyWithMNG := []string{"spot", "enable-node-repair", "instance-types"}
 	if flagName, found := findChangedFlag(cmd, flagsValidOnlyWithMNG); found {
-		return errors.Errorf("--%s is only valid with managed nodegroups (--managed)", flagName)
+		return fmt.Errorf("--%s is only valid with managed nodegroups (--managed)", flagName)
 	}
 	return nil
 }

--- a/pkg/ctl/cmdutils/filter/filter.go
+++ b/pkg/ctl/cmdutils/filter/filter.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -42,7 +41,7 @@ func (f *Filter) AppendExcludeGlobs(globExprs ...string) error {
 	for _, expr := range globExprs {
 		compiledExpr, err := glob.Compile(expr)
 		if err != nil {
-			return errors.Wrapf(err, "parsing glob filter %q", expr)
+			return fmt.Errorf("parsing glob filter %q: %w", expr, err)
 		}
 		f.excludeGlobs = append(f.excludeGlobs, compiledExpr)
 		f.rawExcludeGlobs = append(f.rawExcludeGlobs, expr)
@@ -164,7 +163,7 @@ func (f *Filter) doAppendIncludeGlobs(names []string, resource string, globExprs
 	for _, expr := range globExprs {
 		compiledExpr, err := glob.Compile(expr)
 		if err != nil {
-			return errors.Wrapf(err, "parsing glob filter %q", expr)
+			return fmt.Errorf("parsing glob filter %q: %w", expr, err)
 		}
 		f.includeGlobs = append(f.includeGlobs, compiledExpr)
 		f.rawIncludeGlobs = append(f.rawIncludeGlobs, expr)

--- a/pkg/ctl/cmdutils/kms.go
+++ b/pkg/ctl/cmdutils/kms.go
@@ -1,7 +1,8 @@
 package cmdutils
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 )
 
 func NewUtilsKMSLoader(cmd *Cmd) ClusterConfigLoader {
@@ -13,7 +14,7 @@ func NewUtilsKMSLoader(cmd *Cmd) ClusterConfigLoader {
 
 	l.validateWithConfigFile = func() error {
 		if cmd.NameArg != "" {
-			return errors.Errorf("config file and key ARN %s", IncompatibleFlags)
+			return fmt.Errorf("config file and key ARN %s", IncompatibleFlags)
 		}
 		if l.ClusterConfig.SecretsEncryption == nil || l.ClusterConfig.SecretsEncryption.KeyARN == "" {
 			return errors.New("field secretsEncryption.keyARN is required")

--- a/pkg/ctl/create/fargate.go
+++ b/pkg/ctl/create/fargate.go
@@ -2,8 +2,8 @@ package create
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -38,7 +38,7 @@ func doCreateFargateProfile(cmd *cmdutils.Cmd) error {
 	ctx := context.TODO()
 	ctl, err := cmd.NewProviderForExistingCluster(ctx)
 	if err != nil {
-		return errors.Wrap(err, "couldn't create cluster provider from command line options")
+		return fmt.Errorf("couldn't create cluster provider from command line options: %w", err)
 	}
 
 	manager := actionsfargate.New(cmd.ClusterConfig, ctl, ctl.NewStackManager(cmd.ClusterConfig))

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v3/pkg/selector"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -33,7 +32,7 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 		ngFilter := filter.NewNodeGroupFilter()
 		if err := cmdutils.NewCreateNodeGroupLoader(cmd, ng, ngFilter, options).Load(); err != nil {
-			return errors.Wrap(err, "couldn't create node group filter from command line options")
+			return fmt.Errorf("couldn't create node group filter from command line options: %w", err)
 		}
 
 		if options.DryRun {

--- a/pkg/ctl/register/cluster.go
+++ b/pkg/ctl/register/cluster.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -49,7 +48,7 @@ func registerCluster(cmd *cmdutils.Cmd, cluster connector.ExternalCluster) error
 
 	manifestTemplate, err := connector.GetManifestTemplate()
 	if err != nil {
-		return errors.Wrap(err, "error getting manifests for EKS Connector")
+		return fmt.Errorf("error getting manifests for EKS Connector: %w", err)
 	}
 
 	c := connector.EKSConnector{
@@ -58,7 +57,7 @@ func registerCluster(cmd *cmdutils.Cmd, cluster connector.ExternalCluster) error
 	}
 	resourceList, err := c.RegisterCluster(ctx, cluster)
 	if err != nil {
-		return errors.Wrap(err, "error registering cluster")
+		return fmt.Errorf("error registering cluster: %w", err)
 	}
 
 	logger.Info("registered cluster %q successfully", cluster.Name)

--- a/pkg/ctl/utils/enable_secrets_encryption.go
+++ b/pkg/ctl/utils/enable_secrets_encryption.go
@@ -2,10 +2,10 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -82,7 +82,7 @@ func doEnableSecretsEncryption(cmd *cmdutils.Cmd, encryptExistingSecrets bool) e
 			return err
 		}
 		if err := kubernetes.RefreshSecrets(ctx, clientSet.CoreV1()); err != nil {
-			return errors.Wrap(err, "error updating secrets")
+			return fmt.Errorf("error updating secrets: %w", err)
 		}
 		logger.Info("KMS encryption applied to all Secret resources")
 	}

--- a/pkg/ctl/utils/update_legacy_subnet_settings.go
+++ b/pkg/ctl/utils/update_legacy_subnet_settings.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -66,7 +65,7 @@ func doUpdateLegacySubnetSettings(cmd *cmdutils.Cmd) error {
 		return fmt.Errorf("error describing cluster stack: %w", err)
 	}
 	if err := ctl.LoadClusterVPC(ctx, cfg, stack, true); err != nil {
-		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
+		return fmt.Errorf("getting VPC configuration for cluster %q: %w", cfg.Metadata.Name, err)
 	}
 
 	logger.Info("updating settings { MapPublicIpOnLaunch: enabled } for public subnets %v", cfg.VPC.Subnets.Public)

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -20,7 +20,6 @@ import (
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -245,11 +244,11 @@ func LoadConfigFromFile(configFile string) (*api.ClusterConfig, error) {
 func LoadConfigWithReader(configFile string, configReader io.Reader) (*api.ClusterConfig, error) {
 	data, err := readConfig(configFile, configReader)
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading config file %q", configFile)
+		return nil, fmt.Errorf("reading config file %q: %w", configFile, err)
 	}
 	clusterConfig, err := ParseConfig(data)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading config file %q", configFile)
+		return nil, fmt.Errorf("loading config file %q: %w", configFile, err)
 	}
 	return clusterConfig, nil
 }
@@ -278,7 +277,7 @@ func (c *ClusterProvider) IsSupportedRegion() bool {
 func (c *ClusterProvider) GetCredentialsEnv(ctx context.Context) ([]string, error) {
 	creds, err := c.AWSProvider.CredentialsProvider().Retrieve(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting effective credentials")
+		return nil, fmt.Errorf("getting effective credentials: %w", err)
 	}
 	return []string{
 		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", creds.AccessKeyID),
@@ -291,7 +290,7 @@ func (c *ClusterProvider) GetCredentialsEnv(ctx context.Context) ([]string, erro
 func (c *ClusterProvider) checkAuth(ctx context.Context) (*sts.GetCallerIdentityOutput, error) {
 	output, err := c.AWSProvider.STS().GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
-		return nil, errors.Wrap(err, "checking AWS STS access – cannot get role ARN for current session")
+		return nil, fmt.Errorf("checking AWS STS access – cannot get role ARN for current session: %w", err)
 	}
 	if output == nil || output.Arn == nil {
 		return nil, fmt.Errorf("unexpected response from AWS STS")
@@ -314,13 +313,13 @@ func ResolveAMI(ctx context.Context, provider api.ClusterProvider, version strin
 			ami.NewAutoResolver(provider.EC2()),
 		)
 	default:
-		return errors.Errorf("invalid AMI value: %q", ng.AMI)
+		return fmt.Errorf("invalid AMI value: %q", ng.AMI)
 	}
 
 	instanceType := api.SelectInstanceType(np)
 	id, err := resolver.Resolve(ctx, provider.Region(), version, instanceType, ng.AMIFamily)
 	if err != nil {
-		return errors.Wrap(err, "unable to determine AMI to use")
+		return fmt.Errorf("unable to determine AMI to use: %w", err)
 	}
 	if id == "" {
 		return ami.NewErrFailedResolution(provider.Region(), version, instanceType, ng.AMIFamily)
@@ -352,7 +351,7 @@ func SetAvailabilityZones(ctx context.Context, spec *api.ClusterConfig, given []
 	logger.Debug("determining availability zones")
 	zones, err := az.GetAvailabilityZones(ctx, ec2API, region, spec)
 	if err != nil {
-		return false, errors.Wrap(err, "getting availability zones")
+		return false, fmt.Errorf("getting availability zones: %w", err)
 	}
 
 	logger.Info("setting availability zones to %v", zones)

--- a/pkg/eks/nodegroup_service.go
+++ b/pkg/eks/nodegroup_service.go
@@ -2,6 +2,7 @@ package eks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -11,7 +12,6 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v3/pkg/selector"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
@@ -124,7 +124,7 @@ func (n *NodeGroupService) ExpandInstanceSelectorOptions(nodePools []api.NodePoo
 	}
 
 	instanceTypesMismatchErr := func(ng *api.NodeGroupBase, path string) error {
-		return errors.Errorf("instance types matched by instance selector criteria do not match %s.instanceTypes for nodegroup %q; either remove instanceSelector or instanceTypes and retry the operation", path, ng.Name)
+		return fmt.Errorf("instance types matched by instance selector criteria do not match %s.instanceTypes for nodegroup %q; either remove instanceSelector or instanceTypes and retry the operation", path, ng.Name)
 	}
 
 	for _, np := range nodePools {
@@ -139,11 +139,11 @@ func (n *NodeGroupService) ExpandInstanceSelectorOptions(nodePools []api.NodePoo
 		}
 		instanceTypes, err := n.expandInstanceSelector(baseNG.InstanceSelector, azs)
 		if err != nil {
-			return errors.Wrapf(err, "error expanding instance selector options for nodegroup %q", baseNG.Name)
+			return fmt.Errorf("error expanding instance selector options for nodegroup %q: %w", baseNG.Name, err)
 		}
 
 		if len(instanceTypes) > maxInstanceTypes {
-			return errors.Errorf("instance selector filters resulted in %d instance types, which is greater than the maximum of %d, please set more selector options", len(instanceTypes), maxInstanceTypes)
+			return fmt.Errorf("instance selector filters resulted in %d instance types, which is greater than the maximum of %d, please set more selector options", len(instanceTypes), maxInstanceTypes)
 		}
 
 		switch ng := np.(type) {
@@ -169,7 +169,7 @@ func (n *NodeGroupService) ExpandInstanceSelectorOptions(nodePools []api.NodePoo
 			}
 
 		default:
-			return errors.Errorf("unhandled NodePool type %T", np)
+			return fmt.Errorf("unhandled NodePool type %T", np)
 		}
 	}
 	return nil
@@ -193,7 +193,7 @@ func (n *NodeGroupService) expandInstanceSelector(ins *api.InstanceSelector, azs
 	if ins.Memory != "" {
 		memory, err := bytequantity.ParseToByteQuantity(ins.Memory)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value %q for instanceSelector.memory", ins.Memory)
+			return nil, fmt.Errorf("invalid value %q for instanceSelector.memory: %w", ins.Memory, err)
 		}
 		filters.MemoryRange = &selector.ByteQuantityRangeFilter{
 			LowerBound: memory,
@@ -219,7 +219,7 @@ func (n *NodeGroupService) expandInstanceSelector(ins *api.InstanceSelector, azs
 	if ins.Allow != nil {
 		regexVal, err := regexp.Compile(*ins.Allow)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value %q for instanceSelector.allow", *ins.Allow)
+			return nil, fmt.Errorf("invalid value %q for instanceSelector.allow: %w", *ins.Allow, err)
 		}
 		filters.AllowList = regexVal
 	}
@@ -227,14 +227,14 @@ func (n *NodeGroupService) expandInstanceSelector(ins *api.InstanceSelector, azs
 	if ins.Deny != nil {
 		regexVal, err := regexp.Compile(*ins.Deny)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value %q for instanceSelector.deny", *ins.Deny)
+			return nil, fmt.Errorf("invalid value %q for instanceSelector.deny: %w", *ins.Deny, err)
 		}
 		filters.DenyList = regexVal
 	}
 
 	instanceTypes, err := n.instanceSelector.Filter(context.TODO(), filters)
 	if err != nil {
-		return nil, errors.Wrap(err, "error querying instance types for the specified instance selector criteria")
+		return nil, fmt.Errorf("error querying instance types for the specified instance selector criteria: %w", err)
 	}
 	if len(instanceTypes) == 0 {
 		return nil, errors.New("instance selector criteria matched no instances; consider broadening your criteria so that more instance types are returned")
@@ -265,7 +265,7 @@ func DoAllNodegroupStackTasks(taskTree *tasks.TaskTree, region, name string) err
 func ValidateExistingNodeGroupsForCompatibility(ctx context.Context, cfg *api.ClusterConfig, stackManager manager.StackManager) error {
 	infoByNodeGroup, err := stackManager.DescribeNodeGroupStacksAndResources(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting resources for all nodegroup stacks")
+		return fmt.Errorf("getting resources for all nodegroup stacks: %w", err)
 	}
 	if len(infoByNodeGroup) == 0 {
 		return nil

--- a/pkg/fargate/delete.go
+++ b/pkg/fargate/delete.go
@@ -2,12 +2,12 @@ package fargate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 )
 
 // DeleteProfile drains and delete the Fargate profile with the provided name.
@@ -18,7 +18,7 @@ func (c *Client) DeleteProfile(ctx context.Context, name string, waitForDeletion
 	out, err := c.api.DeleteFargateProfile(ctx, deleteRequest(c.clusterName, name))
 	logger.Debug("Fargate profile: delete request: received: %#v", out)
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete Fargate profile %q", name)
+		return fmt.Errorf("failed to delete Fargate profile %q: %w", name, err)
 	}
 	if waitForDeletion {
 		return c.waitForDeletion(ctx, name)

--- a/pkg/fargate/get.go
+++ b/pkg/fargate/get.go
@@ -2,12 +2,12 @@ package fargate
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/utils/strings"
@@ -18,7 +18,7 @@ import (
 func (c *Client) ReadProfile(ctx context.Context, name string) (*api.FargateProfile, error) {
 	out, err := c.api.DescribeFargateProfile(ctx, describeRequest(c.clusterName, name))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get Fargate profile %q", name)
+		return nil, fmt.Errorf("failed to get Fargate profile %q: %w", name, err)
 	}
 	logger.Debug("Fargate profile: describe request: received: %#v", out)
 	return toFargateProfile(out.FargateProfile), nil
@@ -65,7 +65,7 @@ func (c *Client) sendListRequestOnce(ctx context.Context, request *eks.ListFarga
 	logger.Debug("Fargate profile: list request: sending: %#v", request)
 	out, err := c.api.ListFargateProfiles(ctx, request)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get Fargate profile(s) for cluster %q", c.clusterName)
+		return nil, fmt.Errorf("failed to get Fargate profile(s) for cluster %q: %w", c.clusterName, err)
 	}
 	logger.Debug("Fargate profile: list request: received %v profile(s): %#v", len(out.FargateProfileNames), out)
 	return out, nil

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -1,10 +1,10 @@
 package gitops
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -24,7 +24,7 @@ func Setup(kubeconfigPath string, k8sRestConfig *rest.Config, k8sClientSet kubec
 	installer, err := flux.New(k8sClientSet, cfg.GitOps)
 	logger.Info("gitops configuration detected, setting installer to Flux v2")
 	if err != nil {
-		return errors.Wrapf(err, "could not initialise Flux installer")
+		return fmt.Errorf("could not initialise Flux installer: %w", err)
 	}
 
 	return installer.Run()

--- a/pkg/iam/iam.go
+++ b/pkg/iam/iam.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/awsapi"
@@ -28,7 +27,7 @@ func ImportInstanceRoleFromProfileARN(ctx context.Context, iamAPI awsapi.IAM, ng
 	}
 	output, err := iamAPI.GetInstanceProfile(ctx, input)
 	if err != nil {
-		return errors.Wrap(err, "importing instance role ARN")
+		return fmt.Errorf("importing instance role ARN: %w", err)
 	}
 
 	roles := output.InstanceProfile.Roles

--- a/pkg/kops/kops.go
+++ b/pkg/kops/kops.go
@@ -9,7 +9,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -83,7 +82,7 @@ func (k *Wrapper) UseVPC(ctx context.Context, ec2API awsapi.EC2, spec *api.Clust
 
 	logger.Debug("subnets = %#v", spec.VPC.Subnets)
 	if err := spec.HasSufficientSubnets(); err != nil {
-		return errors.Wrapf(err, "using VPC from kops cluster %q", k.clusterName)
+		return fmt.Errorf("using VPC from kops cluster %q: %w", k.clusterName, err)
 	}
 	return nil
 }

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -8,7 +9,6 @@ import (
 	"github.com/blang/semver/v4"
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -120,7 +120,7 @@ func (c *RawClient) new() (*RawClient, error) {
 				Err: err,
 			}
 		}
-		return nil, errors.Wrap(err, "getting list of API resources for raw REST client")
+		return nil, fmt.Errorf("getting list of API resources for raw REST client: %w", err)
 	}
 
 	c.mapper = restmapper.NewDiscoveryRESTMapper(apiGroupResources)
@@ -133,7 +133,7 @@ func (c *RawClient) new() (*RawClient, error) {
 	}
 
 	if err := restclient.SetKubernetesDefaults(c.config); err != nil {
-		return nil, errors.Wrap(err, "applying defaults for REST client")
+		return nil, fmt.Errorf("applying defaults for REST client: %w", err)
 	}
 	return c, nil
 }
@@ -141,12 +141,12 @@ func (c *RawClient) new() (*RawClient, error) {
 func getServerVersion(discoveryClient discovery.DiscoveryInterface) (string, error) {
 	v, err := discoveryClient.ServerVersion()
 	if err != nil {
-		return "", errors.Wrapf(err, "getting Kubernetes API version")
+		return "", fmt.Errorf("getting Kubernetes API version: %w", err)
 	}
 
 	sv, err := semver.ParseTolerant(v.GitVersion)
 	if err != nil {
-		return "", errors.Wrapf(err, "parsing Kubernetes API version")
+		return "", fmt.Errorf("parsing Kubernetes API version: %w", err)
 	}
 
 	sv.Pre = nil   // clear extra info
@@ -168,7 +168,7 @@ func (c *RawClient) ClientSet() Interface { return c.clientSet }
 func (c *RawClient) NewHelperFor(gvk schema.GroupVersionKind) (*resource.Helper, error) {
 	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version, "")
 	if err != nil {
-		return nil, errors.Wrapf(err, "constructing REST client mapping for %s", gvk.String())
+		return nil, fmt.Errorf("constructing REST client mapping for %s: %w", gvk.String(), err)
 	}
 
 	switch gvk.Group {
@@ -182,7 +182,7 @@ func (c *RawClient) NewHelperFor(gvk schema.GroupVersionKind) (*resource.Helper,
 
 	client, err := restclient.RESTClientFor(c.config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "constructing REST client for %s", gvk.String())
+		return nil, fmt.Errorf("constructing REST client for %s: %w", gvk.String(), err)
 	}
 
 	return resource.NewHelper(client, mapping), nil
@@ -327,7 +327,7 @@ func (r *RawResource) LogAction(plan bool, verb string) string {
 func (r *RawResource) CreateOrReplace(plan bool) (string, error) {
 	_, exists, err := r.Get()
 	if err != nil {
-		return "", errors.Wrap(err, "unexpected non-404 error")
+		return "", fmt.Errorf("unexpected non-404 error: %w", err)
 	}
 	if !exists {
 		if !plan {
@@ -341,7 +341,7 @@ func (r *RawResource) CreateOrReplace(plan bool) (string, error) {
 
 	convertedObj, err := scheme.Scheme.ConvertToVersion(r.Info.Object, r.GVK.GroupVersion())
 	if err != nil {
-		return "", errors.Wrapf(err, "converting object")
+		return "", fmt.Errorf("converting object: %w", err)
 	}
 	scheme.Scheme.Default(convertedObj)
 	if !plan {
@@ -392,7 +392,7 @@ func (r *RawResource) CreatePatchOrReplace() error {
 
 	convertedObj, err := scheme.Scheme.ConvertToVersion(r.Info.Object.DeepCopyObject(), r.GVK.GroupVersion())
 	if err != nil {
-		return errors.Wrapf(err, "converting object")
+		return fmt.Errorf("converting object: %w", err)
 	}
 	scheme.Scheme.Default(convertedObj)
 	newData, err := runtime.Encode(unstructured.UnstructuredJSONScheme, convertedObj)

--- a/pkg/kubernetes/manifests.go
+++ b/pkg/kubernetes/manifests.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,7 +93,7 @@ func AppendFlattened(components *metav1.List, component runtime.RawExtension) er
 	}
 	obj, err := runtime.Decode(scheme.Codecs.UniversalDeserializer(), component.Raw)
 	if err != nil {
-		return errors.Wrapf(err, "decoding object")
+		return fmt.Errorf("decoding object: %w", err)
 	}
 	return AppendFlattened(components, runtime.RawExtension{Object: obj})
 }

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +48,7 @@ func CheckNamespaceExists(clientSet Interface, name string) (bool, error) {
 		return true, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return false, errors.Wrapf(err, "checking whether namespace %q exists", name)
+		return false, fmt.Errorf("checking whether namespace %q exists: %w", name, err)
 	}
 	return false, nil
 }

--- a/pkg/kubernetes/nodegroup.go
+++ b/pkg/kubernetes/nodegroup.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -16,7 +15,7 @@ func GetNodegroupKubernetesVersion(nodes v1.NodeInterface, ngName string) (strin
 		LabelSelector: fmt.Sprintf("%s=%s", api.NodeGroupNameLabel, ngName),
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "failed to list nodes")
+		return "", fmt.Errorf("failed to list nodes: %w", err)
 	} else if len(n.Items) == 0 {
 		return "", nil
 	}

--- a/pkg/kubernetes/serviceaccount.go
+++ b/pkg/kubernetes/serviceaccount.go
@@ -2,9 +2,9 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,7 @@ func CheckServiceAccountExists(clientSet Interface, meta metav1.ObjectMeta) (boo
 	sa, err := clientSet.CoreV1().ServiceAccounts(meta.Namespace).Get(context.TODO(), meta.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return false, false, errors.Wrapf(err, "checking whether serviceaccount %q exists", name)
+			return false, false, fmt.Errorf("checking whether serviceaccount %q exists: %w", name, err)
 		}
 		return false, false, nil
 	}

--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -2,12 +2,12 @@ package managed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
-	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
@@ -55,7 +55,7 @@ func (m *Service) GetHealth(ctx context.Context, nodeGroupName string) ([]Health
 	output, err := m.eksAPI.DescribeNodegroup(ctx, input)
 	if err != nil {
 		if IsNotFound(err) {
-			return nil, errors.Wrapf(err, "could not find a managed nodegroup with name %q", nodeGroupName)
+			return nil, fmt.Errorf("could not find a managed nodegroup with name %q: %w", nodeGroupName, err)
 		}
 		return nil, err
 	}

--- a/pkg/nodebootstrap/al2.go
+++ b/pkg/nodebootstrap/al2.go
@@ -1,8 +1,9 @@
 package nodebootstrap
 
 import (
+	"fmt"
+
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap/assets"
@@ -31,7 +32,7 @@ func (b *AmazonLinux2) UserData() (string, error) {
 
 	body, err := linuxConfig(b.clusterConfig, al2BootScript, assets.BootstrapAl2Sh, b.clusterDNS, b.ng, scripts...)
 	if err != nil {
-		return "", errors.Wrap(err, "encoding user data")
+		return "", fmt.Errorf("encoding user data: %w", err)
 	}
 
 	logger.Debug("user-data = %s", body)

--- a/pkg/nodebootstrap/bottlerocket.go
+++ b/pkg/nodebootstrap/bottlerocket.go
@@ -2,11 +2,11 @@ package nodebootstrap
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
 	toml "github.com/pelletier/go-toml"
-	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 )
 
@@ -37,7 +37,7 @@ func (b *Bottlerocket) UserData() (string, error) {
 		"settings": *ng.Bottlerocket.Settings,
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "error loading user provided settings")
+		return "", fmt.Errorf("error loading user provided settings: %w", err)
 	}
 
 	// All input settings key names need to be checked & protected against
@@ -85,7 +85,7 @@ func extractKubernetesSettings(np api.NodePool) (map[string]interface{}, error) 
 	if val, ok := settings["kubernetes"]; ok {
 		kubernetesSettings, ok = val.(map[string]interface{})
 		if !ok {
-			return nil, errors.Errorf("expected settings.kubernetes to be of type %T; got %T", kubernetesSettings, val)
+			return nil, fmt.Errorf("expected settings.kubernetes to be of type %T; got %T", kubernetesSettings, val)
 		}
 	} else {
 		kubernetesSettings = make(map[string]interface{})

--- a/pkg/nodebootstrap/managed_al2.go
+++ b/pkg/nodebootstrap/managed_al2.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	nodeadm "github.com/awslabs/amazon-eks-ami/nodeadm/api/v1alpha1"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -101,7 +100,7 @@ func createMimeMessage(writer io.Writer, scripts, cloudboots []string, nodeConfi
 	mw := multipart.NewWriter(writer)
 	if mimeBoundary != "" {
 		if err := mw.SetBoundary(mimeBoundary); err != nil {
-			return errors.Wrap(err, "unexpected error setting MIME boundary")
+			return fmt.Errorf("unexpected error setting MIME boundary: %w", err)
 		}
 	}
 	fmt.Fprint(writer, "MIME-Version: 1.0\r\n")

--- a/pkg/nodebootstrap/managed_bottlerocket.go
+++ b/pkg/nodebootstrap/managed_bottlerocket.go
@@ -2,9 +2,10 @@ package nodebootstrap
 
 import (
 	"encoding/base64"
+	"errors"
+	"fmt"
 
 	toml "github.com/pelletier/go-toml"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 )
@@ -32,7 +33,7 @@ func (b *ManagedBottlerocket) UserData() (string, error) {
 		"settings": *b.ng.Bottlerocket.Settings,
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "error loading user-provided Bottlerocket settings")
+		return "", fmt.Errorf("error loading user-provided Bottlerocket settings: %w", err)
 	}
 
 	// Check and protect all input key names against TOML's dotted key semantics.
@@ -41,7 +42,7 @@ func (b *ManagedBottlerocket) UserData() (string, error) {
 	if enableAdminContainer := b.ng.Bottlerocket.EnableAdminContainer; enableAdminContainer != nil {
 		const adminContainerEnabledKey = "settings.host-containers.admin.enabled"
 		if settings.Has(adminContainerEnabledKey) {
-			return "", errors.Errorf("cannot set both bottlerocket.enableAdminContainer and %s", adminContainerEnabledKey)
+			return "", fmt.Errorf("cannot set both bottlerocket.enableAdminContainer and %s", adminContainerEnabledKey)
 		}
 		settings.Set(adminContainerEnabledKey, *enableAdminContainer)
 	}
@@ -78,14 +79,14 @@ func validateBottlerocketSettings(kubernetesSettings map[string]interface{}) err
 	clusterBootstrapKeys := []string{"cluster-certificate", "api-server", "cluster-name", "cluster-dns-ip"}
 	for _, k := range clusterBootstrapKeys {
 		if _, ok := kubernetesSettings[k]; ok {
-			return errors.Errorf("cannot set settings.kubernetes.%s; EKS automatically injects cluster bootstrapping fields into user-data", k)
+			return fmt.Errorf("cannot set settings.kubernetes.%s; EKS automatically injects cluster bootstrapping fields into user-data", k)
 		}
 	}
 
 	apiFields := []string{"node-labels", "node-taints"}
 	for _, k := range apiFields {
 		if _, ok := kubernetesSettings[k]; ok {
-			return errors.Errorf("cannot set settings.kubernetes.%s; labels and taints should be set on the managedNodeGroup object", k)
+			return fmt.Errorf("cannot set settings.kubernetes.%s; labels and taints should be set on the managedNodeGroup object", k)
 		}
 	}
 

--- a/pkg/nodebootstrap/ubuntu.go
+++ b/pkg/nodebootstrap/ubuntu.go
@@ -1,8 +1,9 @@
 package nodebootstrap
 
 import (
+	"fmt"
+
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap/assets"
@@ -29,7 +30,7 @@ func NewUbuntuBootstrapper(clusterConfig *api.ClusterConfig, np api.NodePool, cl
 func (b *Ubuntu) UserData() (string, error) {
 	body, err := linuxConfig(b.clusterConfig, ubuntuBootScript, assets.BootstrapUbuntuSh, b.clusterDNS, b.np)
 	if err != nil {
-		return "", errors.Wrap(err, "encoding user data")
+		return "", fmt.Errorf("encoding user data: %w", err)
 	}
 
 	logger.Debug("user-data = %s", body)

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap/assets"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap/utils"
 
@@ -57,7 +55,7 @@ func NewBootstrapper(clusterConfig *api.ClusterConfig, ng *api.NodeGroup) (Boots
 	case api.NodeImageFamilyAmazonLinux2:
 		return NewAL2Bootstrapper(clusterConfig, ng, clusterDNS), nil
 	default:
-		return nil, errors.Errorf("unrecognized AMI family %q for creating bootstrapper", ng.AMIFamily)
+		return nil, fmt.Errorf("unrecognized AMI family %q for creating bootstrapper", ng.AMIFamily)
 
 	}
 }
@@ -117,7 +115,7 @@ func GetClusterDNS(clusterConfig *api.ClusterConfig) (string, error) {
 
 	parsedIP, _, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
-		return "", errors.Wrapf(err, "unexpected error parsing KubernetesNetworkConfig service CIDR: %q", serviceCIDR)
+		return "", fmt.Errorf("unexpected error parsing KubernetesNetworkConfig service CIDR: %q: %w", serviceCIDR, err)
 	}
 	return toClusterDNS(parsedIP), nil
 }
@@ -159,7 +157,7 @@ func linuxConfig(clusterConfig *api.ClusterConfig, bootScriptName, bootScriptCon
 
 	body, err := config.Encode()
 	if err != nil {
-		return "", errors.Wrap(err, "encoding user data")
+		return "", fmt.Errorf("encoding user data: %w", err)
 	}
 
 	return body, nil

--- a/pkg/printers/table.go
+++ b/pkg/printers/table.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"k8s.io/kops/util/pkg/tables"
 )
 
@@ -36,7 +35,7 @@ func (t *TablePrinter) PrintObj(obj interface{}, writer io.Writer) error {
 func (t *TablePrinter) PrintObjWithKind(kind string, obj interface{}, writer io.Writer) error {
 	itemsValue := reflect.ValueOf(obj)
 	if itemsValue.Kind() != reflect.Slice {
-		return errors.Errorf("table printer expects a slice but the kind was %v", itemsValue.Kind())
+		return fmt.Errorf("table printer expects a slice but the kind was %v", itemsValue.Kind())
 	}
 
 	if itemsValue.Len() == 0 {

--- a/pkg/utils/ipnet/ipnet.go
+++ b/pkg/utils/ipnet/ipnet.go
@@ -8,10 +8,9 @@ package ipnet
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 var nullString = "null"
@@ -72,12 +71,12 @@ func (ipnet *IPNet) UnmarshalJSON(b []byte) (err error) {
 	var cidr string
 	err = json.Unmarshal(b, &cidr)
 	if err != nil {
-		return errors.Wrap(err, "failed to Unmarshal string")
+		return fmt.Errorf("failed to Unmarshal string: %w", err)
 	}
 
 	ip, net, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return errors.Wrap(err, "failed to Parse cidr string to net.IPNet")
+		return fmt.Errorf("failed to Parse cidr string to net.IPNet: %w", err)
 	}
 
 	// This check is needed in order to work around a strange quirk in the Go

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/kballard/go-shellquote"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -334,7 +333,7 @@ func lockConfigFile(filePath string) (*flock.Flock, error) {
 	flock := flock.New(lockFileName)
 	err := flock.Lock()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to obtain exclusive lock on kubeconfig lockfile")
+		return nil, fmt.Errorf("failed to obtain exclusive lock on kubeconfig lockfile: %w", err)
 	}
 
 	return flock, nil
@@ -343,7 +342,7 @@ func lockConfigFile(filePath string) (*flock.Flock, error) {
 func unlockConfigFile(fl *flock.Flock) error {
 	err := fl.Unlock()
 	if err != nil {
-		return errors.Wrap(err, "failed to release exclusive lock on kubeconfig lockfile")
+		return fmt.Errorf("failed to release exclusive lock on kubeconfig lockfile: %w", err)
 	}
 
 	return nil
@@ -369,7 +368,7 @@ func Write(path string, newConfig clientcmdapi.Config, setContext bool) (string,
 
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to read existing kubeconfig file %q", path)
+		return "", fmt.Errorf("unable to read existing kubeconfig file %q: %w", path, err)
 	}
 
 	logger.Debug("merging kubeconfig files")
@@ -381,7 +380,7 @@ func Write(path string, newConfig clientcmdapi.Config, setContext bool) (string,
 	}
 
 	if err := clientcmd.ModifyConfig(configAccess, *merged, true); err != nil {
-		return "", errors.Wrapf(err, "unable to modify kubeconfig %s", path)
+		return "", fmt.Errorf("unable to modify kubeconfig %s: %w", path, err)
 	}
 
 	return configFileName, nil
@@ -417,11 +416,11 @@ func AutoPath(name string) string {
 func isValidConfig(p, name string) error {
 	clientConfig, err := clientcmd.LoadFromFile(p)
 	if err != nil {
-		return errors.Wrapf(err, "unable to load config %q", p)
+		return fmt.Errorf("unable to load config %q: %w", p, err)
 	}
 
 	if err := clientcmd.ConfirmUsable(*clientConfig, ""); err != nil {
-		return errors.Wrapf(err, "unable to parse config %q", p)
+		return fmt.Errorf("unable to parse config %q: %w", p, err)
 	}
 
 	// we want to make sure we only delete config files that haven't be modified by the user

--- a/pkg/utils/kubectl/kubectl.go
+++ b/pkg/utils/kubectl/kubectl.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 )
 
 const Command = "kubectl"
@@ -95,7 +94,7 @@ func (vm *VersionManager) ServerVersion(env []string, args []string) (string, er
 func (vm *VersionManager) ValidateVersion(version string, vType VersionType) error {
 	parsedVersion, err := semver.Parse(strings.TrimLeft(version, "v"))
 	if err != nil {
-		return errors.Wrapf(err, "parsing kubernetes %s version string %s / %q", vType, version, parsedVersion)
+		return fmt.Errorf("parsing kubernetes %s version string %s / %q: %w", vType, version, parsedVersion, err)
 	}
 	minVersion := getMinVersionForType(vType)
 	if parsedVersion.Compare(getMinVersionForType(vType)) < 0 {

--- a/pkg/utils/taints/taints.go
+++ b/pkg/utils/taints/taints.go
@@ -1,10 +1,9 @@
 package taints
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -17,12 +16,12 @@ func Validate(t corev1.Taint) error {
 	}
 
 	if errs := validation.IsQualifiedName(t.Key); len(errs) > 0 {
-		return errors.Errorf("invalid taint key: %v, %s", t.Key, strings.Join(errs, "; "))
+		return fmt.Errorf("invalid taint key: %v, %s", t.Key, strings.Join(errs, "; "))
 	}
 
 	if t.Value != "" {
 		if errs := validation.IsValidLabelValue(t.Value); len(errs) > 0 {
-			return errors.Errorf("invalid taint value: %v, %s", t.Value, strings.Join(errs, "; "))
+			return fmt.Errorf("invalid taint value: %v, %s", t.Value, strings.Join(errs, "; "))
 		}
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 )
 
 var matchFirstCap = regexp.MustCompile("([0-9]+|[A-Z])")
@@ -40,11 +39,11 @@ func IsMinVersion(minimumVersion, version string) (bool, error) {
 func CompareVersions(a, b string) (int, error) {
 	aVersion, err := semver.ParseTolerant(a)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to parse first version %q", a)
+		return 0, fmt.Errorf("unable to parse first version %q: %w", a, err)
 	}
 	bVersion, err := semver.ParseTolerant(b)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to parse second version %q", b)
+		return 0, fmt.Errorf("unable to parse second version %q: %w", b, err)
 	}
 	return aVersion.Compare(bVersion), nil
 }

--- a/pkg/utils/waiters/waiters.go
+++ b/pkg/utils/waiters/waiters.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 )
 
 // Wait for something with a name to reach status that is expressed by acceptors using newRequest
@@ -30,7 +29,7 @@ func Wait(name, msg string, acceptors []request.WaiterAcceptor, newRequest func(
 				return wrappedErr
 			}
 		}
-		return errors.Wrap(waitErr, msg)
+		return fmt.Errorf("%s: %w", msg, waitErr)
 	}
 	logger.Debug("done after %s of %s", time.Since(startTime), msg)
 	return nil

--- a/pkg/version/parse.go
+++ b/pkg/version/parse.go
@@ -1,10 +1,10 @@
 package version
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 )
 
 // ParseEksctlVersion parses the an eksctl version as semver while ignoring
@@ -14,7 +14,7 @@ func ParseEksctlVersion(raw string) (semver.Version, error) {
 	semverVersion := strings.Split(raw, ExtraSep)[0]
 	v, err := semver.ParseTolerant(semverVersion)
 	if err != nil {
-		return v, errors.Wrapf(err, "unexpected error parsing eksctl version %q", raw)
+		return v, fmt.Errorf("unexpected error parsing eksctl version %q: %w", raw, err)
 	}
 	return v, nil
 }


### PR DESCRIPTION
### Description

This PR replaces usages of the archived package [`github.com/pkg/errors`](https://github.com/pkg/errors) with `errors` and `fmt` packages.

Follows #8256

`github.com/pkg/errors` was not deleted from `ATTRIBUTIONS.md` because it is an indirect dependency for a few packages.

I used these commands to automate the refactoring process: 

```sh
# Update `errors.Wrapf`:
find . -name "*.go" -exec sed -i '' -E 's/errors\.Wrapf\(([^,]+), "([^"]+)", ([^)]+)\)/fmt.Errorf\("\2: %w", \3, \1\)/g' {} +

# Update `errors.Wrap`:
find . -name "*.go" -exec sed -i '' -E 's/errors\.Wrap\(([^,]+), "([^"]+)"\)/fmt.Errorf\("\2: %w", \1\)/g' {} +
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

