### PR TITLE
Remove redundant 'typecheck' linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,7 +146,6 @@ linters:
         - ineffassign
         - misspell
         - staticcheck
-        - typecheck
         - unused
         # TODO: enable the below linter in the future
 #    - maligned


### PR DESCRIPTION
### Description

This PR removes redundant `typecheck` from the `linters.enable` list.

`typecheck` is not a linter and it doesn't perform any analysis. It's just a way to identify, parse, and display compiling errors and some linter errors.

More info:

- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

