### PR TITLE
fix: Fix GPU instance filtering when --instance-selector-gpus=0

### DIFF
--- a/pkg/eks/nodegroup_service.go
+++ b/pkg/eks/nodegroup_service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/outposts"
 	"github.com/weaveworks/eksctl/pkg/ssh"
+	"github.com/weaveworks/eksctl/pkg/utils/instance"
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 )
 
@@ -238,6 +239,22 @@ func (n *NodeGroupService) expandInstanceSelector(ins *api.InstanceSelector, azs
 	}
 	if len(instanceTypes) == 0 {
 		return nil, errors.New("instance selector criteria matched no instances; consider broadening your criteria so that more instance types are returned")
+	}
+
+	// Workaround for AWS API bug: filter out GPU instances when GPUs=0 is specified
+	// AWS incorrectly reports GPU count as 0 for some GPU instances (e.g., g6f family)
+	if ins.GPUs != nil && *ins.GPUs == 0 {
+		filteredTypes := make([]string, 0, len(instanceTypes))
+		for _, instanceType := range instanceTypes {
+			if !instance.IsGPUInstanceType(instanceType) {
+				filteredTypes = append(filteredTypes, instanceType)
+			}
+		}
+		instanceTypes = filteredTypes
+
+		if len(instanceTypes) == 0 {
+			return nil, errors.New("instance selector criteria matched no non-GPU instances; consider broadening your criteria")
+		}
 	}
 
 	return instanceTypes, nil

--- a/pkg/eks/nodegroup_service_gpu_test.go
+++ b/pkg/eks/nodegroup_service_gpu_test.go
@@ -1,0 +1,97 @@
+package eks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/amazon-ec2-instance-selector/v3/pkg/selector"
+	"github.com/stretchr/testify/assert"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+)
+
+// MockInstanceSelector for testing
+type MockInstanceSelector struct {
+	returnInstances []string
+	returnError     error
+}
+
+func (m *MockInstanceSelector) Filter(ctx context.Context, filters selector.Filters) ([]string, error) {
+	return m.returnInstances, m.returnError
+}
+
+func TestExpandInstanceSelector_GPUFiltering(t *testing.T) {
+	tests := []struct {
+		name                string
+		instanceSelector    *api.InstanceSelector
+		mockReturnInstances []string
+		expectedInstances   []string
+		expectError         bool
+	}{
+		{
+			name: "filters out GPU instances when GPUs=0",
+			instanceSelector: &api.InstanceSelector{
+				VCPUs: 8,
+				GPUs:  newIntPtr(0),
+			},
+			mockReturnInstances: []string{"m5.2xlarge", "g6f.2xlarge", "c5.2xlarge", "g4dn.xlarge"},
+			expectedInstances:   []string{"m5.2xlarge", "c5.2xlarge"},
+			expectError:         false,
+		},
+		{
+			name: "includes GPU instances when GPUs=1",
+			instanceSelector: &api.InstanceSelector{
+				VCPUs: 8,
+				GPUs:  newIntPtr(1),
+			},
+			mockReturnInstances: []string{"m5.2xlarge", "g6f.2xlarge", "c5.2xlarge", "g4dn.xlarge"},
+			expectedInstances:   []string{"m5.2xlarge", "g6f.2xlarge", "c5.2xlarge", "g4dn.xlarge"},
+			expectError:         false,
+		},
+		{
+			name: "no filtering when GPUs is nil",
+			instanceSelector: &api.InstanceSelector{
+				VCPUs: 8,
+			},
+			mockReturnInstances: []string{"m5.2xlarge", "g6f.2xlarge", "c5.2xlarge"},
+			expectedInstances:   []string{"m5.2xlarge", "g6f.2xlarge", "c5.2xlarge"},
+			expectError:         false,
+		},
+		{
+			name: "error when all instances are filtered out",
+			instanceSelector: &api.InstanceSelector{
+				VCPUs: 8,
+				GPUs:  newIntPtr(0),
+			},
+			mockReturnInstances: []string{"g6f.2xlarge", "g4dn.xlarge"},
+			expectedInstances:   nil,
+			expectError:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSelector := &MockInstanceSelector{
+				returnInstances: tt.mockReturnInstances,
+			}
+
+			service := &NodeGroupService{
+				instanceSelector: mockSelector,
+			}
+
+			result, err := service.expandInstanceSelector(tt.instanceSelector, []string{"us-west-2a"})
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedInstances, result)
+			}
+		})
+	}
+}
+
+func newIntPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
### Description
The AWS DescribeInstanceTypes API incorrectly reports GPU count as 0 for g6f family instances (g6f.large, g6f.xlarge, g6f.2xlarge, g6f.4xlarge) even though they have 1 L4 GPU each. This caused the instance selector to include these GPU instances when users specified `--instance-selector-gpus=0`. e.g.

```
aws ec2 describe-instance-types --instance-types g6f.2xlarge --query "InstanceTypes[].GpuInfo" 
[
    {
        "Gpus": [
            {
                "Name": "L4",
                "Manufacturer": "NVIDIA",
                "Count": 0,
                "MemoryInfo": {
                    "SizeInMiB": 5722
                }
            }
        ],
        "TotalGpuMemoryInMiB": 5722
    }
```

This is inconsistent with the latest ec2 doc https://docs.aws.amazon.com/ec2/latest/instancetypes/ac.html

This fix adds an additional filtering step that uses eksctl's accurate local instance types map to remove GPU instances when GPUs=0 is specified, while preserving existing behavior for all other cases.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

