### PR TITLE
Allow adding remote network config to private clusters

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -90,14 +90,6 @@ func (c *ClusterConfig) validateRemoteNetworkingConfig() error {
 		return nil
 	}
 
-	if !IsEnabled(c.VPC.ClusterEndpoints.PublicAccess) {
-		return fmt.Errorf("remoteNetworkConfig requires public cluster endpoint access")
-	}
-
-	if c.IsFullyPrivate() {
-		return fmt.Errorf("remoteNetworkConfig is not supported on fully private EKS cluster")
-	}
-
 	if c.IPv6Enabled() {
 		return fmt.Errorf("remoteNetworkConfig is not supported on EKS cluster configured with IPv6 address family")
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -993,16 +993,20 @@ var _ = Describe("ClusterConfig validation", func() {
 				cc.VPC.ClusterEndpoints = &api.ClusterEndpoints{
 					PublicAccess: api.Disabled(),
 				}
+				cc.RemoteNetworkConfig.IAM = &api.RemoteNodesIAM{
+					Provider: aws.String("BLOB"),
+				}
 			},
-			expectedErr: "remoteNetworkConfig requires public cluster endpoint access",
 		}),
 		Entry("fully private EKS cluster", remoteNetworkConfigEntry{
 			overrideConfig: func(cc *api.ClusterConfig) {
 				cc.PrivateCluster = &api.PrivateCluster{
 					Enabled: true,
 				}
+				cc.RemoteNetworkConfig.IAM = &api.RemoteNodesIAM{
+					Provider: aws.String("BLOB"),
+				}
 			},
-			expectedErr: "remoteNetworkConfig is not supported on fully private EKS cluster",
 		}),
 		Entry("IPv6 family", remoteNetworkConfigEntry{
 			overrideConfig: func(cc *api.ClusterConfig) {


### PR DESCRIPTION
### Description

Remove validation rules that prevented remote network config from being used with private clusters.

Tested manually that validation did not fail with ```privateCluster.enabled=true``` added to this file https://github.com/eksctl-io/eksctl/blob/main/examples/43-hybrid-nodes.yaml 
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [X] Added tests that cover your change (if possible)
- [none required] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

