### PR TITLE
Drain nodegroup: gracefully handle transient control plane failures (#7550)

### DIFF
--- a/pkg/drain/nodegroup.go
+++ b/pkg/drain/nodegroup.go
@@ -3,6 +3,7 @@ package drain
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -261,12 +262,27 @@ func isEvictionErrorRecoverable(err error) bool {
 		apierrors.IsTimeout,
 		// IsTooManyRequests also captures PDB errors
 		apierrors.IsTooManyRequests,
+		isTransientControlPlaneError,
 	)
 
 	for _, f := range recoverableCheckerFuncs {
 		if f(err) {
 			return true
 		}
+	}
+	return false
+}
+
+func isTransientControlPlaneError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "etcdserver: leader changed") {
+		return true
+	}
+	if strings.Contains(msg, "raft proposal dropped") {
+		return true
 	}
 	return false
 }

--- a/pkg/drain/nodegroup_test.go
+++ b/pkg/drain/nodegroup_test.go
@@ -286,6 +286,57 @@ var _ = Describe("Drain", func() {
 		})
 	})
 
+	When("an eviction fails recoverably due to leader changed", func() {
+		var pod corev1.Pod
+
+		BeforeEach(func() {
+			pod = corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1",
+				},
+			}
+
+			for i := 0; i < 2; i++ {
+				fakeEvictor.GetPodsForEvictionReturnsOnCall(i, &evictor.PodDeleteList{
+					Items: []evictor.PodDelete{
+						{
+							Pod: pod,
+							Status: evictor.PodDeleteStatus{
+								Delete: true,
+							},
+						},
+					},
+				}, nil)
+			}
+			fakeEvictor.GetPodsForEvictionReturnsOnCall(2, nil, nil)
+
+			fakeEvictor.EvictOrDeletePodReturnsOnCall(0, errors.New("etcdserver: leader changed"))
+			fakeEvictor.EvictOrDeletePodReturnsOnCall(1, nil)
+
+			_, err := fakeClientSet.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: false,
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not error", func() {
+			nodeGroupDrainer := drain.NewNodeGroupDrainer(fakeClientSet, &mockNG, time.Second, time.Second, 0, false, false, 1)
+			nodeGroupDrainer.SetDrainer(fakeEvictor)
+
+			Expect(nodeGroupDrainer.Drain(ctx, sem)).To(Succeed())
+
+			Expect(fakeEvictor.GetPodsForEvictionCallCount()).To(Equal(3))
+			Expect(fakeEvictor.EvictOrDeletePodCallCount()).To(Equal(2))
+			Expect(fakeEvictor.EvictOrDeletePodArgsForCall(0)).To(Equal(pod))
+			Expect(fakeEvictor.EvictOrDeletePodArgsForCall(1)).To(Equal(pod))
+		})
+	})
+
 	When("an eviction fails irrecoverably", func() {
 		var pod corev1.Pod
 		var evictionError error


### PR DESCRIPTION
### Description

Fixes #7550

When draining nodegroups, the kubernetes api server might return transient HTTP 5xx errors like `etcdserver: leader changed` or `raft proposal dropped` during leadership transitions. Previously, `eksctl` would fail the drain operation entirely when encountering these errors.

This PR introduces a `isTransientControlPlaneError` check to recognize these string patterns as recoverable errors inside `isEvictionErrorRecoverable`. This ensures `eksctl` correctly retries evicting the pods instead of surfacing an unrecoverable failure to the user.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
