### PR TITLE
docs: Add Auto Mode behavior change notices

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -36,6 +36,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 	"github.com/weaveworks/eksctl/pkg/outposts"
 	"github.com/weaveworks/eksctl/pkg/printers"
+	"github.com/weaveworks/eksctl/pkg/utils/deprecation"
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 	"github.com/weaveworks/eksctl/pkg/utils/names"
 	"github.com/weaveworks/eksctl/pkg/utils/nodes"
@@ -305,6 +306,9 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	if err := nodeGroupService.Normalize(ctx, nodePools, cfg); err != nil {
 		return err
 	}
+
+	// Check for Auto Mode deprecation warning
+	deprecation.CheckAutoModeDeprecation(cfg)
 
 	logger.Info("using Kubernetes version %s", meta.Version)
 	logger.Info("creating %s", cfg.LogString())

--- a/pkg/utils/deprecation/auto_mode.go
+++ b/pkg/utils/deprecation/auto_mode.go
@@ -1,0 +1,62 @@
+package deprecation
+
+import (
+	"github.com/kris-nova/logger"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+)
+
+// AutoModeDeprecationConfig holds deprecation warning settings
+type AutoModeDeprecationConfig struct {
+	Message          string
+	DocumentationURL string
+	LogLevel         string
+}
+
+// DefaultAutoModeDeprecationConfig returns default deprecation warning config
+func DefaultAutoModeDeprecationConfig() *AutoModeDeprecationConfig {
+	return &AutoModeDeprecationConfig{
+		Message: "Auto Mode will be enabled by default in an upcoming release of eksctl. " +
+			"This means managed node groups and managed networking add-ons will no longer be created by default. " +
+			"To maintain current behavior, explicitly set 'autoModeConfig.enabled: false' in your cluster configuration.",
+		DocumentationURL: "https://eksctl.io/usage/auto-mode/",
+		LogLevel:         "warning",
+	}
+}
+
+// CheckAutoModeDeprecation shows deprecation warning if needed
+func CheckAutoModeDeprecation(cfg *v1alpha5.ClusterConfig) {
+	if shouldShowAutoModeDeprecationWarning(cfg) {
+		logAutoModeDeprecationWarning(DefaultAutoModeDeprecationConfig())
+	}
+}
+
+// CheckAutoModeDeprecationWithConfig shows deprecation warning with custom config
+func CheckAutoModeDeprecationWithConfig(cfg *v1alpha5.ClusterConfig, deprecationConfig *AutoModeDeprecationConfig) {
+	if shouldShowAutoModeDeprecationWarning(cfg) {
+		logAutoModeDeprecationWarning(deprecationConfig)
+	}
+}
+
+// shouldShowAutoModeDeprecationWarning returns true if warning should be shown
+func shouldShowAutoModeDeprecationWarning(cfg *v1alpha5.ClusterConfig) bool {
+	// Show warning only when AutoMode is nil or Enabled is nil (not explicitly set)
+	return cfg.AutoModeConfig == nil || cfg.AutoModeConfig.Enabled == nil
+}
+
+// logAutoModeDeprecationWarning logs the deprecation warning
+func logAutoModeDeprecationWarning(config *AutoModeDeprecationConfig) {
+	fullMessage := config.Message
+	if config.DocumentationURL != "" {
+		fullMessage += " Learn more: " + config.DocumentationURL
+	}
+
+	// Log at configured level
+	switch config.LogLevel {
+	case "info":
+		logger.Info(fullMessage)
+	case "warning":
+		logger.Warning(fullMessage)
+	default:
+		logger.Warning(fullMessage)
+	}
+}

