### PR TITLE
Fix CoreDNS scheduling on Fargate failing when component label in selector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.65
-	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.3
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.4
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.4
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.3

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.33 h1:/frG8aV09yhCVSOEC2pzktflJJO
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.33/go.mod h1:8vwASlAcV366M+qxZnjNzCjeastk1Rt1bpSRaGZanGU=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.3 h1:QsKdBxtC8csnKt5BbV7D1op4Nf13p2YkTJIkppaCakw=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.3/go.mod h1:CDqMoc3KRdZJ8qziW96J35lKH01Wq3B2aihtHj2JbRs=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.4 h1:vzLD0FyNU4uxf2QE5UDG0jSEitiJXbVEUwf2Sk3usF4=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.4/go.mod h1:CDqMoc3KRdZJ8qziW96J35lKH01Wq3B2aihtHj2JbRs=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2 h1:o9cuZdZlI9VWMqsNa2mnf2IRsFAROHnaYA1BW3lHGuY=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2/go.mod h1:penaZKzGmqHGZId4EUCBIW/f9l4Y7hQ5NKd45yoCYuI=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.4 h1:pQpinmWv9jEisDR6/DccOf2cXdAf/CAwQ39nfJfJDlE=

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,6 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.33 h1:/frG8aV09yhCVSOEC2pzktflJJO48NwY3xntHBwxHiA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.33/go.mod h1:8vwASlAcV366M+qxZnjNzCjeastk1Rt1bpSRaGZanGU=
-github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.3 h1:QsKdBxtC8csnKt5BbV7D1op4Nf13p2YkTJIkppaCakw=
-github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.3/go.mod h1:CDqMoc3KRdZJ8qziW96J35lKH01Wq3B2aihtHj2JbRs=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.4 h1:vzLD0FyNU4uxf2QE5UDG0jSEitiJXbVEUwf2Sk3usF4=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.4/go.mod h1:CDqMoc3KRdZJ8qziW96J35lKH01Wq3B2aihtHj2JbRs=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2 h1:o9cuZdZlI9VWMqsNa2mnf2IRsFAROHnaYA1BW3lHGuY=

--- a/pkg/fargate/coredns/coredns.go
+++ b/pkg/fargate/coredns/coredns.go
@@ -43,7 +43,7 @@ func IsSchedulableOnFargate(profiles []*api.FargateProfile) bool {
 }
 
 func selectsCoreDNS(selector api.FargateProfileSelector) bool {
-	return selector.Namespace == Namespace && len(selector.Labels) == 0
+	return selector.Namespace == Namespace && (len(selector.Labels) == 0 || selector.Labels["eks.amazonaws.com/component"] == Name)
 }
 
 // IsScheduledOnFargate checks if EKS' coredns is scheduled onto Fargate.

--- a/pkg/fargate/coredns/coredns_test.go
+++ b/pkg/fargate/coredns/coredns_test.go
@@ -73,15 +73,14 @@ var (
 		},
 	}
 
