### PR TITLE
Implementation of MCP server for eksctl

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/eksctl/pkg/ctl/deregister"
-	"github.com/weaveworks/eksctl/pkg/ctl/register"
 
 	"github.com/weaveworks/eksctl/pkg/actions/anywhere"
 	"github.com/weaveworks/eksctl/pkg/ctl/associate"
@@ -16,10 +14,14 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/completion"
 	"github.com/weaveworks/eksctl/pkg/ctl/create"
 	"github.com/weaveworks/eksctl/pkg/ctl/delete"
+	"github.com/weaveworks/eksctl/pkg/ctl/deregister"
 	"github.com/weaveworks/eksctl/pkg/ctl/disassociate"
 	"github.com/weaveworks/eksctl/pkg/ctl/drain"
 	"github.com/weaveworks/eksctl/pkg/ctl/enable"
 	"github.com/weaveworks/eksctl/pkg/ctl/get"
+	"github.com/weaveworks/eksctl/pkg/ctl/mcp"
+	"github.com/weaveworks/eksctl/pkg/ctl/misc"
+	"github.com/weaveworks/eksctl/pkg/ctl/register"
 	"github.com/weaveworks/eksctl/pkg/ctl/scale"
 	"github.com/weaveworks/eksctl/pkg/ctl/set"
 	"github.com/weaveworks/eksctl/pkg/ctl/unset"
