### PR TITLE
Remove deprecated "set-public-access-cidrs" integration tests

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -500,67 +500,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 		})
 	})
 
-	Context("configuring K8s API", Serial, Ordered, func() {
-		var (
-			k8sAPICall func() error
-		)
-
-		BeforeAll(func() {
-			cfg := makeClusterConfig()
-
-			ctl, err := eks.New(context.TODO(), &api.ProviderConfig{Region: params.Region}, cfg)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = ctl.RefreshClusterStatus(context.Background(), cfg)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			clientSet, err := ctl.NewStdClientSet(cfg)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			k8sAPICall = func() error {
-				_, err = clientSet.CoreV1().ServiceAccounts(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
-				return err
-			}
-		})
-
-		AfterAll(func() {
-			// When the disable public access test below fails, the re-enable public access test is skipped so the
-			// cluster is left in a state where the API server is unreachable. This causes some of the tests later
-			// to fail as well. To avoid this, we need to re-enable public access here so calls to the API
-			// server can be made in subsequent tests.
-			Expect(params.EksctlUtilsCmd.WithArgs(
-				"set-public-access-cidrs",
-				"--cluster", params.ClusterName,
-				"0.0.0.0/0",
-				"--approve",
-			)).To(RunSuccessfully())
-		})
-
-		It("should have public access by default", func() {
-			Expect(k8sAPICall()).ShouldNot(HaveOccurred())
-		})
-
-		It("should disable public access", func() {
-			Expect(params.EksctlUtilsCmd.WithArgs(
-				"set-public-access-cidrs",
-				"--cluster", params.ClusterName,
-				"1.1.1.1/32,2.2.2.0/24",
-				"--approve",
-			)).To(RunSuccessfully())
-			Eventually(k8sAPICall, "5m", "20s").Should(HaveOccurred())
-		})
-
-		It("should re-enable public access", func() {
-			Expect(params.EksctlUtilsCmd.WithArgs(
-				"set-public-access-cidrs",
-				"--cluster", params.ClusterName,
-				"0.0.0.0/0",
-				"--approve",
-			)).To(RunSuccessfully())
-			Expect(k8sAPICall()).ShouldNot(HaveOccurred())
-		})
-	})
-
 	Context("configuring Cloudwatch logging", Serial, Ordered, func() {
 		var (
 			cfg *api.ClusterConfig


### PR DESCRIPTION
### Description

This PR removes the integration tests for `eksctl utils set-public-access-cidrs`

Tried fixing these flaky tests with a few different mechanisms including manually sleeps, timeouts, etc, but they remain to be flaky.

Since this functionality has a warning deprecation to be removed in the future anyways (in favor of more generic vpc-config), removing these tests for now to unblock the remaining integration tests. We can add in other integration tests around the `update-cluster-vpc-config` command in the future as needed.

Note: `Command "set-public-access-cidrs" is deprecated, this command is deprecated and will be removed soon. Use eksctl utils update-cluster-vpc-config --public-access-cidrs=<> instead.`

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

