### PR TITLE
remove namespace validation for update-addon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1
 	github.com/aws/aws-sdk-go-v2/service/eks v1.71.1
-	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.2
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.47.1
 	github.com/aws/aws-sdk-go-v2/service/kms v1.38.3

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/aws/aws-sdk-go-v2/service/eks v1.71.1 h1:94CuP2LDRD8zwfJIm+oOEx0vRuwo
 github.com/aws/aws-sdk-go-v2/service/eks v1.71.1/go.mod h1:ROhcontVJDIaR0dUrg2+EdGzJtdSzq+PnM06gNV5zK8=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.2 h1:5gfKj9+gRRVTzsrDp1z8AoEuSV3iLZpDJTiKsSqet6I=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.2/go.mod h1:Tdj16jxblwZwdRKwqRvTEgrPM8yG5aLBkT6VNUwAZ3U=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.0 h1:1Ene7r6v8NQdgc2KzqBO7ip/uBb2awfTf6K4XS6yVlg=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.0/go.mod h1:Tdj16jxblwZwdRKwqRvTEgrPM8yG5aLBkT6VNUwAZ3U=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.50.0 h1:Izk3Yw7XXSl3YsXcsfzY3tbaeh5sxiV/Rxc9YlLcmYs=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.50.0/go.mod h1:g8wrIE3I6tNQ9j/w+8aCkd/1kJGsvBuT7oh74prjdaI=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.36.12 h1:uH6GOnGSvVN9MCk6o3+HvZFpdqL7AzJKNOTM/6l+3/s=

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1 h1:+4A9SDduLZFlDeXWRmfQ6r8kyEJ
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.71.1 h1:94CuP2LDRD8zwfJIm+oOEx0vRuwodfon0BPImHs8aww=
 github.com/aws/aws-sdk-go-v2/service/eks v1.71.1/go.mod h1:ROhcontVJDIaR0dUrg2+EdGzJtdSzq+PnM06gNV5zK8=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.2 h1:5gfKj9+gRRVTzsrDp1z8AoEuSV3iLZpDJTiKsSqet6I=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.32.2/go.mod h1:Tdj16jxblwZwdRKwqRvTEgrPM8yG5aLBkT6VNUwAZ3U=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.0 h1:1Ene7r6v8NQdgc2KzqBO7ip/uBb2awfTf6K4XS6yVlg=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.0/go.mod h1:Tdj16jxblwZwdRKwqRvTEgrPM8yG5aLBkT6VNUwAZ3U=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.50.0 h1:Izk3Yw7XXSl3YsXcsfzY3tbaeh5sxiV/Rxc9YlLcmYs=

--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -824,8 +824,6 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 			Expect(cmd).NotTo(RunSuccessfully())
 		})
 
