### PR TITLE
Skip instance type support validation for custom AMI ID

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -249,6 +249,23 @@ var _ = Describe("GPU instance support", func() {
 		}),
 	)
 
+	Describe("No GPU instance type support validation for custom AMI", func() {
+		amiFamily := api.NodeImageFamilyAmazonLinux2023
+		instanceType := "g5g.2xlarge"
+
+		ngFail := api.NewNodeGroup()
+		ngFail.AMIFamily = amiFamily
+		ngFail.InstanceType = instanceType
+
+		ngPass := api.NewNodeGroup()
+		ngPass.AMIFamily = amiFamily
+		ngPass.InstanceType = instanceType
+		ngPass.AMI = "ami-xxxx"
+
+		Expect(api.ValidateNodeGroup(0, ngFail, api.NewClusterConfig())).To(HaveOccurred())
+		Expect(api.ValidateNodeGroup(0, ngPass, api.NewClusterConfig())).NotTo(HaveOccurred())
+	})
+
 	DescribeTable("ARM-based GPU instance type support", func(amiFamily string, expectErr bool) {
 		ng := api.NewNodeGroup()
 		ng.InstanceType = "g5g.2xlarge"
@@ -261,6 +278,7 @@ var _ = Describe("GPU instance support", func() {
 		}
 	},
 		Entry("AmazonLinux2", api.NodeImageFamilyAmazonLinux2, true),
+		Entry("AmazonLinux2023", api.NodeImageFamilyAmazonLinux2023, true),
 		Entry("Ubuntu2004", api.NodeImageFamilyUbuntu2004, true),
 		Entry("Ubuntu1804", api.NodeImageFamilyUbuntu1804, true),
 		Entry("Windows2019Full", api.NodeImageFamilyWindowsServer2019FullContainer, true),

--- a/pkg/nodebootstrap/managed_al2.go
+++ b/pkg/nodebootstrap/managed_al2.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
-	"strings"
 
 	nodeadm "github.com/awslabs/amazon-eks-ami/nodeadm/api/v1alpha1"
 	"sigs.k8s.io/yaml"
@@ -32,7 +31,7 @@ func NewManagedAL2Bootstrapper(ng *api.ManagedNodeGroup) *ManagedAL2 {
 func (m *ManagedAL2) UserData() (string, error) {
 	ng := m.ng
 
-	if strings.HasPrefix(ng.AMI, "ami-") {
+	if api.IsAMI(ng.AMI) {
 		return makeCustomAMIUserData(ng.NodeGroupBase, m.UserDataMimeBoundary)
 	}
 


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

closes: https://github.com/eksctl-io/eksctl/issues/8304

When using a nodegroup with an a custom AMI based on a supported AMIFamily (ex. for an arm64 gpu AL2023 derivative) you will/could be blocked in the validation stage with the error
```
Error: could not create cluster provider from options: ARM GPU instance types are not supported for unmanaged nodegroups with AMIFamily AmazonLinux2023
```

This should be supported for any `AMIFamily` as long as a custom AMI is provided, as we can't make an assumption about the details of the AMI.

### Reproduction

```bash
eksctl create ng -f config.yaml --dry-run
```

using the following config

```yaml
# config.yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: testbed
  region: us-west-2

nodeGroups:
  - name: test-nvidia-arm
    instanceType: g5g.2xlarge
    desiredCapacity: 1
    amiFamily: AmazonLinux2023
    ami: <ami-XXX>
    iam:
       attachPolicyARNs:
          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
```

### Testing

building locally `make build` and running `./eksctl create ng -f config.yaml --dry-run` output valid data. also ran without `--dry-run` to confirm test node launched and joined cluster.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

