### PR TITLE
Addon update: fix resolving 'latest' version (#7841)

### DIFF
--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -74,6 +74,7 @@ func (a *Manager) Update(ctx context.Context, addon *api.Addon, podIdentityIAMUp
 			logger.Info("new version provided %s", latestVersion)
 		}
 		updateAddonInput.AddonVersion = &latestVersion
+		addon.Version = latestVersion
 	}
 
 	var deleteServiceAccountIAMResources []string

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -182,10 +182,11 @@ var _ = Describe("Update", func() {
 
 			When("the version is set to latest", func() {
 				It("discovers and uses the latest available version", func() {
-					err := addonManager.Update(context.Background(), &api.Addon{
+					addonObj := &api.Addon{
 						Name:    "my-addon",
 						Version: "latest",
-					}, &podIdentityIAMUpdater, 0)
+					}
+					err := addonManager.Update(context.Background(), addonObj, &podIdentityIAMUpdater, 0)
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(*describeAddonInput.ClusterName).To(Equal("my-cluster"))
@@ -194,6 +195,7 @@ var _ = Describe("Update", func() {
 					Expect(*updateAddonInput.AddonName).To(Equal("my-addon"))
 					Expect(*updateAddonInput.AddonVersion).To(Equal("v1.7.7-eksbuild.2"))
 					Expect(*updateAddonInput.ServiceAccountRoleArn).To(Equal("original-arn"))
+					Expect(addonObj.Version).To(Equal("v1.7.7-eksbuild.2"))
 				})
 			})
 


### PR DESCRIPTION
### Description

Fixes #7841

When updating an addon with `version: latest`, `eksctl` correctly resolves the latest semantic version to send to the AWS API but fails to update the internal `addon` struct. As a result, subsequent calls, like `getRecommendedPoliciesForPodID`, attempt to use `"latest"` instead of the resolved version, causing a failure.

This PR updates the internal `addon.Version` inside the `else` block so that the resolved version is used consistently throughout the `eksctl update addon` execution. It also adds a unit test to verify this behavior.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