-
-
 		It("should work with addons that have no namespace config", func() {
 			By("creating an addon without namespace config")
 			clusterConfig.Addons = []*api.Addon{

--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -50,8 +50,6 @@ func (a *Manager) Update(ctx context.Context, addon *api.Addon, podIdentityIAMUp
 		return err
 	}
 
-
-
 	var requiresIAMPermissions bool
 	if addon.Version == "" {
 		// preserve existing version
@@ -222,5 +220,3 @@ func (a *Manager) createNewTemplate(addon *api.Addon, namespace, serviceAccount 
 	}
 	return resourceSet.RenderJSON()
 }
-
-

--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -50,10 +50,7 @@ func (a *Manager) Update(ctx context.Context, addon *api.Addon, podIdentityIAMUp
 		return err
 	}
 
-	// Validate namespace config immutability
-	if err := a.validateNamespaceConfigImmutability(addon, &summary); err != nil {
-		return err
-	}
+
 
 	var requiresIAMPermissions bool
 	if addon.Version == "" {
@@ -226,33 +223,4 @@ func (a *Manager) createNewTemplate(addon *api.Addon, namespace, serviceAccount 
 	return resourceSet.RenderJSON()
 }
 
-// validateNamespaceConfigImmutability validates that namespace configuration is not being modified during update
-func (a *Manager) validateNamespaceConfigImmutability(addon *api.Addon, summary *Summary) error {
-	existingNamespace := ""
-	if summary.NamespaceConfig != nil {
-		existingNamespace = summary.NamespaceConfig.Namespace
-	}
 
-	requestedNamespace := ""
-	if addon.NamespaceConfig != nil {
-		requestedNamespace = addon.NamespaceConfig.Namespace
-	}
-
-	// Compare existing and requested namespace configurations
-	if existingNamespace != requestedNamespace {
-		existingDisplay := "<none>"
-		if existingNamespace != "" {
-			existingDisplay = fmt.Sprintf("%q", existingNamespace)
-		}
-
-		requestedDisplay := "<none>"
-		if requestedNamespace != "" {
-			requestedDisplay = fmt.Sprintf("%q", requestedNamespace)
-		}
-
-		return fmt.Errorf("invalid configuration for %q addon: namespace configuration cannot be modified after addon creation (existing: %s, requested: %s)",
-			addon.Name, existingDisplay, requestedDisplay)
-	}
-
-	return nil
-}

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -687,7 +687,6 @@ var _ = Describe("Update", func() {
 
 })
 
-
 var _ = Describe("Update - Namespace Config Updates", func() {
 	var (
 		addonManager     *addon.Manager

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -687,7 +687,8 @@ var _ = Describe("Update", func() {
 
 })
 
-var _ = Describe("Update - Namespace Config Immutability", func() {
+
+var _ = Describe("Update - Namespace Config Updates", func() {
 	var (
 		addonManager     *addon.Manager
 		mockProvider     *mockprovider.MockProvider
@@ -707,21 +708,9 @@ var _ = Describe("Update - Namespace Config Immutability", func() {
 		mockProvider = mockprovider.NewMockProvider()
 		fakeStackManager = new(fakes.FakeStackManager)
 
-		fakeStackManager.CreateStackStub = func(_ context.Context, _ string, rs builder.ResourceSetReader, _ map[string]string, _ map[string]string, errs chan error) error {
-			go func() {
-				errs <- nil
-			}()
-			Expect(rs).To(BeAssignableToTypeOf(&builder.IAMRoleResourceSet{}))
-			rs.(*builder.IAMRoleResourceSet).OutputRole = "new-service-account-role-arn"
-			return nil
-		}
-
 		oidc := makeOIDCManager()
 
-		mockProvider.MockEKS().On("DescribeAddonVersions", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			Expect(args).To(HaveLen(2))
-			Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonVersionsInput{}))
-		}).Return(&awseks.DescribeAddonVersionsOutput{
+		mockProvider.MockEKS().On("DescribeAddonVersions", mock.Anything, mock.Anything).Return(&awseks.DescribeAddonVersionsOutput{
 			Addons: []ekstypes.AddonInfo{
 				{
 					AddonName: aws.String("my-addon"),
@@ -742,25 +731,29 @@ var _ = Describe("Update - Namespace Config Immutability", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("namespace config immutability", func() {
+	Context("namespace config updates", func() {
 		var podIdentityIAMUpdater mocks.PodIdentityIAMUpdater
 
-		When("attempting to modify namespace config", func() {
-			It("returns an error when trying to change namespace config", func() {
+		When("updating addon with different namespace config", func() {
+			It("succeeds without validation error", func() {
 				// Mock DescribeAddon to return an addon with existing namespace config
-				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonInput{}))
-				}).Return(&awseks.DescribeAddonOutput{
+				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Return(&awseks.DescribeAddonOutput{
 					Addon: &ekstypes.Addon{
-						AddonName:    aws.String("my-addon"),
-						AddonVersion: aws.String("v1.0.0-eksbuild.2"),
-						Status:       "created",
+						AddonName:             aws.String("my-addon"),
+						AddonVersion:          aws.String("v1.0.0-eksbuild.2"),
+						ServiceAccountRoleArn: aws.String("original-arn"),
+						Status:                "created",
 						NamespaceConfig: &ekstypes.AddonNamespaceConfigResponse{
 							Namespace: aws.String("existing-namespace"),
 						},
 					},
 				}, nil).Once()
+
+				mockProvider.MockEKS().On("UpdateAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					Expect(args).To(HaveLen(2))
+					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.UpdateAddonInput{}))
+					updateAddonInput = args[1].(*awseks.UpdateAddonInput)
+				}).Return(&awseks.UpdateAddonOutput{}, nil).Once()
 
 				err := addonManager.Update(context.Background(), &api.Addon{
 					Name:    "my-addon",
@@ -770,168 +763,7 @@ var _ = Describe("Update - Namespace Config Immutability", func() {
 					},
 				}, &podIdentityIAMUpdater, 0)
 
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("namespace configuration cannot be modified after addon creation")))
-				Expect(err).To(MatchError(ContainSubstring("existing: \"existing-namespace\", requested: \"new-namespace\"")))
-			})
-
-			It("returns an error when trying to add namespace config to addon without one", func() {
-				// Mock DescribeAddon to return an addon without namespace config
-				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonInput{}))
-				}).Return(&awseks.DescribeAddonOutput{
-					Addon: &ekstypes.Addon{
-						AddonName:       aws.String("my-addon"),
-						AddonVersion:    aws.String("v1.0.0-eksbuild.2"),
-						Status:          "created",
-						NamespaceConfig: nil, // No existing namespace config
-					},
-				}, nil).Once()
-
-				err := addonManager.Update(context.Background(), &api.Addon{
-					Name:    "my-addon",
-					Version: "v1.0.0-eksbuild.2",
-					NamespaceConfig: &api.AddonNamespaceConfig{
-						Namespace: "new-namespace",
-					},
-				}, &podIdentityIAMUpdater, 0)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("namespace configuration cannot be modified after addon creation")))
-				Expect(err).To(MatchError(ContainSubstring("existing: <none>, requested: \"new-namespace\"")))
-			})
-
-			It("returns an error when trying to remove namespace config from addon with one", func() {
-				// Mock DescribeAddon to return an addon with existing namespace config
-				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonInput{}))
-				}).Return(&awseks.DescribeAddonOutput{
-					Addon: &ekstypes.Addon{
-						AddonName:    aws.String("my-addon"),
-						AddonVersion: aws.String("v1.0.0-eksbuild.2"),
-						Status:       "created",
-						NamespaceConfig: &ekstypes.AddonNamespaceConfigResponse{
-							Namespace: aws.String("existing-namespace"),
-						},
-					},
-				}, nil).Once()
-
-				err := addonManager.Update(context.Background(), &api.Addon{
-					Name:            "my-addon",
-					Version:         "v1.0.0-eksbuild.2",
-					NamespaceConfig: nil, // Trying to remove namespace config
-				}, &podIdentityIAMUpdater, 0)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("namespace configuration cannot be modified after addon creation")))
-				Expect(err).To(MatchError(ContainSubstring("existing: \"existing-namespace\", requested: <none>")))
-			})
-		})
-
-		When("namespace config is unchanged", func() {
-			It("succeeds when namespace config is identical", func() {
-				// Mock DescribeAddon to return an addon with existing namespace config
-				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonInput{}))
-				}).Return(&awseks.DescribeAddonOutput{
-					Addon: &ekstypes.Addon{
-						AddonName:             aws.String("my-addon"),
-						AddonVersion:          aws.String("v1.0.0-eksbuild.2"),
-						ServiceAccountRoleArn: aws.String("original-arn"),
-						Status:                "created",
-						NamespaceConfig: &ekstypes.AddonNamespaceConfigResponse{
-							Namespace: aws.String("same-namespace"),
-						},
-					},
-				}, nil).Once()
-
-				mockProvider.MockEKS().On("UpdateAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.UpdateAddonInput{}))
-					updateAddonInput = args[1].(*awseks.UpdateAddonInput)
-				}).Return(&awseks.UpdateAddonOutput{}, nil).Once()
-
-				err := addonManager.Update(context.Background(), &api.Addon{
-					Name:    "my-addon",
-					Version: "v1.0.0-eksbuild.2",
-					NamespaceConfig: &api.AddonNamespaceConfig{
-						Namespace: "same-namespace",
-					},
-				}, &podIdentityIAMUpdater, 0)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(*updateAddonInput.ClusterName).To(Equal("my-cluster"))
-				Expect(*updateAddonInput.AddonName).To(Equal("my-addon"))
-				Expect(*updateAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.2"))
-			})
-
-			It("succeeds when both namespace configs are nil", func() {
-				// Mock DescribeAddon to return an addon without namespace config
-				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonInput{}))
-				}).Return(&awseks.DescribeAddonOutput{
-					Addon: &ekstypes.Addon{
-						AddonName:             aws.String("my-addon"),
-						AddonVersion:          aws.String("v1.0.0-eksbuild.2"),
-						ServiceAccountRoleArn: aws.String("original-arn"),
-						Status:                "created",
-						NamespaceConfig:       nil, // No existing namespace config
-					},
-				}, nil).Once()
-
-				mockProvider.MockEKS().On("UpdateAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.UpdateAddonInput{}))
-					updateAddonInput = args[1].(*awseks.UpdateAddonInput)
-				}).Return(&awseks.UpdateAddonOutput{}, nil).Once()
-
-				err := addonManager.Update(context.Background(), &api.Addon{
-					Name:            "my-addon",
-					Version:         "v1.0.0-eksbuild.2",
-					NamespaceConfig: nil, // No new namespace config either
-				}, &podIdentityIAMUpdater, 0)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(*updateAddonInput.ClusterName).To(Equal("my-cluster"))
-				Expect(*updateAddonInput.AddonName).To(Equal("my-addon"))
-				Expect(*updateAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.2"))
-			})
-
-			It("succeeds when both namespace configs have empty namespace", func() {
-				// Mock DescribeAddon to return an addon with empty namespace config
-				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonInput{}))
-				}).Return(&awseks.DescribeAddonOutput{
-					Addon: &ekstypes.Addon{
-						AddonName:             aws.String("my-addon"),
-						AddonVersion:          aws.String("v1.0.0-eksbuild.2"),
-						ServiceAccountRoleArn: aws.String("original-arn"),
-						Status:                "created",
-						NamespaceConfig: &ekstypes.AddonNamespaceConfigResponse{
-							Namespace: aws.String(""), // Empty namespace
-						},
-					},
-				}, nil).Once()
-
-				mockProvider.MockEKS().On("UpdateAddon", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					Expect(args).To(HaveLen(2))
-					Expect(args[1]).To(BeAssignableToTypeOf(&awseks.UpdateAddonInput{}))
-					updateAddonInput = args[1].(*awseks.UpdateAddonInput)
-				}).Return(&awseks.UpdateAddonOutput{}, nil).Once()
-
-				err := addonManager.Update(context.Background(), &api.Addon{
-					Name:    "my-addon",
-					Version: "v1.0.0-eksbuild.2",
-					NamespaceConfig: &api.AddonNamespaceConfig{
-						Namespace: "", // Empty namespace
-					},
-				}, &podIdentityIAMUpdater, 0)
-
+				// Should succeed without namespace config immutability error
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*updateAddonInput.ClusterName).To(Equal("my-cluster"))
 				Expect(*updateAddonInput.AddonName).To(Equal("my-addon"))

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -2164,6 +2164,16 @@ func (in *PodIdentityAssociation) DeepCopyInto(out *PodIdentityAssociation) {
 			(*out)[key] = val
 		}
 	}
