### PR TITLE
add notify homebrew update workflow

### DIFF
--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,0 +1,21 @@
+name: Notify Homebrew Update
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create update issue
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/aws/homebrew-tap/issues \
+            -d '{
+              "title": "Update eksctl to ${{ github.event.release.tag_name }}",
+              "body": "New eksctl release ${{ github.event.release.tag_name }} is available.\n\nRelease URL: ${{ github.event.release.html_url }}",
+              "labels": ["eksctl-update"]
+            }'


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Adds a GitHub workflow that automatically notifies the AWS Homebrew tap when a new eksctl release is published. The homebrew-tap repository has a corresponding workflow that responds to these issues by automatically updating the eksctl formula https://github.com/aws/homebrew-tap/pull/635


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

