### PR TITLE
fix: detect ROLLBACK_COMPLETE nodegroup stacks during create

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -544,7 +544,6 @@ func nonTransitionalReadyStackStatuses() []types.StackStatus {
 	return []types.StackStatus{
 		types.StackStatusCreateComplete,
 		types.StackStatusUpdateComplete,
-		types.StackStatusRollbackComplete,
 		types.StackStatusUpdateRollbackComplete,
 	}
 }

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter.go
@@ -2,8 +2,10 @@ package filter
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/kris-nova/logger"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -126,6 +128,22 @@ func (f *NodeGroupFilter) loadLocalAndRemoteNodegroups(ctx context.Context, eksA
 	if err != nil {
 		return err
 	}
+
+	if f.onlyLocal {
+		localNames := sets.New(clusterConfig.GetAllNodeGroupNames()...)
+		var rolledBack []string
+		for _, s := range nodeGroupsWithStacks {
+			if s.Stack != nil && s.Stack.StackStatus == cfntypes.StackStatusRollbackComplete && localNames.Has(s.NodeGroupName) {
+				rolledBack = append(rolledBack, s.NodeGroupName)
+			}
+		}
+		if len(rolledBack) > 0 {
+			return fmt.Errorf("nodegroup(s) %q have a CloudFormation stack in ROLLBACK_COMPLETE state; "+
+				"delete the failed stack(s) with 'eksctl delete nodegroup --cluster=%s --name=<name>' and then retry creation",
+				strings.Join(rolledBack, ", "), clusterConfig.Metadata.Name)
+		}
+	}
+
 	for _, s := range nodeGroupsWithStacks {
 		f.remoteNodegroups.Insert(s.NodeGroupName)
 	}

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/stretchr/testify/mock"
 