+	if in.TargetRoleARN != nil {
+		in, out := &in.TargetRoleARN, &out.TargetRoleARN
+		*out = new(string)
+		**out = **in
+	}
+	if in.DisableSessionTags != nil {
+		in, out := &in.DisableSessionTags, &out.DisableSessionTags
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/ctl/update/addon_test.go
+++ b/pkg/ctl/update/addon_test.go
@@ -31,33 +31,7 @@ var _ = Describe("update addon", func() {
 		})
 	})
 
-	Describe("namespace config immutability validation", func() {
-		Context("attempting to modify namespace config", func() {
-			cfg := &api.ClusterConfig{
-				TypeMeta: api.ClusterConfigTypeMeta(),
-				Metadata: &api.ClusterMeta{
-					Name:   "cluster-1",
-					Region: "us-west-2",
-				},
-				Addons: []*api.Addon{
-					{
-						Name: "vpc-cni",
-						NamespaceConfig: &api.AddonNamespaceConfig{
-							Namespace: "custom-namespace",
-						},
-					},
-				},
-			}
-			It("should return an immutability error", func() {
-				cmd := newMockCmd("addon", "--config-file", ctltest.CreateConfigFile(cfg))
-				_, err := cmd.execute()
-				// Note: The actual immutability check happens in the update logic
-				// This test validates that the config parsing works correctly
-				// The immutability error would come from the update action logic
-				Expect(err).ToNot(MatchError(ContainSubstring("is not a valid Kubernetes namespace name")))
-			})
-		})
-
+	Describe("namespace config validation", func() {
 		Context("with invalid namespace config during update", func() {
 			cfg := &api.ClusterConfig{
 				TypeMeta: api.ClusterConfigTypeMeta(),


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
#### Problem
The validateNamespaceConfigImmutability() function in addon updates was causing false positive validation errors. The EKS DescribeAddon API can return a default namespace even when no namespace was explicitly specified during addon creation, which could cause unnecessary validation failures when users attempt to update addons.

#### Solution
Removed the namespace configuration immutability validation from the addon update process to allow legitimate namespace configuration updates.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

