### PR TITLE
Make vpc-cni and kube-proxy optional when creating IPv6 clusters

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -700,28 +700,23 @@ func (c *ClusterConfig) validateKubernetesNetworkConfig() error {
 	case strings.ToLower(IPV4Family), "":
 	case strings.ToLower(IPV6Family):
 		if !c.IsAutoModeEnabled() {
-			if missing := c.addonContainsManagedAddons([]string{VPCCNIAddon, CoreDNSAddon, KubeProxyAddon}); len(missing) != 0 {
+			if missing := c.addonContainsManagedAddons([]string{CoreDNSAddon}); len(missing) != 0 {
 				return fmt.Errorf("the default core addons must be defined for IPv6; missing addon(s): %s; either define them or use EKS Auto Mode", strings.Join(missing, ", "))
 			}
 
-			// Check if at least one credential provider (Pod identity or IRSA) is configured
-			if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) != 0 && (c.IAM == nil || c.IAM != nil && IsDisabled(c.IAM.WithOIDC)) {
-				return errors.New("either pod identity or oidc needs to be enabled if IPv6 is set; set either one or use EKS Auto Mode")
-			}
-
-			// If the pod identity addon is present, verify it is correctly configured for use by the VPC CNI addon
-			// Assuming user intends to use pod identities if the pod identity agent addon is added.
-			if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) == 0 && !c.AddonsConfig.AutoApplyPodIdentityAssociations {
-				vpcCNIAddonEntry := c.getAddon(VPCCNIAddon)
-
-				if vpcCNIAddonEntry == nil {
-					// should be unreachable
-					return errors.New("the vpc-cni addon must be defined for IPv6; either define it or use EKS Auto Mode")
+			if vpcCNIAddonEntry := c.getAddon(VPCCNIAddon); vpcCNIAddonEntry != nil {
+				// Check if at least one credential provider (Pod identity or IRSA) is configured
+				if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) != 0 && (c.IAM == nil || c.IAM != nil && IsDisabled(c.IAM.WithOIDC)) {
+					return errors.New("either pod identity or oidc needs to be enabled if IPv6 is set; set either one or use EKS Auto Mode")
 				}
 
-				if !vpcCNIAddonEntry.UseDefaultPodIdentityAssociations &&
-					(vpcCNIAddonEntry.PodIdentityAssociations == nil || len(*vpcCNIAddonEntry.PodIdentityAssociations) == 0) {
-					return fmt.Errorf("Set one of: addonsConfig.autoApplyPodIdentityAssociations, useDefaultPodIdentityAssociations on the vpc-cni addon, apply a custom pod identity on the vpc-cni addon")
+				// If the pod identity addon is present, verify it is correctly configured for use by the VPC CNI addon
+				// Assuming user intends to use pod identities if the pod identity agent addon is added.
+				if len(c.addonContainsManagedAddons([]string{PodIdentityAgentAddon})) == 0 && !c.AddonsConfig.AutoApplyPodIdentityAssociations {
+					if !vpcCNIAddonEntry.UseDefaultPodIdentityAssociations &&
+						(vpcCNIAddonEntry.PodIdentityAssociations == nil || len(*vpcCNIAddonEntry.PodIdentityAssociations) == 0) {
+						return fmt.Errorf("Set one of: addonsConfig.autoApplyPodIdentityAssociations, useDefaultPodIdentityAssociations on the vpc-cni addon, apply a custom pod identity on the vpc-cni addon")
+					}
 				}
 			}
 		}

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1233,7 +1233,7 @@ var _ = Describe("ClusterConfig validation", func() {
 						}
 						cfg.Addons = append(cfg.Addons, &api.Addon{Name: api.KubeProxyAddon})
 						err = api.ValidateClusterConfig(cfg)
-						Expect(err).To(MatchError(ContainSubstring("the default core addons must be defined for IPv6; missing addon(s): vpc-cni, coredns")))
+						Expect(err).To(MatchError(ContainSubstring("the default core addons must be defined for IPv6; missing addon(s): coredns")))
 					})
 				})
 
