### PR TITLE
fix: bump helm.sh/helm/v3 v3.20.2 → v3.21.3 to resolve oras-go CVE-2026-50151/48978/50162

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v2 v2.4.0
-	helm.sh/helm/v3 v3.20.2
+	helm.sh/helm/v3 v3.21.3
 	k8s.io/api v0.35.1
 	k8s.io/apiextensions-apiserver v0.35.1
 	k8s.io/apimachinery v0.35.1
@@ -448,7 +448,7 @@ require (
 	k8s.io/kubectl v0.35.1 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
+	oras.land/oras-go/v2 v2.6.1 // indirect
 	sigs.k8s.io/controller-runtime v0.23.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect


### PR DESCRIPTION
## Summary

Bumps `helm.sh/helm/v3` from **v3.20.2** to **v3.21.3**.

helm v3.21.3 transitively upgrades `oras.land/oras-go/v2` from **v2.6.0** → **v2.6.1**, resolving three published CVEs:

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-50151 | HIGH | Bearer token leaked to third-party via cross-host redirect during OCI push |
| CVE-2026-48978 | MEDIUM | SSRF via `WWW-Authenticate: Bearer realm=<URL>` without scheme/host validation |
| CVE-2026-50162 | MEDIUM | Symlink traversal write outside `workingDir` via `resolveWritePath()` |

## Dependency chain

```
exsctl (before)
  └── helm.sh/helm/v3  v3.20.2
        └── oras.land/oras-go/v2  v2.6.0  ← vulnerable

exsctl (after)
  └── helm.sh/helm/v3  v3.21.3
        └── oras.land/oras-go/v2  v2.6.1  ← fixed
```

## Note

`go mod tidy` is required to update `go.sum` after merging.

A fourth CVE (CVE-2026-50163) requires oras-go v2.6.2, which no helm release has adopted yet.

Related issue: #8788