@@ -137,6 +138,81 @@ var _ = Describe("nodegroup filter", func() {
 			Expect(included.HasAll("test-ng3a", "test-ng3b")).To(BeTrue())
 			Expect(excluded).To(HaveLen(4))
 			Expect(excluded.HasAll("test-ng1a", "test-ng1b", "test-ng2a", "test-ng2b")).To(BeTrue())
+		})
+	})
+
+	Context("ROLLBACK_COMPLETE handling", func() {
+		var (
+			filter       *NodeGroupFilter
+			cfg          *api.ClusterConfig
+			mockProvider *mockprovider.MockProvider
+		)
+
+		BeforeEach(func() {
+			cfg = newClusterConfig()
+			addGroupA(cfg)
+
+			filter = NewNodeGroupFilter()
+
+			mockProvider = mockprovider.NewMockProvider()
+			mockProvider.MockEKS().On("ListNodegroups", mock.Anything, mock.Anything, mock.Anything).Return(&eks.ListNodegroupsOutput{Nodegroups: nil}, nil)
+		})
+
+		It("should return an error when SetOnlyLocal finds a config nodegroup in ROLLBACK_COMPLETE", func() {
+			mockLister := newMockStackListerWithStacks([]manager.NodeGroupStack{
+				{
+					NodeGroupName: "test-ng1a",
+					Stack: &manager.Stack{
+						StackStatus: cfntypes.StackStatusRollbackComplete,
+					},
+				},
+				{
+					NodeGroupName: "test-ng2a",
+					Stack: &manager.Stack{
+						StackStatus: cfntypes.StackStatusCreateComplete,
+					},
+				},
+			})
+
+			err := filter.SetOnlyLocal(context.Background(), mockProvider.EKS(), mockLister, cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ROLLBACK_COMPLETE"))
+			Expect(err.Error()).To(ContainSubstring("test-ng1a"))
+			Expect(err.Error()).To(ContainSubstring("eksctl delete nodegroup"))
+		})
+
+		It("should not error when a non-config nodegroup is in ROLLBACK_COMPLETE", func() {
+			mockLister := newMockStackListerWithStacks([]manager.NodeGroupStack{
+				{
+					NodeGroupName: "unrelated-ng",
+					Stack: &manager.Stack{
+						StackStatus: cfntypes.StackStatusRollbackComplete,
+					},
+				},
+				{
+					NodeGroupName: "test-ng1a",
+					Stack: &manager.Stack{
+						StackStatus: cfntypes.StackStatusCreateComplete,
+					},
+				},
+			})
+
+			err := filter.SetOnlyLocal(context.Background(), mockProvider.EKS(), mockLister, cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not error when SetOnlyRemote finds a config nodegroup in ROLLBACK_COMPLETE", func() {
+			mockLister := newMockStackListerWithStacks([]manager.NodeGroupStack{
+				{
+					NodeGroupName: "test-ng1a",
+					Stack: &manager.Stack{
+						StackStatus: cfntypes.StackStatusRollbackComplete,
+					},
+				},
+			})
+
+			err := filter.SetOnlyRemote(context.Background(), mockProvider.EKS(), mockLister, cfg)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
@@ -668,12 +744,18 @@ func (s *mockStackLister) ListNodeGroupStacksWithStatuses(_ context.Context) ([]
 }
 
 func newMockStackLister(ngs ...string) *mockStackLister {
-	stacks := make([]manager.NodeGroupStack, 0)
+	stacks := make([]manager.NodeGroupStack, 0, len(ngs))
 	for _, ng := range ngs {
 		stacks = append(stacks, manager.NodeGroupStack{
 			NodeGroupName: ng,
 		})
 	}
+	return &mockStackLister{
+		nodesResult: stacks,
+	}
+}
+
+func newMockStackListerWithStacks(stacks []manager.NodeGroupStack) *mockStackLister {
 	return &mockStackLister{
 		nodesResult: stacks,
 	}

--- a/pkg/eks/nodegroup_service.go
+++ b/pkg/eks/nodegroup_service.go
@@ -306,7 +306,7 @@ func ValidateExistingNodeGroupsForCompatibility(ctx context.Context, cfg *api.Cl
 	}
 
 	if len(incompatibleNodeGroups) == 0 {
-		logger.Info("all nodegroups have up-to-date cloudformation templates")
+		logger.Info("all nodegroups have compatible shared security group configuration")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- `eksctl create nodegroup` now fails fast with an actionable error when it encounters a nodegroup stack in `ROLLBACK_COMPLETE` state that matches a nodegroup in the user's config, instead of silently skipping it and exiting 0
- Rewords the misleading `"all nodegroups have up-to-date cloudformation templates"` log message to accurately describe what is checked (shared security group compatibility)
- Removes `ROLLBACK_COMPLETE` from `nonTransitionalReadyStackStatuses`, which incorrectly grouped failed-create stacks with healthy terminal states like `CREATE_COMPLETE`

Fixes #8712
Related: #4006 (same symptom, closed by stale-bot without a fix)

### Root cause

Two bugs combined to produce the silent failure:

1. **The create-nodegroup filter treated ROLLBACK_COMPLETE stacks as healthy existing nodegroups.** `NodeGroupFilter.SetOnlyLocal` calls `loadLocalAndRemoteNodegroups`, which lists all nodegroup stacks and marks them as "remote" (i.e. already exists, skip creation). `ListNodeGroupStacks` only filters out `DELETE_COMPLETE`/`DELETE_FAILED`, so `ROLLBACK_COMPLETE` stacks pass through — causing the nodegroup to be silently excluded from the create plan.

2. **The post-create compatibility check used a misleading log message.** `ValidateExistingNodeGroupsForCompatibility` only checks shared security group CFN outputs via `isNodeGroupCompatible`, but logged `"all nodegroups have up-to-date cloudformation templates"` — reading like a general health assertion. Its stack filter `StackStatusIsNotTransitional` also included `ROLLBACK_COMPLETE` in the "ready" set, so broken stacks passed the check.

### Changes

| File | Change |
|---|---|
| `pkg/ctl/cmdutils/filter/nodegroup_filter.go` | Detect ROLLBACK_COMPLETE stacks in `loadLocalAndRemoteNodegroups` (gated on `f.onlyLocal` so only the create path is affected); return actionable error with `eksctl delete nodegroup` hint |
| `pkg/eks/nodegroup_service.go` | Reword line 309 log message to `"all nodegroups have compatible shared security group configuration"` |
| `pkg/cfn/manager/api.go` | Remove `StackStatusRollbackComplete` from `nonTransitionalReadyStackStatuses` (keep `UPDATE_ROLLBACK_COMPLETE` which is genuinely healthy) |
| `pkg/ctl/cmdutils/filter/nodegroup_filter_test.go` | 3 new test cases: error on config nodegroup in ROLLBACK_COMPLETE, no error for unrelated nodegroup, no error on delete path |

## Test plan

- [x] New unit tests pass: `go test -tags=release ./pkg/ctl/cmdutils/filter/... -ginkgo.focus "ROLLBACK_COMPLETE"`
- [x] Full test suites pass for all modified packages: `go test -tags=release ./pkg/ctl/cmdutils/filter/... ./pkg/eks/... ./pkg/cfn/manager/...`
- [x] `golangci-lint run` reports 0 issues on modified packages
- [x] `go build -tags=release ./...` compiles cleanly
- [ ] Manual E2E: create a nodegroup with an invalid config so CFN reaches ROLLBACK_COMPLETE, then re-run `eksctl create nodegroup` — should now fail fast with the actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)