### PR TITLE
Default to newest k8s 1.32 version

### DIFF
--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -636,7 +636,7 @@ var _ = Describe("Update", func() {
 
 		addonManager, err := addon.New(&api.ClusterConfig{
 			Metadata: &api.ClusterMeta{
-				Version: api.Version1_30,
+				Version: api.Version1_32,
 				Name:    clusterName,
 			},
 			AddonsConfig: e.addonsConfig,

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -46,10 +46,11 @@ const (
 	Version1_29                  = "1.29"
 	Version1_30                  = "1.30"
 	Version1_31                  = "1.31"
+	Version1_32                  = "1.32"
 	DockershimDeprecationVersion = Version1_24
 	//TODO: Remove this and replace with output from DescribeClusterVersions endpoint
 	// DefaultVersion (default)
-	DefaultVersion = Version1_30
+	DefaultVersion = Version1_32
 )
 
 const (

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
@@ -346,7 +346,7 @@ const expected = `
 		"metadata": {
 		  "name": "test-3x3-ngs",
 		  "region": "eu-central-1",
-		  "version": "1.30"
+		  "version": "1.32"
 		},
 		"kubernetesNetworkConfig": {
         	"ipFamily": "IPv4"


### PR DESCRIPTION
We have called out
```
	//TODO: Remove this and replace with output from DescribeClusterVersions endpoint
	// DefaultVersion (default)
```

BUT since we are not there yet, let's bump to 1.32 so that the integration tests can use the latest k8s versions.

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