-	profileWithCoreDNSLabelAndAdditionalLabels = []*api.FargateProfile{
+	profileSelectingCoreDNSWithComponentLabel = []*api.FargateProfile{
 		{
-			Name: "not-selecting-coredns-because-of-multiple-labels",
+			Name: "selecting-coredns-with-label",
 			Selectors: []api.FargateProfileSelector{
 				{
 					Namespace: "kube-system",
 					Labels: map[string]string{
 						"eks.amazonaws.com/component": "coredns",
-						"environment": "prod",
 					},
 				},
 			},
@@ -113,20 +112,7 @@ var _ = Describe("coredns", func() {
 		})
 
 		It("should return true when a Fargate profile matches kube-system and has the CoreDNS component label", func() {
-			profileWithCoreDNSLabel := []*api.FargateProfile{
-				{
-					Name: "selecting-coredns-with-label",
-					Selectors: []api.FargateProfileSelector{
-						{
-							Namespace: "kube-system",
-							Labels: map[string]string{
-								"eks.amazonaws.com/component": "coredns",
-							},
-						},
-					},
-				},
-			}
-			Expect(coredns.IsSchedulableOnFargate(profileWithCoreDNSLabel)).To(BeTrue())
+			Expect(coredns.IsSchedulableOnFargate(profileSelectingCoreDNSWithComponentLabel)).To(BeTrue())
 		})
 
 		It("should return true when provided the default Fargate profile", func() {
@@ -137,10 +123,6 @@ var _ = Describe("coredns", func() {
 
 		It("should return false when a Fargate profile matches kube-system but has labels", func() {
 			Expect(coredns.IsSchedulableOnFargate(profileNotSelectingCoreDNSBecauseOfLabels)).To(BeFalse())
-		})
-
-		It("should return false when a Fargate profile has the CoreDNS component label but also additional labels", func() {
-			Expect(coredns.IsSchedulableOnFargate(profileWithCoreDNSLabelAndAdditionalLabels)).To(BeFalse())
 		})
 
 		It("should return false when a Fargate profile doesn't match kube-system", func() {

--- a/pkg/fargate/coredns/coredns_test.go
+++ b/pkg/fargate/coredns/coredns_test.go
@@ -97,6 +97,23 @@ var _ = Describe("coredns", func() {
 			Expect(coredns.IsSchedulableOnFargate(multipleProfilesWithOneSelectingCoreDNS)).To(BeTrue())
 		})
 
+		It("should return true when a Fargate profile matches kube-system and has the CoreDNS component label", func() {
+			profileWithCoreDNSLabel := []*api.FargateProfile{
+				{
+					Name: "selecting-coredns-with-label",
+					Selectors: []api.FargateProfileSelector{
+						{
+							Namespace: "kube-system",
+							Labels: map[string]string{
+								"eks.amazonaws.com/component": "coredns",
+							},
+						},
+					},
+				},
+			}
+			Expect(coredns.IsSchedulableOnFargate(profileWithCoreDNSLabel)).To(BeTrue())
+		})
+
 		It("should return true when provided the default Fargate profile", func() {
 			cfg := api.NewClusterConfig()
 			cfg.SetDefaultFargateProfile()

--- a/pkg/fargate/coredns/coredns_test.go
+++ b/pkg/fargate/coredns/coredns_test.go
@@ -73,6 +73,21 @@ var (
 		},
 	}
 
+	profileWithCoreDNSLabelAndAdditionalLabels = []*api.FargateProfile{
+		{
+			Name: "not-selecting-coredns-because-of-multiple-labels",
+			Selectors: []api.FargateProfileSelector{
+				{
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						"eks.amazonaws.com/component": "coredns",
+						"environment": "prod",
+					},
+				},
+			},
+		},
+	}
+
 	profileNotSelectingCoreDNSBecauseOfNamespace = []*api.FargateProfile{
 		{
 			Name: "not-selecting-coredns-because-of-namespace",
@@ -122,6 +137,10 @@ var _ = Describe("coredns", func() {
 
 		It("should return false when a Fargate profile matches kube-system but has labels", func() {
 			Expect(coredns.IsSchedulableOnFargate(profileNotSelectingCoreDNSBecauseOfLabels)).To(BeFalse())
+		})
+
+		It("should return false when a Fargate profile has the CoreDNS component label but also additional labels", func() {
+			Expect(coredns.IsSchedulableOnFargate(profileWithCoreDNSLabelAndAdditionalLabels)).To(BeFalse())
 		})
 
 		It("should return false when a Fargate profile doesn't match kube-system", func() {


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Update cluster creation with Fargate to support adding a CoreDNS profile with the selector label `eks.amazonaws.com/component: coredns`. 

Closes https://github.com/eksctl-io/eksctl/issues/8355

### Testing

Create a cluster.yaml file with a Fargate profile including the CoreDNS label:

```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: cluster-name
  region: us-west-2
fargateProfiles:
  - name: main
    selectors:
      - namespace: kube-system
        labels:
          eks.amazonaws.com/component: coredns
```

**On main**, running `eksctl create cluster -f ~/cluster-fargate.yaml` results in a cluster with the CoreDNS pods stuck in a Pending status:

```
$ kubectl get pods -n kube-system
NAME                              READY   STATUS    RESTARTS   AGE
coredns-5449774944-85rg8          0/1     Pending   0          7h38m
coredns-5449774944-rrfc8          0/1     Pending   0          7h38m
```

**On this branch**, running the same command shows some extra logs printed after Fargate's created, and the CoreDNS pods automatically update to a Running status:

```
...
2025-04-17 23:05:18 [ℹ]  created Fargate profile "main" on EKS cluster "cluster-name"
2025-04-17 23:05:48 [ℹ]  "coredns" is now schedulable onto Fargate
2025-04-17 23:06:51 [ℹ]  "coredns" is now scheduled onto Fargate
2025-04-17 23:06:51 [ℹ]  "coredns" pods are now scheduled onto Fargate
...

$ kubectl get pods -n kube-system
NAME                              READY   STATUS    RESTARTS   AGE
coredns-68fc64c5d7-kpvcj          1/1     Running   0          8h
coredns-68fc64c5d7-qk7f7          1/1     Running   0          8h
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

