### PR TITLE
Fix nil pointer dereference when checking if auto mode enabled

### DIFF
--- a/pkg/actions/podidentityassociation/migrator.go
+++ b/pkg/actions/podidentityassociation/migrator.go
@@ -234,7 +234,7 @@ func IsPodIdentityAgentInstalled(ctx context.Context, eksAPI awsapi.EKS, cluster
 }
 
 func IsAutoModeEnabled(ctx context.Context, eksAPI awsapi.EKS, clusterName string) (bool, error) {
-	clstrDescribeResponse, err := eksAPI.DescribeCluster(ctx, &awseks.DescribeClusterInput{
+	cluster, err := eksAPI.DescribeCluster(ctx, &awseks.DescribeClusterInput{
 		Name: aws.String(clusterName),
 	})
 
@@ -242,11 +242,12 @@ func IsAutoModeEnabled(ctx context.Context, eksAPI awsapi.EKS, clusterName strin
 		return false, fmt.Errorf("calling EKS::DescribeCluster: %w", err)
 	}
 
-	if *clstrDescribeResponse.Cluster.ComputeConfig.Enabled {
-		return true, nil
+	if cluster.Cluster.ComputeConfig == nil ||
+		cluster.Cluster.ComputeConfig.Enabled == nil {
+		return false, nil
 	}
 
-	return false, nil
+	return *cluster.Cluster.ComputeConfig.Enabled, nil
 }
 
 type IRSAv1StackNameResolver map[string]IRSAv1StackSummary

--- a/pkg/actions/podidentityassociation/migrator.go
+++ b/pkg/actions/podidentityassociation/migrator.go
@@ -242,7 +242,8 @@ func IsAutoModeEnabled(ctx context.Context, eksAPI awsapi.EKS, clusterName strin
 		return false, fmt.Errorf("calling EKS::DescribeCluster: %w", err)
 	}
 
-	if cluster.Cluster.ComputeConfig == nil ||
+	if cluster.Cluster == nil ||
+		cluster.Cluster.ComputeConfig == nil ||
 		cluster.Cluster.ComputeConfig.Enabled == nil {
 		return false, nil
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

An update was recently merged to allow creating pod identity assosiations in EKS Auto Mode clusters (#8358). That update includes checking the `DescribeCluster` response field `Cluster.ComputeConfig.Enabled`. However, in some cases this field will be nil. This PR updates the auto mode check to handle nil `ComputeConfig` as meaning auto mode is not enabled. 


### Testing

Create a cluster, then attempt to update an addon. 

Before:

```sh
% ./eksctl update addon --cluster m8-e --name kube-proxy --version v1.32.3
2025-05-08 17:19:55 [!]  no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=us-west-2 --cluster=m8-e'
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x465b95e]

goroutine 1 [running]:
github.com/weaveworks/eksctl/pkg/actions/podidentityassociation.IsAutoModeEnabled({0x661ee68, 0x8e11a00}, {0x665c648, 0xc000e22540}, {0x7ffdafb27125, 0x4})
        /home/nclonts/workplace/eksctl/pkg/actions/podidentityassociation/migrator.go:245 +0x11e
github.com/weaveworks/eksctl/pkg/actions/podidentityassociation.IsPodIdentityAgentInstalled({0x661ee68, 0x8e11a00}, {0x665c648, 0xc000e22540}, {0x7ffdafb27125, 0x4})
        /home/nclonts/workplace/eksctl/pkg/actions/podidentityassociation/migrator.go:219 +0xbd
github.com/weaveworks/eksctl/pkg/ctl/update.validatePodIdentityAgentAddon({0x661ee68?, 0x8e11a00?}, {0x665c648?, 0xc000e22540?}, 0xc0002c22c0)
        /home/nclonts/workplace/eksctl/pkg/ctl/update/addon.go:126 +0x55
github.com/weaveworks/eksctl/pkg/ctl/update.updateAddon(0xc000289c80, 0x0, 0xe3?)
        /home/nclonts/workplace/eksctl/pkg/ctl/update/addon.go:77 +0x1e6
github.com/weaveworks/eksctl/pkg/ctl/update.updateAddonCmd.func3(0xc001180d00?, {0xc0001a61e0?, 0x4?, 0x5c621d4?})
        /home/nclonts/workplace/eksctl/pkg/ctl/update/addon.go:48 +0x7a
github.com/spf13/cobra.(*Command).execute(0xc000974c08, {0xc000313f20, 0x6, 0x6})
        /home/nclonts/.gvm/pkgsets/go1.24/global/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0xc0007ee308)
        /home/nclonts/.gvm/pkgsets/go1.24/global/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
        /home/nclonts/.gvm/pkgsets/go1.24/global/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()
        /home/nclonts/workplace/eksctl/cmd/eksctl/main.go:102 +0x552
```

After:

```sh
% ./eksctl update addon --cluster m8-e --name kube-proxy --version v1.32.3
2025-05-08 17:29:19 [!]  no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=us-west-2 --cluster=m8-e'
2025-05-08 17:29:19 [ℹ]  Kubernetes version "1.32" in use by cluster "m8-e"
2025-05-08 17:29:21 [ℹ]  new version provided v1.32.3-eksbuild.7
2025-05-08 17:29:21 [ℹ]  updating addon
2025-05-08 17:29:31 [ℹ]  addon "kube-proxy" active
```


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

