### PR TITLE
Disable eks-pod-identity-agent check in case of EKS auto mode

### DIFF
--- a/pkg/actions/podidentityassociation/migrator.go
+++ b/pkg/actions/podidentityassociation/migrator.go
@@ -215,6 +215,16 @@ func (m *Migrator) MigrateToPodIdentity(ctx context.Context, options PodIdentity
 }
 
 func IsPodIdentityAgentInstalled(ctx context.Context, eksAPI awsapi.EKS, clusterName string) (bool, error) {
+	// If the cluster is using "auto mode", don't check for the podIdentity agent addon
+	clusterOutput, err := eksAPI.DescribeCluster(ctx, &awseks.DescribeClusterInput{
+		Name: aws.String(clusterName),
+	})
+	if err == nil && clusterOutput.Cluster != nil {
+		if *clusterOutput.Cluster.ComputeConfig.Enabled {
+			return true, nil
+		}
+	}
+
 	if _, err := eksAPI.DescribeAddon(ctx, &awseks.DescribeAddonInput{
 		AddonName:   aws.String(api.PodIdentityAgentAddon),
 		ClusterName: &clusterName,


### PR DESCRIPTION
### Description

Fixes the error:
```
eksctl create podidentityassociation  .....            
Error: the "eks-pod-identity-agent" addon must be installed to create pod identity associations; please enable it using `eksctl ....
```

eksctl does not check whether EKS is using auto-mode or not. In EKS auto-mode, there is no need to check whether the eks-pod-identity-agent is installed or not, because eks-pod-identity-agent is part of the EKS auto-mode.
I added a check to the IsPodIdentityAgentInstalled function that verifies if the EKS cluster is using auto-mode and, if necessary, skips the check for the eks-pod-identity-agent.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