@@ -45,11 +47,11 @@ func addCommands(rootCmd *cobra.Command, flagGrouping *cmdutils.FlagGrouping) {
 	rootCmd.AddCommand(deregister.Command(flagGrouping))
 	rootCmd.AddCommand(utils.Command(flagGrouping))
 	rootCmd.AddCommand(completion.Command(rootCmd))
+	rootCmd.AddCommand(mcp.Command(rootCmd))
 	//Ensures "eksctl --help" presents eksctl anywhere as a command, but adds no subcommands since we invoke the binary.
 	rootCmd.AddCommand(cmdutils.NewVerbCmd("anywhere", "EKS anywhere", ""))
 
-	cmdutils.AddResourceCmd(flagGrouping, rootCmd, infoCmd)
-	cmdutils.AddResourceCmd(flagGrouping, rootCmd, versionCmd)
+	misc.Command(flagGrouping, rootCmd)
 }
 
 func main() {
@@ -115,6 +117,10 @@ func checkCommand(rootCmd *cobra.Command) {
 	for _, cmd := range rootCmd.Commands() {
 		// just a precaution as the verb command didn't have runE
 		if cmd.RunE != nil {
+			continue
+		}
+		// mcp command does not need a resource type
+		if cmd.Name() == "mcp" {
 			continue
 		}
 		cmd.RunE = func(c *cobra.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/kris-nova/lolgopher v0.0.0-20210112022122-73f0047e8b65
 	github.com/kubicorn/kubicorn v0.0.0-20191114212505-a2c64ce430b9
 	github.com/lithammer/dedent v1.1.0
+	github.com/mark3labs/mcp-go v0.31.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.11.2
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.23.3
@@ -397,6 +398,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gitlab.com/bosi/decorder v0.4.2 // indirect
 	go-simpler.org/musttag v0.13.0 // indirect
 	go-simpler.org/sloglint v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,8 @@ github.com/maratori/testableexamples v1.0.0 h1:dU5alXRrD8WKSjOUnmJZuzdxWOEQ57+7s
 github.com/maratori/testableexamples v1.0.0/go.mod h1:4rhjL1n20TUTT4vdh3RDqSizKLyXp7K2u6HgraZCGzE=
 github.com/maratori/testpackage v1.1.1 h1:S58XVV5AD7HADMmD0fNnziNHqKvSdDuEKdPD1rNTU04=
 github.com/maratori/testpackage v1.1.1/go.mod h1:s4gRK/ym6AMrqpOa/kEbQTV4Q4jb7WeLZzVhVVVOQMc=
+github.com/mark3labs/mcp-go v0.31.0 h1:4UxSV8aM770OPmTvaVe/b1rA2oZAjBMhGBfUgOGut+4=
+github.com/mark3labs/mcp-go v0.31.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/matoous/godox v1.1.0 h1:W5mqwbyWrwZv6OQ5Z1a/DHGMOvXYCBP3+Ht7KMoJhq4=
 github.com/matoous/godox v1.1.0/go.mod h1:jgE/3fUXiTurkdHOLT5WEkThTSuE7yxHv5iWPa80afs=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
@@ -1059,6 +1061,8 @@ github.com/yeya24/promlinter v0.3.0 h1:JVDbMp08lVCP7Y6NP3qHroGAO6z2yGKQtS5Jsjqto
 github.com/yeya24/promlinter v0.3.0/go.mod h1:cDfJQQYv9uYciW60QT0eeHlFodotkYZlL+YcPQN+mW4=
 github.com/ykadowak/zerologlint v0.1.5 h1:Gy/fMz1dFQN9JZTPjv1hxEk+sRWm05row04Yoolgdiw=
 github.com/ykadowak/zerologlint v0.1.5/go.mod h1:KaUskqF3e/v59oPmdq1U1DnKcuHokl2/K1U4pmIELKg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/ctl/mcp/README.md
+++ b/pkg/ctl/mcp/README.md
@@ -98,3 +98,6 @@ To quickly test the MCP server, you can run the following command in your termin
 ```bash
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | eksctl mcp | jq
 ```
+
+## Recommendations
+- Monitor background operations for long-running commands. Commands such as cluster creations have a 45-second timeout for command responses but the processes continue in background.

--- a/pkg/ctl/mcp/README.md
+++ b/pkg/ctl/mcp/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `pkg/ctl/mcp` package implements a [Model Context Protocol (MCP)](https://github.com/mark3labs/mcp) server for eksctl. This server enables AI assistants like Amazon Q to interact with eksctl functionality directly through a standardized protocol, allowing for seamless integration of eksctl commands into AI-powered workflows.
+The `pkg/ctl/mcp` package implements a [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server for eksctl. This server enables AI assistants like Amazon Q to interact with eksctl functionality directly through a standardized protocol, allowing for seamless integration of eksctl commands into AI-powered workflows.
 
 ## What is MCP?
 

--- a/pkg/ctl/mcp/README.md
+++ b/pkg/ctl/mcp/README.md
@@ -1,0 +1,100 @@
+# eksctl MCP (Model Context Protocol) Package
+
+## Overview
+
+The `pkg/ctl/mcp` package implements a [Model Context Protocol (MCP)](https://github.com/mark3labs/mcp) server for eksctl. This server enables AI assistants like Amazon Q to interact with eksctl functionality directly through a standardized protocol, allowing for seamless integration of eksctl commands into AI-powered workflows.
+
+## What is MCP?
+
+Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context and tools to Large Language Models (LLMs). It enables AI assistants to:
+
+1. Discover available tools and their capabilities
+2. Execute commands and receive structured responses
+3. Provide contextual information to enhance AI interactions
+
+## How the eksctl MCP Server Works
+
+The eksctl MCP server exposes all eksctl commands as tools that can be invoked by AI assistants. The implementation consists of several key components:
+
+### Core Components
+
+1. **`mcp.go`**: Entry point that defines the `mcp` command and starts the MCP server
+2. **`server.go`**: Creates and configures the MCP server with all eksctl commands
+3. **`tools.go`**: Handles the registration of eksctl commands as MCP tools
+4. **`types.go`**: Defines types and interfaces used by the MCP implementation
+
+### Implementation Details
+
+- The server uses the `mcp-go` library to implement the Model Context Protocol
+- It dynamically registers all eksctl commands (create, get, delete, etc.) as MCP tools
+- Each command's help text, flags, and parameters are exposed through the protocol
+- The server runs as a stdio server, communicating through standard input/output
+
+### Command Registration Process
+
+1. The server recursively traverses the eksctl command tree
+2. For each command, it extracts:
+   - Command description and usage information
+   - Available flags and their descriptions
+   - Required and optional parameters
+
+## Using the eksctl MCP Server with Amazon Q Chat
+
+To use the eksctl MCP server with Amazon Q Chat, you need to register it in the Amazon Q configuration file.
+
+Create or edit the file at `$HOME/.aws/amazonq/mcp.json` with the following content:
+
+```json
+{
+  "mcpServers": {
+    "eks-tools": {
+      "command": "eksctl",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}
+```
+
+This configuration tells Amazon Q Chat to:
+1. Register a server named "eks-tools"
+2. Use the `eksctl mcp` command to start the MCP server
+3. Make all eksctl commands available as tools with the prefix `eks___`
+
+## Benefits
+
+- **Seamless Integration**: AI assistants can execute eksctl commands directly
+- **Structured Responses**: Commands return structured data that can be parsed by AI models
+- **Discoverability**: AI assistants can discover available commands and their parameters
+- **Context-Aware**: Provides rich context about EKS clusters and resources
+
+## Development
+
+When extending the MCP server functionality:
+
+1. Add new command registrations in `server.go` if new eksctl commands are created
+2. Extend type definitions in `types.go` as needed
+3. Modify `tools.go` if changes to tool registration logic are required
+
+## Example Usage in Amazon Q Chat
+
+Once configured, users can interact with eksctl through Amazon Q Chat:
+
+```
+User: What EKS clusters do I have?
+Amazon Q: Let me check your EKS clusters.
+[Amazon Q executes the eksctl get cluster command and displays the results]
+
+User: Create a new EKS cluster
+Amazon Q: [Guides the user through cluster creation using eksctl commands]
+```
+
+The MCP server enables these interactions by providing Amazon Q with the ability to execute eksctl commands and interpret their results.
+
+## Quick test for MCP server
+To quickly test the MCP server, you can run the following command in your terminal:
+
+```bash
+echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | eksctl mcp | jq
+```

--- a/pkg/ctl/mcp/mcp.go
+++ b/pkg/ctl/mcp/mcp.go
@@ -1,0 +1,65 @@
+// Package mcp implements the Model Context Protocol (MCP) server functionality for eksctl
+// MCP allows eksctl to be used as a tool provider for AI assistants
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/eksctl/pkg/version"
+)
+
+// Command creates the `mcp` commands
+// This command starts an MCP server that provides eksctl functionality through the Model Context Protocol
+func Command(rootCommand *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Start an MCP (Model Context Protocol) server",
+		Long:  "Start an MCP server that provides eksctl functionality through the Model Context Protocol",
+		Run: func(_ *cobra.Command, _ []string) {
+			startMCPServer(rootCommand)
+		},
+		Hidden: true, // Hide this command from normal usage
+	}
+
+	return cmd
+}
+
+// startMCPServer initializes and starts the MCP server
+// It creates an eksctl MCP server and connects it to stdin/stdout for communication
+func startMCPServer(rootCommand *cobra.Command) {
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCommand, version.GetVersion())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating MCP server: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create a stdio server
+	stdioServer := server.NewStdioServer(mcpServer)
+
+	// Start the server
+	if err := stdioServer.Listen(context.Background(), os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "Error starting MCP server: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// newEksctlMCPServer creates and configures an MCP server for eksctl
+// It sets up the command structure and registers all eksctl commands as MCP tools
+func newEksctlMCPServer(rootCmd *cobra.Command, version string) (*server.MCPServer, error) {
+
+	// Create a new MCP server with the specified name and version
+	s := server.NewMCPServer("eksctl", version, server.WithInstructions("MCP server for eksctl"))
+
+	// Register all eksctl commands as MCP tools
+	if err := registerTools(s, rootCmd); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/pkg/ctl/mcp/mcp_test.go
+++ b/pkg/ctl/mcp/mcp_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEksctlMCPServer(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Add a test subcommand
+	testCmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	rootCmd.AddCommand(testCmd)
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+
+	// Verify server creation
+	assert.NoError(t, err)
+	assert.NotNil(t, mcpServer)
+
+	// We can't directly access name and version fields, but we can verify the server was created
+	require.NotNil(t, mcpServer)
+}
+
+func TestCommand(t *testing.T) {
+	// Create a root command
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create the MCP command
+	mcpCmd := Command(rootCmd)
+
+	// Verify command properties
+	assert.Equal(t, "mcp", mcpCmd.Use)
+	assert.True(t, mcpCmd.Hidden)
+	assert.NotEmpty(t, mcpCmd.Short)
+	assert.NotEmpty(t, mcpCmd.Long)
+}

--- a/pkg/ctl/mcp/misc_test.go
+++ b/pkg/ctl/mcp/misc_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/ctl/misc"
+)
+
+// TestMiscCommandRegistration tests that misc commands are properly registered
+func TestMiscCommandRegistration(t *testing.T) {
+	// Create a root command
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create a flag grouping for the commands
+	flagGrouping := cmdutils.NewGrouping()
+
+	// Register misc commands to the root command
+	misc.Command(flagGrouping, rootCmd)
+
+	// Create the MCP server with the root command
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Verify that the version command was registered
+	versionCmd := findCommandInTest(rootCmd, "version")
+	assert.NotNil(t, versionCmd, "version command should be registered")
+
+	// Verify that the info command was registered
+	infoCmd := findCommandInTest(rootCmd, "info")
+	assert.NotNil(t, infoCmd, "info command should be registered")
+}
+
+// findCommandInTest recursively searches for a command by name
+func findCommandInTest(cmd *cobra.Command, name string) *cobra.Command {
+	for _, subCmd := range cmd.Commands() {
+		if subCmd.Name() == name {
+			return subCmd
+		}
+		if found := findCommandInTest(subCmd, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/pkg/ctl/mcp/session_test.go
+++ b/pkg/ctl/mcp/session_test.go
@@ -1,0 +1,221 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionManagement tests session registration and management
+func TestSessionManagement(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Create a test session
+	sessionID := "test-session"
+	notificationChan := make(chan mcp.JSONRPCNotification, 10)
+	session := &testSession{
+		id:                 sessionID,
+		notificationChan:   notificationChan,
+		isInitialized:      false,
+		initializationFunc: func() { /* no-op */ },
+	}
+
+	// Register the session
+	err = mcpServer.RegisterSession(context.Background(), session)
+	assert.NoError(t, err)
+
+	// Try to register the same session again (should fail)
+	err = mcpServer.RegisterSession(context.Background(), session)
+	assert.Error(t, err)
+
+	// Initialize the session
+	session.Initialize()
+	assert.True(t, session.Initialized())
+
+	// Send a notification to the session
+	err = mcpServer.SendNotificationToSpecificClient(sessionID, "test-notification", map[string]any{
+		"data": "test-data",
+	})
+	assert.NoError(t, err)
+
+	// Check that the notification was received
+	select {
+	case notification := <-notificationChan:
+		assert.Equal(t, "test-notification", notification.Method)
+		assert.Equal(t, "test-data", notification.Params.AdditionalFields["data"])
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Expected notification not received")
+	}
+
+	// Unregister the session
+	mcpServer.UnregisterSession(context.Background(), sessionID)
+
+	// Try to send a notification to the unregistered session (should fail)
+	err = mcpServer.SendNotificationToSpecificClient(sessionID, "test-notification", nil)
+	assert.Error(t, err)
+}
+
+// TestSessionContext tests session context management
+func TestSessionContext(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Create a test session
+	sessionID := "test-session"
+	notificationChan := make(chan mcp.JSONRPCNotification, 10)
+	session := &testSession{
+		id:                 sessionID,
+		notificationChan:   notificationChan,
+		isInitialized:      true,
+		initializationFunc: func() { /* no-op */ },
+	}
+
+	// Register the session
+	err = mcpServer.RegisterSession(context.Background(), session)
+	assert.NoError(t, err)
+
+	// Create a context with the session
+	ctx := mcpServer.WithContext(context.Background(), session)
+
+	// Get the session from the context
+	retrievedSession := server.ClientSessionFromContext(ctx)
+	assert.NotNil(t, retrievedSession)
+	assert.Equal(t, sessionID, retrievedSession.SessionID())
+}
+
+// TestSessionNotifications tests sending notifications to sessions
+func TestSessionNotifications(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Create multiple test sessions
+	session1 := &testSession{
+		id:                 "session-1",
+		notificationChan:   make(chan mcp.JSONRPCNotification, 10),
+		isInitialized:      true,
+		initializationFunc: func() { /* no-op */ },
+	}
+	session2 := &testSession{
+		id:                 "session-2",
+		notificationChan:   make(chan mcp.JSONRPCNotification, 10),
+		isInitialized:      true,
+		initializationFunc: func() { /* no-op */ },
+	}
+	session3 := &testSession{
+		id:                 "session-3",
+		notificationChan:   make(chan mcp.JSONRPCNotification, 10),
+		isInitialized:      false, // Not initialized
+		initializationFunc: func() { /* no-op */ },
+	}
+
+	// Register the sessions
+	err = mcpServer.RegisterSession(context.Background(), session1)
+	assert.NoError(t, err)
+	err = mcpServer.RegisterSession(context.Background(), session2)
+	assert.NoError(t, err)
+	err = mcpServer.RegisterSession(context.Background(), session3)
+	assert.NoError(t, err)
+
+	// Send notification to all clients
+	mcpServer.SendNotificationToAllClients("broadcast", map[string]any{
+		"data": "broadcast-data",
+	})
+
+	// Check that initialized sessions received the notification
+	for _, s := range []*testSession{session1, session2} {
+		select {
+		case notification := <-s.notificationChan:
+			assert.Equal(t, "broadcast", notification.Method)
+			assert.Equal(t, "broadcast-data", notification.Params.AdditionalFields["data"])
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("Expected notification not received by session %s", s.id)
+		}
+	}
+
+	// Check that uninitialized session did not receive the notification
+	select {
+	case notification := <-session3.notificationChan:
+		t.Errorf("Unexpected notification received by uninitialized session: %v", notification)
+	case <-time.After(100 * time.Millisecond):
+		// Expected, no notification for uninitialized session
+	}
+
+	// Send notification to specific client
+	err = mcpServer.SendNotificationToSpecificClient("session-1", "specific", map[string]any{
+		"data": "specific-data",
+	})
+	assert.NoError(t, err)
+
+	// Check that only session1 received the notification
+	select {
+	case notification := <-session1.notificationChan:
+		assert.Equal(t, "specific", notification.Method)
+		assert.Equal(t, "specific-data", notification.Params.AdditionalFields["data"])
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Expected notification not received by session1")
+	}
+
+	// Check that session2 did not receive the notification
+	select {
+	case notification := <-session2.notificationChan:
+		t.Errorf("Unexpected notification received by session2: %v", notification)
+	case <-time.After(100 * time.Millisecond):
+		// Expected, no notification for session2
+	}
+}
+
+// testSession is a simple implementation of the ClientSession interface for testing
+type testSession struct {
+	id                 string
+	notificationChan   chan mcp.JSONRPCNotification
+	isInitialized      bool
+	initializationFunc func()
+}
+
+func (s *testSession) SessionID() string {
+	return s.id
+}
+
+func (s *testSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return s.notificationChan
+}
+
+func (s *testSession) Initialize() {
+	s.isInitialized = true
+	s.initializationFunc()
+}
+
+func (s *testSession) Initialized() bool {
+	return s.isInitialized
+}

--- a/pkg/ctl/mcp/stdio_test.go
+++ b/pkg/ctl/mcp/stdio_test.go
@@ -1,0 +1,317 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStdioServer tests the stdio server functionality
+func TestStdioServer(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Add a test subcommand
+	testCmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	rootCmd.AddCommand(testCmd)
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Create mock stdin/stdout
+	mockStdin := &bytes.Buffer{}
+	mockStdout := &bytes.Buffer{}
+
+	// Create a stdio server
+	stdioServer := server.NewStdioServer(mcpServer)
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Start the server in a goroutine
+	go func() {
+		err := stdioServer.Listen(ctx, mockStdin, mockStdout)
+		if err != nil && err != context.DeadlineExceeded && err != io.EOF {
+			t.Errorf("Unexpected error from stdio server: %v", err)
+		}
+	}()
+
+	// Write a ping request to stdin
+	pingRequest := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "ping",
+	}
+	pingRequestBytes, err := json.Marshal(pingRequest)
+	require.NoError(t, err)
+
+	// Add newline to the request
+	pingRequestBytes = append(pingRequestBytes, '\n')
+
+	// Write to mock stdin
+	_, err = mockStdin.Write(pingRequestBytes)
+	require.NoError(t, err)
+
+	// Wait for response
+	time.Sleep(100 * time.Millisecond)
+
+	// Read response from stdout
+	response := mockStdout.String()
+	assert.NotEmpty(t, response)
+
+	// Parse response
+	var responseObj map[string]interface{}
+	err = json.Unmarshal([]byte(strings.TrimSpace(response)), &responseObj)
+	require.NoError(t, err)
+
+	// Verify response
+	assert.Equal(t, "2.0", responseObj["jsonrpc"])
+	assert.Equal(t, float64(1), responseObj["id"])
+	assert.NotNil(t, responseObj["result"])
+}
+
+// TestStdioServerWithToolCall tests the stdio server with a tool call
+func TestStdioServerWithToolCall(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Add a test subcommand with a mock implementation
+	testCmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	rootCmd.AddCommand(testCmd)
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Add a mock tool directly to the server
+	mcpServer.AddTool(
+		mcp.NewTool("mock_tool"),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("Mock tool response"), nil
+		},
+	)
+
+	// Create mock stdin/stdout
+	mockStdin := &bytes.Buffer{}
+	mockStdout := &bytes.Buffer{}
+
+	// Create a stdio server
+	stdioServer := server.NewStdioServer(mcpServer)
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Start the server in a goroutine
+	go func() {
+		err := stdioServer.Listen(ctx, mockStdin, mockStdout)
+		if err != nil && err != context.DeadlineExceeded && err != io.EOF {
+			t.Errorf("Unexpected error from stdio server: %v", err)
+		}
+	}()
+
+	// Write a tool call request to stdin
+	toolRequest := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]interface{}{
+			"name":      "mock_tool",
+			"arguments": map[string]interface{}{},
+		},
+	}
+	toolRequestBytes, err := json.Marshal(toolRequest)
+	require.NoError(t, err)
+
+	// Add newline to the request
+	toolRequestBytes = append(toolRequestBytes, '\n')
+
+	// Write to mock stdin
+	_, err = mockStdin.Write(toolRequestBytes)
+	require.NoError(t, err)
+
+	// Wait for response
+	time.Sleep(100 * time.Millisecond)
+
+	// Read response from stdout
+	response := mockStdout.String()
+	assert.NotEmpty(t, response)
+
+	// Parse response
+	var responseObj map[string]interface{}
+	err = json.Unmarshal([]byte(strings.TrimSpace(response)), &responseObj)
+	require.NoError(t, err)
+
+	// Verify response
+	assert.Equal(t, "2.0", responseObj["jsonrpc"])
+	assert.Equal(t, float64(2), responseObj["id"])
+	assert.NotNil(t, responseObj["result"])
+
+	// Verify tool response content
+	result := responseObj["result"].(map[string]interface{})
+	content := result["content"].([]interface{})
+	assert.Len(t, content, 1)
+
+	textContent := content[0].(map[string]interface{})
+	assert.Equal(t, "text", textContent["type"])
+	assert.Equal(t, "Mock tool response", textContent["text"])
+}
+
+// TestStdioServerMultipleRequests tests handling multiple requests
+func TestStdioServerMultipleRequests(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Create mock stdin/stdout
+	mockStdin := &bytes.Buffer{}
+	mockStdout := &bytes.Buffer{}
+
+	// Create a stdio server
+	stdioServer := server.NewStdioServer(mcpServer)
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Start the server in a goroutine
+	go func() {
+		err := stdioServer.Listen(ctx, mockStdin, mockStdout)
+		if err != nil && err != context.DeadlineExceeded && err != io.EOF {
+			t.Errorf("Unexpected error from stdio server: %v", err)
+		}
+	}()
+
+	// Write multiple requests to stdin
+	requests := []map[string]interface{}{
+		{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "ping",
+		},
+		{
+			"jsonrpc": "2.0",
+			"id":      2,
+			"method":  "initialize",
+		},
+	}
+
+	for _, req := range requests {
+		reqBytes, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		// Add newline to the request
+		reqBytes = append(reqBytes, '\n')
+
+		// Write to mock stdin
+		_, err = mockStdin.Write(reqBytes)
+		require.NoError(t, err)
+
+		// Wait for response
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Read response from stdout
+	response := mockStdout.String()
+
+	// The response format might vary, so we'll just check that we got some response
+	assert.NotEmpty(t, response)
+
+	// Parse and verify each response - we don't need to check specific values
+	// Just verify we can parse the response
+	responseLines := strings.Split(strings.TrimSpace(response), "\n")
+	for _, line := range responseLines {
+		if line == "" {
+			continue
+		}
+		var responseObj map[string]interface{}
+		err = json.Unmarshal([]byte(line), &responseObj)
+		assert.NoError(t, err, "Response should be valid JSON: %s", line)
+	}
+}
+
+// TestStdioServerInvalidRequest tests handling invalid requests
+func TestStdioServerInvalidRequest(t *testing.T) {
+	// Create a simple root command for testing
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Create the MCP server
+	mcpServer, err := newEksctlMCPServer(rootCmd, "test-version")
+	require.NoError(t, err)
+	require.NotNil(t, mcpServer)
+
+	// Create mock stdin/stdout
+	mockStdin := &bytes.Buffer{}
+	mockStdout := &bytes.Buffer{}
+
+	// Create a stdio server
+	stdioServer := server.NewStdioServer(mcpServer)
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Start the server in a goroutine
+	go func() {
+		err := stdioServer.Listen(ctx, mockStdin, mockStdout)
+		if err != nil && err != context.DeadlineExceeded && err != io.EOF {
+			t.Errorf("Unexpected error from stdio server: %v", err)
+		}
+	}()
+
+	// Write an invalid JSON request to stdin
+	invalidRequest := `{"jsonrpc": "2.0", "id": 1, "method": "ping"`
+	_, err = mockStdin.WriteString(invalidRequest + "\n")
+	require.NoError(t, err)
+
+	// Wait for response
+	time.Sleep(100 * time.Millisecond)
+
+	// Read response from stdout
+	response := mockStdout.String()
+
+	// The response format might vary, so we'll just check that we got some response
+	assert.NotEmpty(t, response)
+
+	// Try to parse the response, but don't assert on specific values
+	var responseObj map[string]interface{}
+	_ = json.Unmarshal([]byte(strings.TrimSpace(response)), &responseObj)
+}

--- a/pkg/ctl/mcp/tools.go
+++ b/pkg/ctl/mcp/tools.go
@@ -1,0 +1,316 @@
+// Package mcp implements the Model Context Protocol (MCP) server functionality for eksctl
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+// registerTools registers all eksctl commands as MCP tools
+// This is the entry point for tool registration that processes the entire command tree
+func registerTools(s *server.MCPServer, rootCmd *cobra.Command) error {
+	return registerToolsRecursive(s, rootCmd)
+}
+
+// registerToolsRecursive recursively registers all commands as tools
+// It processes the current command and then recursively processes all subcommands
+func registerToolsRecursive(s *server.MCPServer, cmd *cobra.Command) error {
+	if err := registerTool(s, cmd); err != nil {
+		return err
+	}
+
+	// Process all subcommands recursively
+	for _, subCmd := range cmd.Commands() {
+		if err := registerToolsRecursive(s, subCmd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// registerTool registers a single command as an MCP tool
+// It builds the tool options and creates a handler for the command
+func registerTool(s *server.MCPServer, cmd *cobra.Command) error {
+	// Skip commands that shouldn't be exposed
+	if shouldSkipCommand(cmd) {
+		return nil
+	}
+
+	// Build tool name and options
+	toolName, toolOptions, err := buildToolOptions(cmd)
+	if err != nil {
+		return fmt.Errorf("error building tool options for %s: %w", cmd.Name(), err)
+	}
+
+	if toolName == "" {
+		return nil
+	}
+
+	// Create and register the tool
+	tool := mcp.NewTool(toolName, toolOptions...)
+	s.AddTool(tool, createToolHandler(cmd))
+
+	return nil
+}
+
+// shouldSkipCommand determines if a command should be skipped for MCP tool registration
+func shouldSkipCommand(cmd *cobra.Command) bool {
+	return cmd.Hidden || cmd.Name() == "help" || cmd.Name() == "completion"
+}
+
+// buildToolOptions builds the MCP tool options from a cobra command
+func buildToolOptions(cmd *cobra.Command) (string, []mcp.ToolOption, error) {
+	// Build the command path (e.g., "create cluster")
+	var cmdPath []string
+	current := cmd
+	for current != nil && current.Name() != "eksctl" {
+		cmdPath = append([]string{current.Name()}, cmdPath...)
+		current = current.Parent()
+	}
+
+	// Skip if no path (this is the root command)
+	if len(cmdPath) == 0 {
+		return "", nil, nil
+	}
+
+	commandPath := strings.Join(cmdPath, " ")
+	toolName := "eksctl_" + strings.Join(cmdPath, "_")
+
+	// Extract description from the command
+	description := cmd.Short
+	if description == "" {
+		description = cmd.Long
+	}
+	if description == "" {
+		description = "Run the eksctl " + commandPath + " command"
+	}
+
+	// Get usage information
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	flagGrouping := cmdutils.NewGrouping()
+
+	if err := flagGrouping.Usage(cmd); err != nil {
+		return "", nil, fmt.Errorf("error printing usage: %w", err)
+	}
+
+	// Create tool options starting with description
+	toolOptions := []mcp.ToolOption{mcp.WithDescription(description + "\n\n" + buf.String())}
+
+	// Add parameters based on command flags
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		// Skip deprecated flags
+		if flag.Deprecated != "" {
+			return
+		}
+
+		name := flag.Name
+		usage := flag.Usage
+
+		// Check for enum values in usage string
+		_ = extractEnumValuesFromUsage(usage)
+
+		switch flag.Value.Type() {
+		case "bool":
+			toolOptions = append(toolOptions, mcp.WithBoolean(
+				name,
+				mcp.Description(usage),
+			))
+		case "stringSlice", "stringArray":
+			// Handle string arrays as regular strings with comma-separated values
+			toolOptions = append(toolOptions, mcp.WithString(
+				name,
+				mcp.Description(usage+" (comma-separated values)"),
+			))
+		case "intSlice", "intArray":
+			// Handle int arrays as regular strings with comma-separated values
+			toolOptions = append(toolOptions, mcp.WithString(
+				name,
+				mcp.Description(usage+" (comma-separated values)"),
+			))
+		case "int", "int32", "int64":
+			// Use string for numbers as well for simplicity
+			toolOptions = append(toolOptions, mcp.WithString(
+				name,
+				mcp.Description(usage),
+			))
+		case "float", "float32", "float64":
+			toolOptions = append(toolOptions, mcp.WithString(
+				name,
+				mcp.Description(usage),
+			))
+		default:
+			// Default to string for all other types
+			stringOpts := []mcp.PropertyOption{mcp.Description(usage)}
+
+			// Mark required if the flag is required
+			if flag.Annotations != nil {
+				if _, required := flag.Annotations["cobra_annotation_required"]; required {
+					stringOpts = append(stringOpts, mcp.Required())
+				}
+			}
+
+			toolOptions = append(toolOptions, mcp.WithString(
+				name,
+				stringOpts...,
+			))
+		}
+	})
+
+	return toolName, toolOptions, nil
+}
+
+// createToolHandler creates a handler function for an MCP tool
+func createToolHandler(cmd *cobra.Command) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Add timeout to context
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		// Build the command path
+		var cmdPath []string
+		current := cmd
+		for current != nil && current.Name() != "eksctl" {
+			cmdPath = append([]string{current.Name()}, cmdPath...)
+			current = current.Parent()
+		}
+
+		// Build arguments for the eksctl command
+		args := cmdPath
+
+		// Add flag values from the request
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			name := flag.Name
+
+			// Handle different flag types
+			switch flag.Value.Type() {
+			case "bool":
+				if request.GetBool(name, false) {
+					args = append(args, "--"+name)
+				}
+			case "stringSlice", "stringArray", "intSlice", "intArray":
+				// Handle arrays as comma-separated values
+				if value := request.GetString(name, ""); value != "" {
+					values := strings.Split(value, ",")
+					for _, v := range values {
+						args = append(args, "--"+name, strings.TrimSpace(v))
+					}
+				}
+			default:
+				// Handle string and number types
+				if value := request.GetString(name, ""); value != "" {
+					args = append(args, "--"+name, value)
+				}
+			}
+		})
+
+		return executeEksctlCommand(ctx, args)
+	}
+}
+
+func executeEksctlCommand(ctx context.Context, args []string) (*mcp.CallToolResult, error) {
+	// Create a context for output collection with a 45-second timeout
+	timeoutCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+
+	cmd := exec.Command("eksctl", args...)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return mcp.NewToolResultError("Failed to create stdout pipe: " + err.Error()), nil
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return mcp.NewToolResultError("Failed to create stderr pipe: " + err.Error()), nil
+	}
+
+	if err := cmd.Start(); err != nil {
+		return mcp.NewToolResultError("Failed to start eksctl: " + err.Error()), nil
+	}
+
+	// Channels to collect output
+	stdoutCh := make(chan string, 1)
+	stderrCh := make(chan string, 1)
+
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, stdoutPipe)
+		stdoutCh <- buf.String()
+	}()
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, stderrPipe)
+		stderrCh <- buf.String()
+	}()
+
+	// Wait for either timeout or command completion
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case <-timeoutCtx.Done():
+		// Timeout: collect whatever output is available
+		stdout := ""
+		select {
+		case stdout = <-stdoutCh:
+		default:
+		}
+		return mcp.NewToolResultText(stdout + "\n\n[Command is still running in the background]"), nil
+	case err := <-done:
+		// Command finished: collect output
+		stdout := <-stdoutCh
+		stderr := <-stderrCh
+		if err != nil {
+			if stderr == "" {
+				stderr = err.Error()
+			}
+			return mcp.NewToolResultError(stderr), nil
+		}
+		return mcp.NewToolResultText(stdout), nil
+	}
+}
+
+// Helper functions for parameter enhancement
+
+// extractEnumValuesFromUsage extracts enum values from usage string
+func extractEnumValuesFromUsage(usage string) []string {
+	// Look for patterns like "must be one of: value1, value2, value3"
+	oneOfPattern := regexp.MustCompile(`(?i)(?:must be|one of|can be)(?:\s+one of)?:\s+([^.]+)`)
+	matches := oneOfPattern.FindStringSubmatch(usage)
+	if len(matches) > 1 {
+		values := strings.Split(matches[1], ",")
+		for i, v := range values {
+			values[i] = strings.Trim(v, " \t\n\r")
+		}
+		return values
+	}
+
+	// Look for patterns like "[value1|value2|value3]"
+	pipePattern := regexp.MustCompile(`\[([^\]]+)\]`)
+	matches = pipePattern.FindStringSubmatch(usage)
+	if len(matches) > 1 && strings.Contains(matches[1], "|") {
+		values := strings.Split(matches[1], "|")
+		for i, v := range values {
+			values[i] = strings.Trim(v, " \t\n\r")
+		}
+		return values
+	}
+
+	return []string{}
+}

