### PR TITLE
Add eksctl support for new AWS region ap-east-2

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -138,6 +138,9 @@ const (
 	// RegionAPEast1 represents the Asia Pacific Region Hong Kong
 	RegionAPEast1 = "ap-east-1"
 
+	// RegionAPEast2 represents the Asia Pacific Region Taipei
+	RegionAPEast2 = "ap-east-2"
+
 	// RegionMECentral1 represents the Middle East Region Dubai
 	RegionMECentral1 = "me-central-1"
 
@@ -312,6 +315,9 @@ const (
 
 	// eksResourceAccountAPEast1 defines the AWS EKS account ID that provides node resources in ap-east-1 region
 	eksResourceAccountAPEast1 = "800184023465"
+
+	// eksResourceAccountAPEast2 defines the AWS EKS account ID that provides node resources in ap-east-2 region
+	eksResourceAccountAPEast2 = "533267051163"
 
 	// eksResourceAccountCAWest1 defines the AWS EKS account ID that provides node resources in ca-west-1 region
 	eksResourceAccountCAWest1 = "761377655185"
@@ -516,6 +522,7 @@ func SupportedRegions() []string {
 		RegionAPSouth1,
 		RegionAPSouth2,
 		RegionAPEast1,
+		RegionAPEast2,
 		RegionMECentral1,
 		RegionMESouth1,
 		RegionSAEast1,
@@ -583,6 +590,8 @@ func EKSResourceAccountID(region string) string {
 	switch region {
 	case RegionAPEast1:
 		return eksResourceAccountAPEast1
+	case RegionAPEast2:
+		return eksResourceAccountAPEast2
 	case RegionCAWest1:
 		return eksResourceAccountCAWest1
 	case RegionMECentral1:


### PR DESCRIPTION
### Description

Add support for the [upcoming AWS region ap-east-2, Taipei](https://aws.amazon.com/local/taipei/).

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

