### PR TITLE
fix: match cloudformation stack name using suffix for pod identity association 

### DIFF
--- a/pkg/actions/podidentityassociation/stack_matching_test.go
+++ b/pkg/actions/podidentityassociation/stack_matching_test.go
@@ -1,0 +1,136 @@
+package podidentityassociation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIAMResourcesStack(t *testing.T) {
+	tests := []struct {
+		name          string
+		stackNames    []string
+		identifier    Identifier
+		expectedStack string
+		expectedFound bool
+		description   string
+	}{
+		{
+			name: "exact match found",
+			stackNames: []string{
+				"eksctl-cluster-podidentityrole-service-service-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "eksctl-cluster-podidentityrole-service-service-account",
+			expectedFound: true,
+			description:   "Should find exact match",
+		},
+		{
+			name: "no substring false positive",
+			stackNames: []string{
+				"eksctl-cluster-podidentityrole-other-service-service-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "",
+			expectedFound: false,
+			description:   "Should not match 'service-service-account' as substring of 'other-service-service-account'",
+		},
+		{
+			name: "multiple stacks with correct match",
+			stackNames: []string{
+				"eksctl-cluster-podidentityrole-other-service-service-account",
+				"eksctl-cluster-podidentityrole-service-service-account",
+				"eksctl-cluster-podidentityrole-another-service-different-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "eksctl-cluster-podidentityrole-service-service-account",
+			expectedFound: true,
+			description:   "Should find correct match among multiple stacks",
+		},
+		{
+			name: "no match found",
+			stackNames: []string{
+				"eksctl-cluster-podidentityrole-other-service-service-account",
+				"eksctl-cluster-podidentityrole-another-service-different-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "",
+			expectedFound: false,
+			description:   "Should not find any match",
+		},
+		{
+			name: "customer reported case",
+			stackNames: []string{
+				"eksctl-cluster-podidentityrole-service-service-account",
+				"eksctl-cluster-podidentityrole-other-service-service-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "eksctl-cluster-podidentityrole-service-service-account",
+			expectedFound: true,
+			description:   "Customer reported case: should match 'service' not 'other-service'",
+		},
+		{
+			name: "customer reported case reverse",
+			stackNames: []string{
+				"eksctl-cluster-podidentityrole-service-service-account",
+				"eksctl-cluster-podidentityrole-other-service-service-account",
+			},
+			identifier: Identifier{
+				Namespace:          "other-service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "eksctl-cluster-podidentityrole-other-service-service-account",
+			expectedFound: true,
+			description:   "Customer reported case reverse: should match 'other-service' not 'service'",
+		},
+		{
+			name: "IRSAv1 pattern match",
+			stackNames: []string{
+				"eksctl-cluster-addon-iamserviceaccount-service-service-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "eksctl-cluster-addon-iamserviceaccount-service-service-account",
+			expectedFound: true,
+			description:   "Should match IRSAv1 pattern",
+		},
+		{
+			name: "IRSAv1 no substring false positive",
+			stackNames: []string{
+				"eksctl-cluster-addon-iamserviceaccount-other-service-service-account",
+			},
+			identifier: Identifier{
+				Namespace:          "service",
+				ServiceAccountName: "service-account",
+			},
+			expectedStack: "",
+			expectedFound: false,
+			description:   "Should not match IRSAv1 'service-service-account' as substring of 'other-service-service-account'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualStack, actualFound := getIAMResourcesStack(tt.stackNames, tt.identifier)
+			assert.Equal(t, tt.expectedFound, actualFound, tt.description)
+			assert.Equal(t, tt.expectedStack, actualStack, tt.description)
+		})
+	}
+}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Issue: https://github.com/eksctl-io/eksctl/issues/8484

When updating or deleting pod identity associations, the wrong CloudFormation stack could be targeted due to substring matching in the `getIAMResourcesStack` function. This occurred when namespace names were substrings of other namespace names.

This PR replaced substring matching with exact suffix matching to handle both IRSAv1 and IRSAv2 stack naming patterns

Manually tested on a cluster by creating two pod identity associations `other-service-service-account` and `service-service-account`, delete `service-service-account` successfully
```
aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE DELETE_COMPLETE --query 'StackSummaries[?contains(StackName, `podidentityrole`) && contains(StackName, `service`)].{StackName:StackName,StackStatus:StackStatus,DeletionTime:DeletionTime}' -
-output table
---------------------------------------------------------------------------------------------------------------------------------
|                                                          ListStacks                                                           |
+--------------------------+--------------------------------------------------------------------------------+-------------------+
|       DeletionTime       |                                   StackName                                    |    StackStatus    |
+--------------------------+--------------------------------------------------------------------------------+-------------------+
|  None                    |  eksctl-xxxxxxx-podidentityrole-other-service-service-account        |  CREATE_COMPLETE  |
|  2025-09-20T01:13:13.415Z|  eksctl-xxxxxxxx-podidentityrole-service-service-account              |  DELETE_COMPLETE  |
```


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