--- a/pkg/utils/deprecation/auto_mode_test.go
+++ b/pkg/utils/deprecation/auto_mode_test.go
@@ -1,0 +1,121 @@
+package deprecation
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+)
+
+func TestShouldShowAutoModeDeprecationWarning_NilConfig(t *testing.T) {
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: nil,
+	}
+
+	result := shouldShowAutoModeDeprecationWarning(cfg)
+	if !result {
+		t.Error("Expected warning to be shown when AutoModeConfig is nil")
+	}
+}
+
+func TestShouldShowAutoModeDeprecationWarning_NilEnabled(t *testing.T) {
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: &v1alpha5.AutoModeConfig{
+			Enabled: nil,
+		},
+	}
+
+	result := shouldShowAutoModeDeprecationWarning(cfg)
+	if !result {
+		t.Error("Expected warning to be shown when AutoModeConfig.Enabled is nil")
+	}
+}
+
+func TestShouldShowAutoModeDeprecationWarning_ExplicitlyFalse(t *testing.T) {
+	enabled := false
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: &v1alpha5.AutoModeConfig{
+			Enabled: &enabled,
+		},
+	}
+
+	result := shouldShowAutoModeDeprecationWarning(cfg)
+	if result {
+		t.Error("Expected no warning when AutoModeConfig.Enabled is explicitly false")
+	}
+}
+
+func TestShouldShowAutoModeDeprecationWarning_ExplicitlyTrue(t *testing.T) {
+	enabled := true
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: &v1alpha5.AutoModeConfig{
+			Enabled: &enabled,
+		},
+	}
+
+	result := shouldShowAutoModeDeprecationWarning(cfg)
+	if result {
+		t.Error("Expected no warning when AutoModeConfig.Enabled is explicitly true")
+	}
+}
+
+func TestDefaultAutoModeDeprecationConfig(t *testing.T) {
+	config := DefaultAutoModeDeprecationConfig()
+
+	if config.Message == "" {
+		t.Error("Expected default message to be non-empty")
+	}
+
+	if config.DocumentationURL == "" {
+		t.Error("Expected default documentation URL to be non-empty")
+	}
+
+	if config.LogLevel != "warning" {
+		t.Errorf("Expected default log level to be 'warning', got '%s'", config.LogLevel)
+	}
+
+	expectedMessage := "Auto Mode will be enabled by default in an upcoming release of eksctl. " +
+		"This means managed node groups and managed networking add-ons will no longer be created by default. " +
+		"To maintain current behavior, explicitly set 'autoModeConfig.enabled: false' in your cluster configuration."
+
+	if config.Message != expectedMessage {
+		t.Errorf("Expected default message to match specification")
+	}
+}
+
+func TestCheckAutoModeDeprecation_WithNilConfig(t *testing.T) {
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: nil,
+	}
+
+	// This test verifies the function doesn't panic and executes the warning logic
+	// We can't easily test the actual logging without mocking the logger
+	CheckAutoModeDeprecation(cfg)
+}
+
+func TestCheckAutoModeDeprecation_WithExplicitlySetConfig(t *testing.T) {
+	enabled := false
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: &v1alpha5.AutoModeConfig{
+			Enabled: &enabled,
+		},
+	}
+
+	// This test verifies the function doesn't show warning when explicitly set
+	// Since we can't easily mock the logger, we just ensure it doesn't panic
+	CheckAutoModeDeprecation(cfg)
+}
+
+func TestCheckAutoModeDeprecationWithConfig_CustomConfig(t *testing.T) {
+	cfg := &v1alpha5.ClusterConfig{
+		AutoModeConfig: nil,
+	}
+
+	customConfig := &AutoModeDeprecationConfig{
+		Message:          "Custom test message",
+		DocumentationURL: "https://example.com",
+		LogLevel:         "info",
+	}
+
+	// This test verifies the function accepts custom configuration
+	CheckAutoModeDeprecationWithConfig(cfg, customConfig)
+}

--- a/userdocs/src/usage/auto-mode.md
+++ b/userdocs/src/usage/auto-mode.md
@@ -1,5 +1,15 @@
 # EKS Auto Mode
 
+> **⚠️ UPCOMING BEHAVIOR CHANGE**
+> 
+> Auto Mode will be enabled by default in an upcoming release of eksctl. 
+> This means managed node groups will no longer be created by default when creating clusters.
+> 
+> **If you want to maintain the current behavior** (creating managed node groups and networking add-ons - VPC-CNI, CoreDNS, kube-proxy by default), 
+> you must explicitly set `autoModeConfig.enabled: false` in your cluster configuration.
+> 
+> This change affects clusters created without an explicit `autoModeConfig` section.
+
 ## Introduction
 
 eksctl supports [EKS Auto Mode][eks-user-guide], a feature that extends AWS management of Kubernetes clusters beyond the cluster itself,


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
- Add prominent warning banner to auto-mode.md about upcoming default behavior change
- Inform users that managed node groups will no longer be created by default

manually tested locally:
```
./eksctl create cluster                      
2025-09-23 18:08:56 [ℹ]  eksctl version 0.215.0-dev+8e3a4e735.2025-09-23T18:07:21Z
2025-09-23 18:08:56 [ℹ]  using region us-west-2
2025-09-23 18:08:56 [ℹ]  setting availability zones to [us-west-2a us-west-2c us-west-2d]
2025-09-23 18:08:56 [ℹ]  subnets for us-west-2a - public:192.168.0.0/19 private:192.168.96.0/19
2025-09-23 18:08:56 [ℹ]  subnets for us-west-2c - public:192.168.32.0/19 private:192.168.128.0/19
2025-09-23 18:08:56 [ℹ]  subnets for us-west-2d - public:192.168.64.0/19 private:192.168.160.0/19
2025-09-23 18:08:56 [ℹ]  nodegroup "ng-07d89506" will use "" [AmazonLinux2023/1.32]
2025-09-23 18:08:56 [!]  Auto Mode will be enabled by default in an upcoming release of eksctl. This means managed node groups will no longer be created by default. To maintain current behavior, explicitly set 'autoModeConfig.enabled: false' in your cluster configuration. Learn more: https://eksctl.io/usage/auto-mode/
2025-09-23 18:08:56 [ℹ]  using Kubernetes version 1.32
2025-09-23 18:08:56 [ℹ]  creating EKS cluster "beautiful-painting-1758676136" in "us-west-2" region with managed nodes
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

