### PR TITLE
Fix failure when VPC CNI is configured to use both iam.withOIDC and useDefaultPodIdentityAssociations

### DIFF
--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -18,7 +18,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 )
 
-func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvider, iamRoleCreator IAMRoleCreator, forceAll bool, timeout time.Duration, region string) (*tasks.TaskTree, *tasks.TaskTree, *tasks.GenericTask, []string) {
+func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvider, iamRoleCreator IAMRoleCreator, podIdentityIAMUpdater PodIdentityIAMUpdater, forceAll bool, timeout time.Duration, region string) (*tasks.TaskTree, *tasks.TaskTree, *tasks.GenericTask, []string) {
 	var addons []*api.Addon
 	var autoDefaultAddonNames []string
 	if !cfg.AddonsConfig.DisableDefaultAddons {
@@ -97,7 +97,7 @@ func CreateAddonTasks(ctx context.Context, cfg *api.ClusterConfig, clusterProvid
 				if err := addonManager.waitForAddonToBeActive(ctx, &api.Addon{Name: api.VPCCNIAddon}, api.DefaultWaitTimeout); err != nil {
 					return fmt.Errorf("waiting for %q to become active: %w", api.VPCCNIAddon, err)
 				}
-				return addonManager.Update(ctx, vpcCNIAddon, nil, clusterProvider.AWSProvider.WaitTimeout())
+				return addonManager.Update(ctx, vpcCNIAddon, podIdentityIAMUpdater, clusterProvider.AWSProvider.WaitTimeout())
 			},
 		}
 	}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -352,7 +352,19 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		ClusterName:  cfg.Metadata.Name,
 		StackCreator: stackManager,
 	}
-	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
+	piaUpdater := &addon.PodIdentityAssociationUpdater{
+		ClusterName: cmd.ClusterConfig.Metadata.Name,
+		IAMRoleCreator: &podidentityassociation.IAMRoleCreator{
+			ClusterName:  cmd.ClusterConfig.Metadata.Name,
+			StackCreator: stackManager,
+		},
+		IAMRoleUpdater: &podidentityassociation.IAMRoleUpdater{
+			StackUpdater: stackManager,
+		},
+		EKSPodIdentityDescriber: ctl.AWSProvider.EKS(),
+		StackDeleter:            stackManager,
+	}
+	preNodegroupAddons, postAddons, updateVPCCNITask, autoDefaultAddons := addon.CreateAddonTasks(ctx, cfg, ctl, iamRoleCreator, piaUpdater, true, cmd.ProviderConfig.WaitTimeout, meta.Region)
 	if len(autoDefaultAddons) > 0 {
 		logger.Info("default addons %s were not specified, will install them as EKS addons", strings.Join(autoDefaultAddons, ", "))
 	}


### PR DESCRIPTION
xref: https://github.com/eksctl-io/eksctl/issues/8141

During create, we were passing podIdentityIAMUpdater to be nil which caused the panic.

Going to try half of https://github.com/eksctl-io/eksctl/pull/8249