### PR TITLE
Allow core/default networking addons on auto-mode clusters with mixed node types

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -44,11 +44,11 @@ var KnownAddons = map[string]struct {
 	},
 }
 
-// HasDefaultAddons reports whether addons contains at least one default addon.
-func HasDefaultAddons(addons []*Addon) bool {
+// HasDefaultNonAutoAddon reports whether addons contains at least one non-auto mode default addon
+func HasDefaultNonAutoAddon(addons []*Addon) bool {
 	for _, addon := range addons {
 		addonConfig, ok := KnownAddons[addon.Name]
-		if ok && addonConfig.IsDefault {
+		if ok && addonConfig.IsDefault && !addonConfig.IsDefaultAutoMode {
 			return true
 		}
 	}

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -317,8 +317,9 @@ func NewCreateClusterLoader(cmd *Cmd, ngFilter *filter.NodeGroupFilter, ng *api.
 				return errors.New("creation of managed or self-managed nodegroups is not supported during cluster creation " +
 					"when Auto Mode is enabled; please create them post cluster creation using `eksctl create nodegroup`" +
 					" after creating core networking addons in the cluster")
-			}
-			if api.HasDefaultAddons(clusterConfig.Addons) {
+			} else if len(clusterConfig.FargateProfiles) == 0 && clusterConfig.RemoteNetworkConfig == nil &&
+				api.HasDefaultNonAutoAddon(clusterConfig.Addons) {
+				// Only an error if fargate profiles and hybrid nodes (remote network config) are not set/defined
 				return errors.New("core networking addons are not required on a cluster using Auto Mode; " +
 					"if you still wish to create them, use `eksctl create addon` post cluster creation")
 			}


### PR DESCRIPTION
### Description

Fixes #8292

This PR allows the creation of default addons on clusters configured for auto mode, if they also have other compute types configured (specifically fargate profiles or hybrid nodes remote networking config, since self managed/managed nodes are not allowed to be created with auto mode clusters).

This also updates the check to only check for non-auto default addons, instead of all default addons. This allows creating, for example, metrics-server, which is a default addon which should be able to be created with auto-mode only clusters.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

