### PR TITLE
feat: validate Flux bootstrap flags before creating the cluster

### DIFF
--- a/pkg/actions/flux/enable.go
+++ b/pkg/actions/flux/enable.go
@@ -28,6 +28,23 @@ type Installer struct {
 	fluxClient InstallerClient
 }
 
+// ValidateFlags checks that the Flux flags configured for bootstrap are
+// recognised by the Flux CLI, without performing an actual bootstrap. It is
+// intended to be called before cluster creation, so misconfigured flags are
+// caught early instead of after a lengthy cluster creation.
+func ValidateFlags(opts *api.GitOps) error {
+	if opts == nil || opts.Flux == nil {
+		return nil
+	}
+
+	fluxClient, err := flux.NewClient(opts.Flux)
+	if err != nil {
+		return err
+	}
+
+	return fluxClient.Validate()
+}
+
 func New(k8sClientSet kubeclient.Interface, opts *api.GitOps) (*Installer, error) {
 	if opts.Flux == nil {
 		return nil, errors.New("expected gitops.flux in cluster configuration but found nil")

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -239,6 +239,9 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		if _, err := exec.LookPath("flux"); err != nil {
 			return fmt.Errorf("flux binary is required when gitops configuration is set: %w", err)
 		}
+		if err := flux.ValidateFlags(cfg.GitOps); err != nil {
+			return fmt.Errorf("validating Flux configuration: %w", err)
+		}
 	}
 
 	if params.InstallWindowsVPCController {

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -15,6 +15,13 @@ import (
 const (
 	fluxBin             = "flux"
 	minSupportedVersion = "0.32.0"
+
+	// validationFlag is appended to the args we pass to `flux bootstrap` when
+	// validating flags. It is never a flag Flux recognises, so pflag will
+	// fail to parse it. Since pflag stops at the first unrecognised flag,
+	// an error that doesn't mention validationFlag means a real flag (one
+	// that appears earlier in the args) is invalid.
+	validationFlag = "eksctl-internal-validate-only"
 )
 
 type Client struct {
@@ -57,6 +64,25 @@ func (c *Client) Bootstrap() error {
 	}
 
 	return c.runFluxCmd(args...)
+}
+
+// Validate checks that the Flux flags configured for bootstrap are
+// recognised by the Flux CLI, without performing an actual bootstrap.
+// Flux has no dry-run mode for bootstrap, so this works around that by
+// appending a flag Flux cannot recognise: see validationFlag.
+func (c *Client) Validate() error {
+	args := []string{"bootstrap", c.opts.GitProvider}
+
+	for k, v := range c.opts.Flags {
+		args = append(args, fmt.Sprintf("--%s", k), v)
+	}
+	args = append(args, fmt.Sprintf("--%s", validationFlag))
+
+	err := c.runFluxCmd(args...)
+	if err == nil || strings.Contains(err.Error(), validationFlag) {
+		return nil
+	}
+	return fmt.Errorf("invalid flux flags: %w", err)
 }
 
 func (c *Client) runFluxCmd(args ...string) error {

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -2,8 +2,10 @@ package flux_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -170,6 +172,53 @@ var _ = Describe("Flux", func() {
 			It("returns the error", func() {
 				Expect(fluxClient.Bootstrap()).To(MatchError("omg"))
 				Expect(fakeExecutor.ExecCallCount()).To(Equal(1))
+			})
+		})
+	})
+
+	Context("Validate", func() {
+		// recognisedFlags simulates the real `flux bootstrap` command:
+		// pflag parses args in order and fails on the first flag it doesn't
+		// recognise.
+		recognisedFlags := map[string]bool{
+			"owner":      true,
+			"repository": true,
+			"branch":     true,
+			"path":       true,
+		}
+
+		BeforeEach(func() {
+			fakeExecutor.ExecCalls(func(_ string, args ...string) error {
+				for _, arg := range args {
+					if !strings.HasPrefix(arg, "--") {
+						continue
+					}
+					flagName := strings.TrimPrefix(arg, "--")
+					if !recognisedFlags[flagName] {
+						return fmt.Errorf("unknown flag: --%s", flagName)
+					}
+				}
+				return nil
+			})
+		})
+
+		When("all configured flags are recognised by Flux", func() {
+			BeforeEach(func() {
+				opts.Flags = api.FluxFlags{"owner": "me", "repository": "my-repo"}
+			})
+
+			It("succeeds, having failed only on the validation sentinel flag", func() {
+				Expect(fluxClient.Validate()).To(Succeed())
+			})
+		})
+
+		When("a configured flag is not recognised by Flux", func() {
+			BeforeEach(func() {
+				opts.Flags = api.FluxFlags{"owner": "me", "totally-bogus-flag": "oops"}
+			})
+
+			It("returns an error identifying the invalid flag, instead of the validation sentinel", func() {
+				Expect(fluxClient.Validate()).To(MatchError(ContainSubstring("totally-bogus-flag")))
 			})
 		})
 	})


### PR DESCRIPTION
### Description

Closes #3664

I think this may resolve this issue. 

Currently `eksctl create cluster` only discovers invalid `gitops.flux.flags` when
it calls `flux bootstrap` at the very end of the process — after the cluster has
already taken ~25 minutes to provision. This PR validates those flags upfront,
before cluster creation starts.

Flux has no dry-run mode for `bootstrap`, so the validation uses the workaround
suggested in the issue: it builds the same args `Bootstrap()` would use and appends
a sentinel flag that Flux can never recognise (`--eksctl-internal-validate-only`).
Since Flux's flag parser (`pflag`) stops at the **first** unrecognised flag:

- if the resulting error mentions the sentinel flag → all real flags were valid
- if it mentions anything else → that's the real flag that's misconfigured

<!--
Please explain the changes you made here.

**Changes:**
- `pkg/flux/flux.go`: new `Client.Validate()` method implementing the check above.
- `pkg/actions/flux/enable.go`: new `ValidateFlags(opts *api.GitOps)` helper that
  wraps `Validate()` for callers that don't need a full `Installer`.
- `pkg/ctl/create/cluster.go`: calls `flux.ValidateFlags()` right after the existing
  check that the `flux` binary is on `PATH`, so a misconfigured flag now fails fast
  instead of after a full cluster creation.
- `pkg/flux/flux_test.go`: added tests that simulate Flux's "fails on first unknown
  flag" behavior, covering both a fully valid flag set and one with a bad flag.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

