### PR TITLE
Fix Clusters Fail to Create Private Endpoint and Identity Provider

### DIFF
--- a/pkg/actions/identityproviders/tasks.go
+++ b/pkg/actions/identityproviders/tasks.go
@@ -32,5 +32,5 @@ func (t *AssociateProvidersTask) Describe() string {
 
 func (t *AssociateProvidersTask) Do() error {
 	m := NewManager(t.metadata, t.eks)
-	return m.Associate(t.ctx, AssociateIdentityProvidersOptions{Providers: t.providers})
+	return m.Associate(t.ctx, AssociateIdentityProvidersOptions{Providers: t.providers, WaitTimeout: api.DefaultWaitTimeout})
 }


### PR DESCRIPTION
### Description

Include a timeout setting when associating an identity provider as part of cluster creation. This allows the task to complete before subsequent tasks attempt to modify the cluster. Addresses issue #8410 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

