### PR TITLE
Add support for custom Bottlerocket AMIs for MNG

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/managed_nodegroup_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/managed_nodegroup_test.go
@@ -84,7 +84,6 @@ var _ = Describe("Managed Nodegroup Validation", func() {
 					AMIFamily: "Bottlerocket",
 				},
 			},
-			errMsg: "cannot set amiFamily to Bottlerocket when using a custom AMI",
 		}),
 		Entry("Custom AMI with overrideBootstrapCommand", &nodeGroupCase{
 			ng: &ManagedNodeGroup{

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -2281,9 +2281,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			mng.AMIFamily = api.NodeImageFamilyBottlerocket
 			mng.OverrideBootstrapCommand = nil
 			err = api.ValidateManagedNodeGroup(0, mng)
-			errorMsg := fmt.Sprintf("cannot set amiFamily to %s when using a custom AMI for managed nodes, only %s are supported", mng.AMIFamily,
-				strings.Join(append(api.SupportedAmazonLinuxImages, api.SupportedUbuntuImages...), ", "))
-			Expect(err).To(MatchError(errorMsg))
+			Expect(err).NotTo(HaveOccurred())
 
 			mng.AMIFamily = api.NodeImageFamilyAmazonLinux2023
 			err = api.ValidateManagedNodeGroup(0, mng)

--- a/pkg/nodebootstrap/managed_bottlerocket.go
+++ b/pkg/nodebootstrap/managed_bottlerocket.go
@@ -2,7 +2,6 @@ package nodebootstrap
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	toml "github.com/pelletier/go-toml"
@@ -47,12 +46,13 @@ func (b *ManagedBottlerocket) UserData() (string, error) {
 		settings.Set(adminContainerEnabledKey, *enableAdminContainer)
 	}
 
-	userData := settings.String()
-	if userData == "" {
-		return "", errors.New("generated unexpected empty TOML user-data from input")
+	// Generate TOML for launch in this NodeGroup.
+	data, err := bottlerocketSettingsTOML(b.clusterConfig, b.ng.NodeGroupBase, settings)
+	if err != nil {
+		return "", err
 	}
 
-	return base64.StdEncoding.EncodeToString([]byte(userData)), nil
+	return base64.StdEncoding.EncodeToString([]byte(data)), nil
 }
 
 // setDerivedSettings configures settings that are derived from top-level nodegroup config

--- a/userdocs/src/usage/custom-ami-support.md
+++ b/userdocs/src/usage/custom-ami-support.md
@@ -89,7 +89,7 @@ managedNodeGroups:
 The `--node-ami-family` flag can also be used with `eksctl create nodegroup`. `eksctl` requires AMI Family to be explicitly set via config file or via `--node-ami-family` CLI flag, whenever working with a custom AMI.
 
 ???+ note
-    At the moment, EKS managed nodegroups only support the following AMI Families when working with custom AMIs: `AmazonLinux2023`, `AmazonLinux2`, `Ubuntu2004`, `Ubuntu2204` and `Ubuntu2404`
+    At the moment, EKS managed nodegroups only support the following AMI Families when working with custom AMIs: `AmazonLinux2023`, `AmazonLinux2`, `Bottlerocket`, `Ubuntu2004`, `Ubuntu2204` and `Ubuntu2404`
 
 ## Windows custom AMI support
 Only self-managed Windows nodegroups can specify a custom AMI. `amiFamily` should be set to a valid Windows AMI family.


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Currently, when creating MNGs using a custom Bottlerocket AMI with `eksctl`, we get the error:
```
Error: could not create cluster provider from options: cannot set amiFamily to Bottlerocket when using a custom AMI for managed nodes, only AmazonLinux2023, AmazonLinux2, UbuntuPro2404, Ubuntu2404, UbuntuPro2204, Ubuntu2204, Ubuntu2004, Ubuntu1804 are supported
```

This PR adds support for custom Bottlerocket AMIs for MNG.

Also, it improves tests in `managed_bottlerocket_test.go` so they verify specific settings rather than entire strings 😁

### Testing

- [ ] `make test`
- [ ] Manual test:
1. Locally built `eksctl`
2. Manifest with an MNG using a custom Bottlerocket AMI:
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: br-custom-ami-cluster
  region: us-west-2
  version: '1.31'

managedNodeGroups:
  - name: br-custom-ami-ng
    instanceType: m5.large
    desiredCapacity: 1
    ami: ami-02516a800443b52d6   # aws ssm get-parameters --names "/aws/service/bottlerocket/aws-k8s-1.31/x86_64/1.40.0/image_id" --region us-west-2
    amiFamily: Bottlerocket
    disableIMDSv1: true
    iam:
       attachPolicyARNs:
          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
    bottlerocket:
      settings:
        motd: "Hello from eksctl!"
```
3. `./eksctl create cluster -f <MANIFEST>` successfully creates cluster and MNG with custom AMI


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

