### PR TITLE
Fix auto mode creation when no permissions boundary is set

### DIFF
--- a/pkg/cfn/builder/auto_mode.go
+++ b/pkg/cfn/builder/auto_mode.go
@@ -31,14 +31,14 @@ type AutoModeRefs struct {
 	NodeRole *gfnt.Value
 }
 
-func AddAutoModeResources(clusterTemplate *gfn.Template, permissionsBoundary string) (AutoModeRefs, error) {
+func AddAutoModeResources(clusterTemplate *gfn.Template, permissionsBoundary api.ARN) (AutoModeRefs, error) {
 	template, err := goformation.ParseYAML(autoModeNodeRoleTemplate)
 	if err != nil {
 		return AutoModeRefs{}, err
 	}
 	for resourceName, resource := range template.GetAllIAMRoleResources() {
-		if permissionsBoundary != "" {
-			resource.PermissionsBoundary = gfnt.NewString(permissionsBoundary)
+		if !permissionsBoundary.IsZero() {
+			resource.PermissionsBoundary = gfnt.NewString(permissionsBoundary.String())
 		}
 		clusterTemplate.Resources[resourceName] = resource
 	}

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -338,7 +338,7 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(subnetDetails *SubnetDe
 		cluster.ComputeConfig = computeConfig
 		if cc.NodeRoleARN.IsZero() {
 			if cc.HasNodePools() {
-				autoModeRefs, err := AddAutoModeResources(c.rs.template, cc.PermissionsBoundaryARN.String())
+				autoModeRefs, err := AddAutoModeResources(c.rs.template, cc.PermissionsBoundaryARN)
 				if err != nil {
 					return fmt.Errorf("error building cluster compute roles: %w", err)
 				}


### PR DESCRIPTION
### Description

After merging #8307, creation of clusters with auto mode without an explicit permissions boundary broke because they were getting set with the 'zero' arn value of `arn:::::`, this fixes that bug.

Tested by manually creating clusters before and after.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

