### PR TITLE
Enable creating IPV6 clusters with pod identities in addition to IRSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ logs/*
 
 # Ignore social cards cache
 userdocs/.cache/*
+
+# Visual Studio Code
+.vscode/

--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -115,7 +115,7 @@ func (a Addon) Validate() error {
 
 	if a.HasPodIDsSet() {
 		if a.CanonicalName() == PodIdentityAgentAddon {
-			return invalidAddonConfigErr(fmt.Sprintf("cannot set pod identity associtations for %q addon", PodIdentityAgentAddon))
+			return invalidAddonConfigErr(fmt.Sprintf("cannot set pod identity associations for %q addon", PodIdentityAgentAddon))
 		}
 
 		for i, pia := range *a.PodIdentityAssociations {

--- a/pkg/apis/eksctl.io/v1alpha5/addon_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Addon", func() {
 					Name:                    api.PodIdentityAgentAddon,
 					PodIdentityAssociations: &[]api.PodIdentityAssociation{{}},
 				},
-				expectedErr: "cannot set pod identity associtations for \"eks-pod-identity-agent\" addon",
+				expectedErr: "cannot set pod identity associations for \"eks-pod-identity-agent\" addon",
 			}),
 			Entry("namespace is not set", addonWithPodIDEntry{
 				addon: api.Addon{

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -609,7 +609,6 @@ func (c *ClusterConfig) validateKubernetesNetworkConfig() error {
 				return fmt.Errorf("the default core addons must be defined for IPv6; missing addon(s): %s; either define them or use EKS Auto Mode", strings.Join(missing, ", "))
 			}
 			if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) != 0 && (c.IAM == nil || c.IAM != nil && IsDisabled(c.IAM.WithOIDC)) {
-
 				return fmt.Errorf("either pod identity or oidc needs to be enabled if IPv6 is set; set either one or use EKS Auto Mode")
 			}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -536,6 +535,15 @@ func (c *ClusterConfig) addonContainsManagedAddons(addons []string) []string {
 	return missing
 }
 
+func (c *ClusterConfig) getAddon(name string) *Addon {
+	for _, addon := range c.Addons {
+		if addon.Name == name {
+			return addon
+		}
+	}
+	return nil
+}
+
 // ValidateClusterEndpointConfig checks the endpoint configuration for potential issues
 func (c *ClusterConfig) ValidateClusterEndpointConfig() error {
 	if c.VPC.ClusterEndpoints != nil {
@@ -614,7 +622,7 @@ func (c *ClusterConfig) validateKubernetesNetworkConfig() error {
 
 			if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) == 0 && !c.AddonsConfig.AutoApplyPodIdentityAssociations {
 				// Assuming user intends to use pod identities if the pod identity agent addon is added.
-				vpcCNIAddonEntry := c.Addons[slices.IndexFunc(c.Addons, func(a *Addon) bool { return a.Name == VPCCNIAddon })]
+				vpcCNIAddonEntry := c.getAddon(VPCCNIAddon)
 
 				if !vpcCNIAddonEntry.UseDefaultPodIdentityAssociations &&
 					(vpcCNIAddonEntry.PodIdentityAssociations == nil || (vpcCNIAddonEntry.PodIdentityAssociations != nil && len(*vpcCNIAddonEntry.PodIdentityAssociations) == 0)) {

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -616,20 +616,24 @@ func (c *ClusterConfig) validateKubernetesNetworkConfig() error {
 			if missing := c.addonContainsManagedAddons([]string{VPCCNIAddon, CoreDNSAddon, KubeProxyAddon}); len(missing) != 0 {
 				return fmt.Errorf("the default core addons must be defined for IPv6; missing addon(s): %s; either define them or use EKS Auto Mode", strings.Join(missing, ", "))
 			}
+
+			// Check if at least one credential provider (Pod identity or IRSA) is configured
 			if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) != 0 && (c.IAM == nil || c.IAM != nil && IsDisabled(c.IAM.WithOIDC)) {
 				return errors.New("either pod identity or oidc needs to be enabled if IPv6 is set; set either one or use EKS Auto Mode")
 			}
 
+			// If the pod identity addon is present, verify it is correctly configured for use by the VPC CNI addon
+			// Assuming user intends to use pod identities if the pod identity agent addon is added.
 			if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) == 0 && !c.AddonsConfig.AutoApplyPodIdentityAssociations {
-				// Assuming user intends to use pod identities if the pod identity agent addon is added.
 				vpcCNIAddonEntry := c.getAddon(VPCCNIAddon)
 
 				if vpcCNIAddonEntry == nil {
+					// should be unreachable
 					return errors.New("the vpc-cni addon must be defined for IPv6; either define it or use EKS Auto Mode")
 				}
 
 				if !vpcCNIAddonEntry.UseDefaultPodIdentityAssociations &&
-					(vpcCNIAddonEntry.PodIdentityAssociations == nil || (vpcCNIAddonEntry.PodIdentityAssociations != nil && len(*vpcCNIAddonEntry.PodIdentityAssociations) == 0)) {
+					(vpcCNIAddonEntry.PodIdentityAssociations == nil || len(*vpcCNIAddonEntry.PodIdentityAssociations) == 0) {
 					return fmt.Errorf("Set one of: addonsConfig.autoApplyPodIdentityAssociations, useDefaultPodIdentityAssociations on the vpc-cni addon, apply a custom pod identity on the vpc-cni addon")
 				}
 			}

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1194,7 +1194,6 @@ var _ = Describe("ClusterConfig validation", func() {
 							cfg.Addons = append(cfg.Addons, &api.Addon{Name: api.VPCCNIAddon})
 							err = api.ValidateClusterConfig(cfg)
 							Expect(err).To(MatchError(ContainSubstring("either pod identity or oidc needs to be enabled if IPv6 is set; set either one or use EKS Auto Mode")))
-
 						})
 					})
 


### PR DESCRIPTION
- **Fix typo on "associations"**
- **Add VS Code folder to gitignore**
- **Enable creating IPV6 clusters with pod identities**

### Description

Currently, creating an IPV6 cluster fails validation if `withOIDC` is not set to `true`. Since the advent of EKS pod identities, OIDC is no longer necessary as long as the pod identity agent is added, and the VPC CNI addon is configured with a pod identity association. Updated the validation logic to allow either pod identities or IRSA for IPV6 clusters.

Unrelated: caught two typos and added the VS Code folder to the gitignore since that's my IDE of choice (and a pretty common one at that).

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

