### PR TITLE
Allow specification of IAM permission boundary for Auto Mode's Node Role

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -304,11 +304,17 @@
           "$ref": "#/definitions/ARN",
           "description": "node role to use for nodes launched by Auto Mode.",
           "x-intellij-html-description": "node role to use for nodes launched by Auto Mode."
+        },
+        "permissionsBoundaryARN": {
+          "$ref": "#/definitions/ARN",
+          "description": "permissions boundary to use when creating the Auto Mode node role.",
+          "x-intellij-html-description": "permissions boundary to use when creating the Auto Mode node role."
         }
       },
       "preferredOrder": [
         "enabled",
         "nodeRoleARN",
+        "permissionsBoundaryARN",
         "nodePools"
       ],
       "additionalProperties": false

--- a/pkg/apis/eksctl.io/v1alpha5/auto_mode.go
+++ b/pkg/apis/eksctl.io/v1alpha5/auto_mode.go
@@ -49,7 +49,7 @@ func ValidateAutoModeConfig(clusterConfig *ClusterConfig) error {
 				return errors.New("cannot specify autoModeConfig.permissionBoundaryARN when autoModeConfig.nodePools is empty")
 			}
 			if !autoModeConfig.NodeRoleARN.IsZero() && !autoModeConfig.PermissionsBoundaryARN.IsZero() {
-				return errors.New("cannot specify autoModeConfig.permissionBoundaryARN when nodeRoleARN is set")
+				return errors.New("cannot specify autoModeConfig.permissionBoundaryARN when autoModeConfig.nodeRoleARN is set")
 			}
 			seenNodePools := map[string]struct{}{}
 			for _, np := range *autoModeConfig.NodePools {
@@ -63,7 +63,7 @@ func ValidateAutoModeConfig(clusterConfig *ClusterConfig) error {
 			}
 		}
 	} else if !autoModeConfig.PermissionsBoundaryARN.IsZero() || !autoModeConfig.NodeRoleARN.IsZero() || autoModeConfig.HasNodePools() {
-		return errors.New("cannot set autoModeConfig.nodeRoleARN, autoModeConfig.permissionBoundaryARN,  or autoModeConfig.nodePools when Auto Mode is disabled")
+		return errors.New("cannot set autoModeConfig.nodeRoleARN, autoModeConfig.permissionBoundaryARN, or autoModeConfig.nodePools when Auto Mode is disabled")
 	}
 	return nil
 }

--- a/pkg/apis/eksctl.io/v1alpha5/auto_mode_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/auto_mode_validation_test.go
@@ -42,5 +42,20 @@ var _ = DescribeTable("Auto Mode Validation", func(c *api.ClusterConfig, expecte
 			NodeRoleARN: api.MustParseARN("arn:aws:iam::1234:role/CustomNodeRole"),
 			NodePools:   &[]string{api.AutoModeNodePoolGeneralPurpose},
 		},
-	}, "cannot set autoModeConfig.nodeRoleARN or autoModeConfig.nodePools when Auto Mode is disabled"),
+	}, "cannot set autoModeConfig.nodeRoleARN, autoModeConfig.permissionBoundaryARN, or autoModeConfig.nodePools when Auto Mode is disabled"),
+	Entry("permissionsBoundary and nodePools specified when Auto Mode is disabled", &api.ClusterConfig{
+		AutoModeConfig: &api.AutoModeConfig{
+			Enabled:                api.Disabled(),
+			PermissionsBoundaryARN: api.MustParseARN("arn:aws:iam::1234:policy/PermissionsBoundary"),
+			NodePools:              &[]string{api.AutoModeNodePoolGeneralPurpose},
+		},
+	}, "cannot set autoModeConfig.nodeRoleARN, autoModeConfig.permissionBoundaryARN, or autoModeConfig.nodePools when Auto Mode is disabled"),
+	Entry("permissionsBoundary, nodeRoleARN, and nodePools specified", &api.ClusterConfig{
+		AutoModeConfig: &api.AutoModeConfig{
+			Enabled:                api.Enabled(),
+			NodeRoleARN:            api.MustParseARN("arn:aws:iam::1234:role/CustomNodeRole"),
+			PermissionsBoundaryARN: api.MustParseARN("arn:aws:iam::1234:policy/PermissionsBoundary"),
+			NodePools:              &[]string{api.AutoModeNodePoolGeneralPurpose},
+		},
+	}, "cannot specify autoModeConfig.permissionBoundaryARN when autoModeConfig.nodeRoleARN is set"),
 )

--- a/pkg/cfn/builder/auto_mode.go
+++ b/pkg/cfn/builder/auto_mode.go
@@ -31,12 +31,15 @@ type AutoModeRefs struct {
 	NodeRole *gfnt.Value
 }
 
-func AddAutoModeResources(clusterTemplate *gfn.Template) (AutoModeRefs, error) {
+func AddAutoModeResources(clusterTemplate *gfn.Template, permissionsBoundary string) (AutoModeRefs, error) {
 	template, err := goformation.ParseYAML(autoModeNodeRoleTemplate)
 	if err != nil {
 		return AutoModeRefs{}, err
 	}
-	for resourceName, resource := range template.Resources {
+	for resourceName, resource := range template.GetAllIAMRoleResources() {
+		if permissionsBoundary != "" {
+			resource.PermissionsBoundary = gfnt.NewString(permissionsBoundary)
+		}
 		clusterTemplate.Resources[resourceName] = resource
 	}
 	for key, output := range template.Outputs {

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -338,7 +338,7 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(subnetDetails *SubnetDe
 		cluster.ComputeConfig = computeConfig
 		if cc.NodeRoleARN.IsZero() {
 			if cc.HasNodePools() {
-				autoModeRefs, err := AddAutoModeResources(c.rs.template)
+				autoModeRefs, err := AddAutoModeResources(c.rs.template, cc.PermissionsBoundaryARN.String())
 				if err != nil {
 					return fmt.Errorf("error building cluster compute roles: %w", err)
 				}


### PR DESCRIPTION
Potential implementation of feature request #8305.

Introduced a new configuration setting for Auto Mode.

Code validates inputs and sets the permissions boundary on the Auto Mode Node role when it's provided. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

