### PR TITLE
fix: duplicate --max-pods arguments in KUBELET_EXTRA_ARGS

### DIFF
--- a/pkg/nodebootstrap/managed_al2.go
+++ b/pkg/nodebootstrap/managed_al2.go
@@ -91,7 +91,7 @@ func makeMaxPodsScript(maxPods int) string {
 	script := `#!/bin/sh
 set -ex
 `
-	script += fmt.Sprintf(`sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$2 --max-pods=%d"/' /etc/eks/bootstrap.sh`, maxPods)
+	script += fmt.Sprintf(`sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$(echo "$2" | sed "s/--max-pods=[0-9]*//" | sed "s/  */ /g" | sed "s/^ *//" | sed "s/ *$//") --max-pods=%d"/' /etc/eks/bootstrap.sh`, maxPods)
 	return script
 }
 

--- a/pkg/nodebootstrap/managed_al2_test.go
+++ b/pkg/nodebootstrap/managed_al2_test.go
@@ -109,7 +109,7 @@ Content-Type: charset="us-ascii"
 
 #!/bin/sh
 set -ex
-sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$2 --max-pods=142"/' /etc/eks/bootstrap.sh
+sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$(echo "$2" | sed "s/--max-pods=[0-9]*//" | sed "s/  */ /g" | sed "s/^ *//" | sed "s/ *$//") --max-pods=142"/' /etc/eks/bootstrap.sh
 --//--
 `,
 	}),


### PR DESCRIPTION
## Description

Fixes #7946 by preventing duplicate `--max-pods` arguments in `KUBELET_EXTRA_ARGS` when using the deprecated `MaxPodsPerNode` setting with AL2 managed nodegroups.

## Problem

When `MaxPodsPerNode` is set, eksctl's `makeMaxPodsScript` function appends `--max-pods` to `KUBELET_EXTRA_ARGS` without checking if it already exists, resulting in:

```
KUBELET_EXTRA_ARGS=... --max-pods=58 --max-pods=30
```

## Solution

Modified `makeMaxPodsScript` to:
- Remove any existing `--max-pods=<number>` arguments using sed
- Clean up extra spaces
- Append the new `--max-pods` value

## Impact

- **AL2 managed nodegroups**: Fixed duplicate `--max-pods` issue
- **AL2023**: No impact (uses nodeadm configuration, not bootstrap scripts)
- **Backward compatibility**: Maintained

## Testing

The fix ensures only one `--max-pods` argument appears in `KUBELET_EXTRA_ARGS`, with eksctl's `MaxPodsPerNode` value taking precedence.