--- a/pkg/ctl/mcp/tools_test.go
+++ b/pkg/ctl/mcp/tools_test.go
@@ -1,0 +1,407 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterTools(t *testing.T) {
+	// Create a test MCP server
+	s := server.NewMCPServer("test-server", "1.0.0", server.WithToolCapabilities(true))
+
+	// Create a test command structure
+	rootCmd := &cobra.Command{
+		Use:   "eksctl",
+		Short: "The official CLI for Amazon EKS",
+	}
+
+	// Add a visible command
+	visibleCmd := &cobra.Command{
+		Use:   "visible",
+		Short: "Visible command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	visibleCmd.Flags().String("test-flag", "", "Test flag")
+	rootCmd.AddCommand(visibleCmd)
+
+	// Add a hidden command
+	hiddenCmd := &cobra.Command{
+		Use:    "hidden",
+		Short:  "Hidden command",
+		Hidden: true,
+		Run:    func(cmd *cobra.Command, args []string) {},
+	}
+	rootCmd.AddCommand(hiddenCmd)
+
+	// Register tools
+	err := registerTools(s, rootCmd)
+	assert.NoError(t, err)
+
+	// Get the list of tools
+	toolsList := s.HandleMessage(context.Background(), []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/list"
+	}`))
+
+	// Verify the response
+	resp, ok := toolsList.(mcp.JSONRPCResponse)
+	assert.True(t, ok)
+
+	result, ok := resp.Result.(mcp.ListToolsResult)
+	assert.True(t, ok)
+
+	// We should have at least one tool (the visible command)
+	assert.NotEmpty(t, result.Tools)
+
+	// Find our visible command tool
+	var foundVisibleTool bool
+	for _, tool := range result.Tools {
+		if tool.Name == "eksctl_visible" {
+			foundVisibleTool = true
+			break
+		}
+	}
+	assert.True(t, foundVisibleTool, "Should find the visible command tool")
+
+	// Make sure hidden command is not registered
+	var foundHiddenTool bool
+	for _, tool := range result.Tools {
+		if tool.Name == "eksctl_hidden" {
+			foundHiddenTool = true
+			break
+		}
+	}
+	assert.False(t, foundHiddenTool, "Should not find the hidden command tool")
+}
+
+func TestBuildToolOptions(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupCmd       func() *cobra.Command
+		expectedName   string
+		expectedParams int
+	}{
+		{
+			name: "Command with string flag",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{
+					Use:   "test",
+					Short: "Test command",
+					Run:   func(cmd *cobra.Command, args []string) {},
+				}
+				cmd.Flags().String("string-flag", "", "String flag")
+				return cmd
+			},
+			expectedName:   "eksctl_test",
+			expectedParams: 1,
+		},
+		{
+			name: "Command with bool flag",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{
+					Use:   "test",
+					Short: "Test command",
+					Run:   func(cmd *cobra.Command, args []string) {},
+				}
+				cmd.Flags().Bool("bool-flag", false, "Bool flag")
+				return cmd
+			},
+			expectedName:   "eksctl_test",
+			expectedParams: 1,
+		},
+		{
+			name: "Command with multiple flags",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{
+					Use:   "test",
+					Short: "Test command",
+					Run:   func(cmd *cobra.Command, args []string) {},
+				}
+				cmd.Flags().String("string-flag", "", "String flag")
+				cmd.Flags().Bool("bool-flag", false, "Bool flag")
+				cmd.Flags().Int("int-flag", 0, "Int flag")
+				cmd.Flags().StringSlice("slice-flag", []string{}, "Slice flag")
+				return cmd
+			},
+			expectedName:   "eksctl_test",
+			expectedParams: 4,
+		},
+		{
+			name: "Command with required flag",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{
+					Use:   "test",
+					Short: "Test command",
+					Run:   func(cmd *cobra.Command, args []string) {},
+				}
+				flag := cmd.Flags().String("required-flag", "", "Required flag")
+				// We can't set Annotations directly, so we'll skip that part in the test
+				_ = flag
+				return cmd
+			},
+			expectedName:   "eksctl_test",
+			expectedParams: 1,
+		},
+		{
+			name: "Command with deprecated flag",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{
+					Use:   "test",
+					Short: "Test command",
+					Run:   func(cmd *cobra.Command, args []string) {},
+				}
+				// We can't set Deprecated directly, so we'll skip that part in the test
+				cmd.Flags().String("flag1", "", "Flag 1")
+				cmd.Flags().String("flag2", "", "Flag 2")
+				return cmd
+			},
+			expectedName:   "eksctl_test",
+			expectedParams: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			rootCmd := &cobra.Command{Use: "eksctl"}
+			cmd := tt.setupCmd()
+			rootCmd.AddCommand(cmd)
+
+			// Test
+			toolName, toolOptions, err := buildToolOptions(cmd)
+
+			// Verify
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedName, toolName)
+
+			// Count parameter options
+			paramCount := 0
+			for _, opt := range toolOptions {
+				if opt != nil {
+					paramCount++
+				}
+			}
+			assert.Equal(t, tt.expectedParams+1, paramCount, "Expected parameters + 1 for description")
+		})
+	}
+}
+
+func TestShouldSkipCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		expected bool
+	}{
+		{
+			name: "Regular command",
+			cmd: &cobra.Command{
+				Use:   "regular",
+				Short: "Regular command",
+			},
+			expected: false,
+		},
+		{
+			name: "Hidden command",
+			cmd: &cobra.Command{
+				Use:    "hidden",
+				Short:  "Hidden command",
+				Hidden: true,
+			},
+			expected: true,
+		},
+		{
+			name: "Help command",
+			cmd: &cobra.Command{
+				Use:   "help",
+				Short: "Help command",
+			},
+			expected: true,
+		},
+		{
+			name: "Completion command",
+			cmd: &cobra.Command{
+				Use:   "completion",
+				Short: "Completion command",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSkipCommand(tt.cmd)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractEnumValuesFromUsage(t *testing.T) {
+	tests := []struct {
+		name     string
+		usage    string
+		expected []string
+	}{
+		{
+			name:     "No enum values",
+			usage:    "Just a regular description",
+			expected: []string{},
+		},
+		{
+			name:     "Must be one of pattern",
+			usage:    "The value must be one of: value1, value2, value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "Can be one of pattern",
+			usage:    "The value can be one of: value1, value2, value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "Pipe pattern",
+			usage:    "The value [value1|value2|value3] is required",
+			expected: []string{"value1", "value2", "value3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractEnumValuesFromUsage(tt.usage)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreateToolHandler(t *testing.T) {
+	// Create a test command with flags
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	cmd.Flags().String("string-flag", "", "String flag")
+	cmd.Flags().Bool("bool-flag", false, "Bool flag")
+	cmd.Flags().StringSlice("slice-flag", []string{}, "Slice flag")
+
+	// Create the handler
+	handler := createToolHandler(cmd)
+	require.NotNil(t, handler)
+
+	// We can't easily test the execution without mocking exec.Command
+	// But we can verify the handler doesn't panic with valid input
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"string-flag": "test-value",
+		"bool-flag":   true,
+		"slice-flag":  "value1,value2",
+	}
+
+	// This will try to execute the real command, which might fail
+	// but at least we can verify the handler doesn't panic
+	_, _ = handler(context.Background(), request)
+}
+
+func TestRegisterTool(t *testing.T) {
+	// Create a test MCP server
+	s := server.NewMCPServer("test-server", "1.0.0", server.WithToolCapabilities(true))
+
+	// Create a test command
+	rootCmd := &cobra.Command{Use: "eksctl"}
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	cmd.Flags().String("flag", "", "Test flag")
+	rootCmd.AddCommand(cmd)
+
+	// Register the tool
+	err := registerTool(s, cmd)
+	assert.NoError(t, err)
+
+	// Verify the tool was registered
+	toolsList := s.HandleMessage(context.Background(), []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/list"
+	}`))
+
+	resp, ok := toolsList.(mcp.JSONRPCResponse)
+	assert.True(t, ok)
+
+	result, ok := resp.Result.(mcp.ListToolsResult)
+	assert.True(t, ok)
+
+	// Find our tool
+	var found bool
+	for _, tool := range result.Tools {
+		if tool.Name == "eksctl_test" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Should find the registered tool")
+}
+
+func TestRegisterToolsRecursive(t *testing.T) {
+	// Create a test MCP server
+	s := server.NewMCPServer("test-server", "1.0.0", server.WithToolCapabilities(true))
+
+	// Create a test command structure with nested commands
+	rootCmd := &cobra.Command{Use: "eksctl"}
+
+	// Level 1 command
+	level1Cmd := &cobra.Command{
+		Use:   "level1",
+		Short: "Level 1 command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	rootCmd.AddCommand(level1Cmd)
+
+	// Level 2 command
+	level2Cmd := &cobra.Command{
+		Use:   "level2",
+		Short: "Level 2 command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	level1Cmd.AddCommand(level2Cmd)
+
+	// Register tools recursively
+	err := registerToolsRecursive(s, rootCmd)
+	assert.NoError(t, err)
+
+	// Verify tools were registered
+	toolsList := s.HandleMessage(context.Background(), []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/list"
+	}`))
+
+	resp, ok := toolsList.(mcp.JSONRPCResponse)
+	assert.True(t, ok)
+
+	result, ok := resp.Result.(mcp.ListToolsResult)
+	assert.True(t, ok)
+
+	// We should have at least 2 tools (level1 and level2)
+	foundLevel1 := false
+	foundLevel2 := false
+
+	for _, tool := range result.Tools {
+		if tool.Name == "eksctl_level1" {
+			foundLevel1 = true
+		}
+		if tool.Name == "eksctl_level1_level2" {
+			foundLevel2 = true
+		}
+	}
+
+	assert.True(t, foundLevel1, "Should find level1 command tool")
+	assert.True(t, foundLevel2, "Should find level2 command tool")
+}

--- a/pkg/ctl/misc/info.go
+++ b/pkg/ctl/misc/info.go
@@ -1,4 +1,5 @@
-package main
+// Package misc provides miscellaneous commands for eksctl
+package misc
 
 import (
 	"fmt"
@@ -9,24 +10,38 @@ import (
 	"github.com/weaveworks/eksctl/pkg/info"
 )
 
+// infoCmd implements the 'info' command which displays system information
+// including eksctl version, kubectl version, and OS details
+// It supports both plain text and JSON output formats
 func infoCmd(cmd *cmdutils.Cmd) {
 	var output string
 
+	// Set up the command description and help text
 	cmd.SetDescription("info", "Output the version of eksctl, kubectl and OS info", "")
+
+	// Define command flags
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		// Add -o/--output flag to specify output format
 		fs.StringVarP(&output, "output", "o", "", "specifies the output format (valid option: json)")
 	})
+
+	// This command doesn't accept any arguments
 	cmd.CobraCommand.Args = cobra.NoArgs
+
+	// Define the command execution logic
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		switch output {
 		case "":
+			// Default output format (plain text)
 			version := info.GetInfo()
 			fmt.Printf("eksctl version: %s\n", version.EksctlVersion)
 			fmt.Printf("kubectl version: %s\n", version.KubectlVersion)
 			fmt.Printf("OS: %s\n", version.OS)
 		case "json":
+			// JSON output format
 			fmt.Printf("%s\n", info.String())
 		default:
+			// Handle invalid output format
 			return fmt.Errorf("unknown output: %s", output)
 		}
 		return nil

--- a/pkg/ctl/misc/misc.go
+++ b/pkg/ctl/misc/misc.go
@@ -1,0 +1,17 @@
+// Package misc provides miscellaneous commands for eksctl that don't fit into other categories
+package misc
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+// Command registers all the miscellaneous commands to the root command
+// These include utility commands like version and info
+func Command(flagGrouping *cmdutils.FlagGrouping, rootCmd *cobra.Command) *cobra.Command {
+	// Register the info command to display system information
+	cmdutils.AddResourceCmd(flagGrouping, rootCmd, infoCmd)
+	// Register the version command to display eksctl version
+	cmdutils.AddResourceCmd(flagGrouping, rootCmd, versionCmd)
+	return rootCmd
+}

--- a/pkg/ctl/misc/version.go
+++ b/pkg/ctl/misc/version.go
@@ -1,4 +1,5 @@
-package main
+// Package misc provides miscellaneous commands for eksctl
+package misc
 
 import (
 	"fmt"
@@ -11,21 +12,34 @@ import (
 	"github.com/weaveworks/eksctl/pkg/version"
 )
 
+// versionCmd implements the 'version' command which displays the eksctl version
+// It supports both plain text and JSON output formats
 func versionCmd(cmd *cmdutils.Cmd) {
 	var output string
 
+	// Set up the command description and help text
 	cmd.SetDescription("version", "Output the version of eksctl", "")
+
+	// Define command flags
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		// Add -o/--output flag to specify output format
 		fs.StringVarP(&output, "output", "o", "", "specifies the output format (valid option: json)")
 	})
+
+	// This command doesn't accept any arguments
 	cmd.CobraCommand.Args = cobra.NoArgs
+
+	// Define the command execution logic
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		switch output {
 		case "":
+			// Default output format (plain text)
 			fmt.Printf("%s\n", version.GetVersion())
 		case "json":
+			// JSON output format
 			fmt.Printf("%s\n", version.String())
 		default:
+			// Handle invalid output format
 			return fmt.Errorf("unknown output: %s", output)
 		}
 		return nil


### PR DESCRIPTION
See README.md for details. Essentially when Amazon Q or Claude Desktop runs `eksctl mcp`, an Stdio based MCP server is started that understands all the commands that `eksctl` provides. You can then interact with EKS via the LLM in natural language and all the eksctl CLI commands are made available through the MCP interface.

Example chat using Amazon Q CLI
```
> what is the eksctl version?
I'll help you check the eksctl version. Let me run the version command to get that information for you.


🛠️  Using tool: eksctl_version from mcp server markdown_tools
 ⋮
 ● Running eksctl_version with the param:
 ⋮  {
 ⋮    "arguments": {},
 ⋮    "name": "eksctl_version"
 ⋮  }
Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> t

 ⋮
 ● Completed in 0.87s
The current eksctl version is:

0.209.0-dev+d1e143f58931.2025-06-08T19:04:37Z


This appears to be a development build of eksctl version 0.209.0, built on June 8, 2025.

> show me more eksctl info
Let me get more detailed information about your eksctl installation.


🛠️  Using tool: eksctl_info from mcp server markdown_tools
 ⋮
 ● Running eksctl_info with the param:
 ⋮  {
 ⋮    "arguments": {},
 ⋮    "name": "eksctl_info"
 ⋮  }
Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> t

 ⋮
 ● Completed in 0.285s
Here's the detailed information about your eksctl installation:

eksctl version: 0.209.0-dev+d1e143f58931.2025-06-08T19:04:37Z
kubectl version: v1.32.3
OS: darwin


This shows:
• You're running eksctl version 0.209.0-dev (a development build from June 8, 2025)
• You have kubectl version v1.32.3 installed
• You're running on macOS (darwin)

> are there any eks clusters running?
I'll check if there are any EKS clusters running in your AWS account.


🛠️  Using tool: eksctl_get_cluster from mcp server markdown_tools
 ⋮
 ● Running eksctl_get_cluster with the param:
 ⋮  {
 ⋮    "arguments": {},
 ⋮    "name": "eksctl_get_cluster"
 ⋮  }
Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> t

 ⋮
 ● Completed in 1.866s
I've used the eksctl tool to check for EKS clusters, and the result shows an empty list [], which means there are no EKS clusters currently running in your AWS account.

The eksctl get cluster command checks across your default AWS region for any EKS clusters. The empty JSON array in the response confirms that no clusters are present.

Would you like me to help you create a new EKS cluster using eksctl? I can guide you through the process if you're interested.

> can you start an eks cluster with kubernetes 1.32 using just one node?
I'll help you create an EKS cluster with Kubernetes 1.32 using just one node. Let me use the eksctl tool to set this up.


🛠️  Using tool: eksctl_create_cluster from mcp server markdown_tools
 ⋮
 ● Running eksctl_create_cluster with the param:
 ⋮  {
 ⋮    "arguments": {
 ⋮      "name": "my-cluster",
 ⋮      "nodes": "1",
 ⋮      "region": "us-west-2",
 ⋮      "version": "1.32"
 ⋮    },
 ⋮    "name": "eksctl_create_cluster"
 ⋮  }
Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> t

 ⋮
 ● Completed in 45.3s
I've started creating an EKS cluster with the following specifications:
• Name: my-cluster
• Kubernetes version: 1.32
• Number of nodes: 1
• Region: us-west-2

The cluster creation process is currently running in the background. This typically takes about 15-20 minutes to complete. The eksctl tool is handling the creation of all
necessary resources including:

1. The EKS control plane
2. A node group with a single EC2 instance
3. Required networking components (VPC, subnets, security groups)
4. IAM roles and policies

Once the cluster is ready, you'll be able to interact with it using kubectl. The kubeconfig file will be automatically updated to include the new cluster.

Would you like me to check the status of the cluster creation after a few minutes? Or is there anything specific you'd like to know about the cluster being created?
```

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

