### PR TITLE
Reduce blast radius of test that disables api server public access failing

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -523,6 +523,19 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			}
 		})
 
+		AfterAll(func() {
+			// When the disable public access test below fails, the re-enable public access test is skipped so the
+			// cluster is left in a state where the API server is unreachable. This causes some of the tests later
+			// to fail as well. To avoid this, we need to re-enable public access here so calls to the API
+			// server can be made in subsequent tests.
+			Expect(params.EksctlUtilsCmd.WithArgs(
+				"set-public-access-cidrs",
+				"--cluster", params.ClusterName,
+				"0.0.0.0/0",
+				"--approve",
+			)).To(RunSuccessfully())
+		})
+
 		It("should have public access by default", func() {
 			Expect(k8sAPICall()).ShouldNot(HaveOccurred())
 		})


### PR DESCRIPTION
Looking at the following CI runs:
- https://github.com/eksctl-io/eksctl-ci/actions/runs/13638043732/job/38122199554#step:10:3428
- https://github.com/eksctl-io/eksctl-ci/actions/runs/13638043732/job/38131703449#step:10:3413

When the test that disables public access fails, the next one that re-enables public access is skipped cause the other tests that run later to possibly fail. So let's add an AfterAll here to re-enable public access