### PR TITLE
Revert "Fix failure when VPC CNI is configured to use both iam.withOIDC and useDefaultPodIdentityAssociations

### DIFF
--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -18,7 +18,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 )
 
-func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvider, iamRoleCreator IAMRoleCreator, podIdentityIAMUpdater PodIdentityIAMUpdater, forceAll bool, timeout time.Duration, region string) (*tasks.TaskTree, *tasks.TaskTree, *tasks.GenericTask, []string) {
+func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvider, iamRoleCreator IAMRoleCreator, forceAll bool, timeout time.Duration, region string) (*tasks.TaskTree, *tasks.TaskTree, *tasks.GenericTask, []string) {
 	var addons []*api.Addon
 	var autoDefaultAddonNames []string
 	if !cfg.AddonsConfig.DisableDefaultAddons {
@@ -97,7 +97,7 @@ func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvid
 				if err := addonManager.waitForAddonToBeActive(ctx, &api.Addon{Name: api.VPCCNIAddon}, api.DefaultWaitTimeout); err != nil {
 					return fmt.Errorf("waiting for %q to become active: %w", api.VPCCNIAddon, err)
 				}
-				return addonManager.Update(ctx, vpcCNIAddon, podIdentityIAMUpdater, clusterProvider.AWSProvider.WaitTimeout())
+				return addonManager.Update(ctx, vpcCNIAddon, nil, clusterProvider.AWSProvider.WaitTimeout())
 			},
 		}
 	}
@@ -174,11 +174,24 @@ func (t *createAddonTask) Do(errorCh chan error) error {
 
 func createAddonManager(ctx context.Context, clusterProvider *eks.ClusterProvider, cfg *api.ClusterConfig) (*Manager, error) {
 	var (
-		oidc *iamoidc.OpenIDConnectManager
+		oidc               *iamoidc.OpenIDConnectManager
+		oidcProviderExists bool
 	)
+	if api.IsEnabled(cfg.IAM.WithOIDC) {
+		var err error
+		oidc, err = clusterProvider.NewOpenIDConnectManager(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		oidcProviderExists, err = oidc.CheckProviderExists(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	stackManager := clusterProvider.NewStackManager(cfg)
 
-	return New(cfg, clusterProvider.AWSProvider.EKS(), stackManager, api.IsEnabled(cfg.IAM.WithOIDC), oidc, func() (kubernetes.Interface, error) {
+	return New(cfg, clusterProvider.AWSProvider.EKS(), stackManager, oidcProviderExists, oidc, func() (kubernetes.Interface, error) {
 		return clusterProvider.NewStdClientSet(cfg)
 	})
 }

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -352,19 +352,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		ClusterName:  cfg.Metadata.Name,
 		StackCreator: stackManager,
 	}
-	piaUpdater := &addon.PodIdentityAssociationUpdater{
-		ClusterName: cmd.ClusterConfig.Metadata.Name,
-		IAMRoleCreator: &podidentityassociation.IAMRoleCreator{
-			ClusterName:  cmd.ClusterConfig.Metadata.Name,
-			StackCreator: stackManager,
-		},
-		IAMRoleUpdater: &podidentityassociation.IAMRoleUpdater{
-			StackUpdater: stackManager,
-		},
-		EKSPodIdentityDescriber: ctl.AWSProvider.EKS(),
-		StackDeleter:            stackManager,
-	}
-	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, piaUpdater, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
+	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
 	if len(autoDefaultAddons) > 0 {
 		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
 	}


### PR DESCRIPTION
Possible culprit in some integration test failures.

This reverts commit 93ba3bcc8f3e2c5aeac94c47e0261fee2583793b.

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

