### PR TITLE
Update default AMI family in integration test to AmazonLinux2023 for K8s 1.32 ManagedNodeGroups

### DIFF
--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -105,7 +105,7 @@ nodeGroups:
   volumeType: gp3
 
 managedNodeGroups:
-- amiFamily: AmazonLinux2
+- amiFamily: AmazonLinux2023
   desiredCapacity: 2
   disableIMDSv1: true
   disablePodIMDS: false


### PR DESCRIPTION
### Description

Update the Dry Run integration test, which uses Kubernetes 1.32, to expect AmazonLinux2023 as [the default AMI family](https://github.com/eksctl-io/eksctl/pull/8351/files#diff-e8e2425e7853997a71d3af8748feaafd751aec738139317e6be05c5aca3aec93R151) for Managed Node Groups.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

