### PR TITLE
Update Windows compatibility hint to recommend AL2023 instead of AL2

### DIFF
--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -83,7 +83,7 @@ func LogWindowsCompatibility(nodeGroups []KubeNodeGroup, clusterMeta *api.Cluste
 	if hasWindowsNode(nodeGroups) {
 		if !hasAmazonLinux2Node(nodeGroups) {
 			logger.Warning("a Linux node group is required to support Windows workloads")
-			logger.Warning("add it using 'eksctl create nodegroup --cluster=%s --node-ami-family=%s'", clusterMeta.Name, api.NodeImageFamilyAmazonLinux2)
+			logger.Warning("add it using 'eksctl create nodegroup --cluster=%s --node-ami-family=%s'", clusterMeta.Name, api.NodeImageFamilyAmazonLinux2023)
 		}
 		logger.Warning("Windows VPC resource controller is required to run Windows workloads")
 		logger.Warning("install it using 'eksctl utils install-vpc-controllers --name=%s --region=%s --approve'", clusterMeta.Name, clusterMeta.Region)


### PR DESCRIPTION
### Description

Amazon EKS stopped publishing EKS-optimized Amazon Linux 2 (AL2) AMIs as of
November 26, 2025, and AL2 itself reaches end of life on June 30, 2026.
AL2 AMIs no longer receive software updates, security patches, or bug fixes.

The Windows compatibility warning currently suggests creating a Linux node group
with `AmazonLinux2`. This updates the hint to recommend `AmazonLinux2023` instead,
so users are guided toward a supported AMI family.

Ref: https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-deprecation-faqs.html

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)