@@ -1298,6 +1298,14 @@ var _ = Describe("ClusterConfig validation", func() {
 								err = api.ValidateClusterConfig(cfg)
 								Expect(err).To(MatchError(ContainSubstring("Set one of: addonsConfig.autoApplyPodIdentityAssociations, useDefaultPodIdentityAssociations on the vpc-cni addon, apply a custom pod identity on the vpc-cni addon")))
 							})
+						})
+					})
+
+					When("vpc-cni addon is not provided", func() {
+						It("accepts that setting", func() {
+							cfg.Addons = []*api.Addon{{Name: api.CoreDNSAddon}}
+							err = api.ValidateClusterConfig(cfg)
+							Expect(err).To(BeNil())
 						})
 					})
 				})

--- a/userdocs/src/usage/vpc-ip-family.md
+++ b/userdocs/src/usage/vpc-ip-family.md
@@ -22,20 +22,20 @@ kubernetesNetworkConfig:
   ipFamily: IPv6 # or IPv4
 
 addons:
-  - name: vpc-cni
+  - name: vpc-cni # optional
   - name: coredns
-  - name: kube-proxy
+  - name: kube-proxy # optional
 
+# required if vpc-cni addon is used
 iam:
   withOIDC: true
 ```
 
 This is an in config file setting only. When IPv6 is set, the following restriction must be followed:
 
-- OIDC is enabled
-- managed addons are defined as shows above
+- OIDC is enabled if `vpc-cni` addon is used
 - cluster version must be => 1.21
-- vpc-cni addon version must be => 1.10.0
+- if used, vpc-cni addon version must be => 1.10.0
 - unmanaged nodegroups are not yet supported with IPv6 clusters
 - managed nodegroup creation is not supported with un-owned IPv6 clusters
 - `vpc.NAT` and `serviceIPv4CIDR` fields are created by eksctl for ipv6 clusters and thus, are not supported configuration options


### PR DESCRIPTION
### Description

The initial implementation of IPv6 cluster creation assumed a requirement for AWS VPC CNI and Kube Proxy. As other CNI/proxy solutions add support for IPv6, this change removes the requirement for the 2 above addons when creating IPv6 clusters. It also removes the requirement to use OIDC if `vpc-cni` is not in use.

I came across this as part of my work on supporting IPv6 in the Cilium ENI IPAM mode, which is tracked in https://github.com/cilium/cilium/issues/18405. This support was released in [Cilium 1.20](https://github.com/cilium/cilium/releases/tag/v1.20.0). A lot of users using EKS + Cilium rely on eksctl to configure their clusters. Even the Cilium project relies on it to set up CI conformance testing. As such, having AWS VPC CNI, which conflicts with Cilium's own CNI and IPAM, as a hard requirement when creating IPv6 clusters is a significant blocker for adoption.

I have manually verified that creating an IPv6 cluster without the kube-proxy and vpc-cni addons is possible, meaning those requirements are only present in the validation in `eksctl`. Even CoreDNS doesn't seem to be a strict requirement. However, this does not conflict with Cilium, so I left it as is.

I also successfully built and ran `eksctl` with this cluster configuration :

```yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: eks-ipv6-eni
  region: eu-north-1
  version: "1.35"

vpc:
  clusterEndpoints:
    publicAccess: true
    privateAccess: true

addonsConfig:
  disableDefaultAddons: true
addons:
- name: coredns
- name: kube-proxy

kubernetesNetworkConfig:
  ipFamily: IPv6
```

After this, I created a managed nodegroup with an IAM role containing the default node permissions plus an AssignIpv6Addresses permission. Then I ran this to install Cilium:

```bash
cilium install --version "v1.20.0" \
  --set kubeProxyReplacement=true \
  --set ipv6.enabled=true \
  --set ipv4.enabled=false \
  --set MTU=9001 \
  --set endpointHealthChecking.enabled=false \
  --set healthChecking=false \
  --set enableIPv6Masquerade=false
```

With this was done, connectivity was working as expected with pods getting IPv6 addresses assigned by Cilium.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

