### PR TITLE
Add exact match check to use specified addon versions

### DIFF
--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -127,6 +127,10 @@ func (a *Manager) getLatestMatchingVersion(ctx context.Context, addon *api.Addon
 			return "", false, err
 		}
 
+		if addonVersion == *addonVersionInfo.AddonVersion {
+			return *addonVersionInfo.AddonVersion, addonVersionInfo.RequiresIamPermissions, nil
+		}
+
 		if addonVersion == "latest" || strings.Contains(*addonVersionInfo.AddonVersion, addonVersion) {
 			versions = append(versions, v)
 		}

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -85,6 +85,9 @@ var _ = Describe("Update", func() {
 						{
 							AddonVersion: aws.String("v1.0.0-eksbuild.2"),
 						},
+						{
+							AddonVersion: aws.String("v1.0.0-eksbuild.20"),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
# Add exact match check to use specified addon versions

### Description

The current addon version selection logic uses partial string matching to find the latest version among all matching candidates. This causes unexpected behavior when users specify exact versions.

For example, when a user runs:
```bash
eksctl update addon --cluster my-cluster --name coredns --version v1.0.0-eksbuild.2
```

The current implementation incorrectly selects `v1.0.0-eksbuild.20` instead of the specified `v1.0.0-eksbuild.2` , because `strings.Contains("v1.0.0-eksbuild.20", "v1.0.0-eksbuild.2")` returns `true`.

This Pull Request adds an exact match check before the partial matching logic in `getLatestMatchingVersion()`. 

### Manual Test Results

before
```bash
eksctl update addon --name coredns --version v1.11.4-eksbuild.1 --cluster <cluster-name> --force
2025-08-24 10:29:50 [!]  no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=ap-northeast-1 --cluster=<cluster-name>'
2025-08-24 10:29:50 [ℹ]  Kubernetes version "1.33" in use by cluster "<cluster-name>"
2025-08-24 10:29:50 [ℹ]  new version provided v1.11.4-eksbuild.14
2025-08-24 10:29:50 [ℹ]  updating addon
```

after
```bash
./eksctl update addon --name coredns --version v1.11.4-eksbuild.1 --cluster <cluster-name> --force
2025-08-24 10:27:27 [!]  no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=ap-northeast-1 --cluster=<cluster-name>'
2025-08-24 10:27:27 [ℹ]  Kubernetes version "1.33" in use by cluster "<cluster-name>"
2025-08-24 10:27:28 [ℹ]  new version provided v1.11.4-eksbuild.1
2025-08-24 10:27:28 [ℹ]  updating addon
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
=> I think no documentation changes are required as the modified behavior aligns with existing documentation expectations.
```
The addon version can be set to latest. Alternatively, the version can be set with the EKS build tag specified, such as v1.7.5-eksbuild.1 or v1.7.5-eksbuild.2. It can also be set to the release version of the addon, such as v1.7.5 or 1.7.5, and the eksbuild suffix tag will be discovered and set for you.
```
https://eksctl.io/usage/addons/
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

