### PR TITLE
Add support for vpc.controlPlaneOnPrivateSubnets

### DIFF
--- a/examples/49-control-plane-on-private-subnets.yaml
+++ b/examples/49-control-plane-on-private-subnets.yaml
@@ -1,0 +1,29 @@
+# An example config for restricting the EKS control plane's cross-account ENIs to private
+# subnets at cluster creation time.
+# To create the cluster, run `eksctl create cluster -f 49-control-plane-on-private-subnets.yaml`
+#
+# Public subnets are still created and used for the NAT gateways and for internet-facing load
+# balancers; only the subnets passed to the EKS API are restricted. Requires at least two
+# private subnets across at least two availability zones.
+
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: cluster-49
+  region: us-west-2
+
+availabilityZones:
+  - us-west-2a
+  - us-west-2b
+
+vpc:
+  controlPlaneOnPrivateSubnets: true
+  nat:
+    gateway: HighlyAvailable
+  clusterEndpoints:
+    publicAccess: true
+    privateAccess: true
+
+managedNodeGroups:
+  - name: mng1
+    privateNetworking: true

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1163,6 +1163,11 @@
           "description": "controls how the control plane routes egress traffic. Valid values: \"AWS_MANAGED\" (default), \"CUSTOMER_ROUTED\"",
           "x-intellij-html-description": "controls how the control plane routes egress traffic. Valid values: &quot;AWS<em>MANAGED&quot; (default), &quot;CUSTOMER</em>ROUTED&quot;"
         },
+        "controlPlaneOnPrivateSubnets": {
+          "type": "boolean",
+          "description": "restricts the control plane (the cross-account ENIs that EKS places in the cluster subnets) to private subnets only, excluding public subnets. It applies both when eksctl creates the VPC and when a pre-existing VPC is used. Cannot be combined with ControlPlaneSubnetIDs. Requires at least two private subnets spanning at least two availability zones, which must have NAT or the relevant VPC endpoints for nodes to reach the API server.",
+          "x-intellij-html-description": "restricts the control plane (the cross-account ENIs that EKS places in the cluster subnets) to private subnets only, excluding public subnets. It applies both when eksctl creates the VPC and when a pre-existing VPC is used. Cannot be combined with ControlPlaneSubnetIDs. Requires at least two private subnets spanning at least two availability zones, which must have NAT or the relevant VPC endpoints for nodes to reach the API server."
+        },
         "controlPlaneSecurityGroupIDs": {
           "items": {
             "type": "string"
@@ -1259,6 +1264,7 @@
         "clusterEndpoints",
         "publicAccessCIDRs",
         "controlPlaneSubnetIDs",
+        "controlPlaneOnPrivateSubnets",
         "controlPlaneSecurityGroupIDs",
         "controlPlaneEgressMode"
       ],

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -927,6 +927,12 @@ func (c *ClusterConfig) IsControlPlaneOnOutposts() bool {
 	return c.Outpost != nil && c.Outpost.ControlPlaneOutpostARN != ""
 }
 
+// IsControlPlaneOnPrivateSubnets returns true if the control plane's cross-account ENIs
+// should be restricted to private subnets only.
+func (c *ClusterConfig) IsControlPlaneOnPrivateSubnets() bool {
+	return c.VPC != nil && IsEnabled(c.VPC.ControlPlaneOnPrivateSubnets)
+}
+
 // GetOutpost returns the Outpost info.
 func (c *ClusterConfig) GetOutpost() *Outpost {
 	return c.Outpost

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -581,9 +581,16 @@ func (c *ClusterConfig) validateControlPlaneOnPrivateSubnets() error {
 	// subnets by zone name, so duplicate zones collapse into a single subnet.
 	// validateAvailabilityZones only checks the count of c.AvailabilityZones and explicitly
 	// permits duplicates, so distinct zones must be counted here instead.
+	//
+	// availabilityZones is optional: when it is left unset, eksctl selects the zones itself
+	// in eks.SetAvailabilityZones, which runs after validation, so c.AvailabilityZones is
+	// still empty here. Auto-selection always yields distinct zones, so there is nothing to
+	// validate on that path.
 	if c.VPC.Subnets == nil {
-		if azs := sets.NewString(c.AvailabilityZones...); azs.Len() < MinRequiredAvailabilityZones {
-			return fmt.Errorf("vpc.controlPlaneOnPrivateSubnets requires at least %d distinct availability zones, got %d (%v)", MinRequiredAvailabilityZones, azs.Len(), c.AvailabilityZones)
+		if len(c.AvailabilityZones) > 0 {
+			if azs := sets.New(c.AvailabilityZones...); azs.Len() < MinRequiredAvailabilityZones {
+				return fmt.Errorf("vpc.controlPlaneOnPrivateSubnets requires at least %d distinct availability zones, got %d (%v)", MinRequiredAvailabilityZones, azs.Len(), c.AvailabilityZones)
+			}
 		}
 		return nil
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -501,6 +501,10 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 		return errors.New("only one of vpc.securityGroup and vpc.controlPlaneSecurityGroupIDs can be specified")
 	}
 
+	if err := c.validateControlPlaneOnPrivateSubnets(); err != nil {
+		return err
+	}
+
 	if (c.VPC.IPv6Cidr != "" || c.VPC.IPv6Pool != "") && !c.IPv6Enabled() {
 		return fmt.Errorf("Ipv6Cidr and Ipv6CidrPool are only supported when IPFamily is set to IPv6")
 	}
@@ -552,6 +556,67 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 	}
 
 	return nil
+}
+
+// validateControlPlaneOnPrivateSubnets validates vpc.controlPlaneOnPrivateSubnets against
+// the rest of the VPC configuration.
+func (c *ClusterConfig) validateControlPlaneOnPrivateSubnets() error {
+	if !IsEnabled(c.VPC.ControlPlaneOnPrivateSubnets) {
+		return nil
+	}
+
+	if len(c.VPC.ControlPlaneSubnetIDs) > 0 {
+		return errors.New("only one of vpc.controlPlaneSubnetIDs and vpc.controlPlaneOnPrivateSubnets can be specified")
+	}
+
+	// The control plane is already restricted to private subnets on Outposts, where a
+	// single subnet in a single zone is expected, so the checks below do not apply.
+	if c.IsControlPlaneOnOutposts() {
+		return nil
+	}
+
+	// Subnets are nil when eksctl creates the VPC. Private subnets are then derived from
+	// availabilityZones by vpc.SetSubnets, which runs after validation and always covers
+	// every requested zone, so there is nothing to check yet.
+	if c.VPC.Subnets == nil {
+		return nil
+	}
+
+	if numPrivate := len(c.VPC.Subnets.Private); numPrivate < MinRequiredSubnets {
+		return fmt.Errorf("vpc.controlPlaneOnPrivateSubnets requires at least %d private subnets, got %d", MinRequiredSubnets, numPrivate)
+	}
+
+	if azs := distinctSubnetAZs(c.VPC.Subnets.Private); len(azs) < MinRequiredAvailabilityZones {
+		return fmt.Errorf("vpc.controlPlaneOnPrivateSubnets requires private subnets in at least %d availability zones, got %d (%v)", MinRequiredAvailabilityZones, len(azs), azs)
+	}
+
+	return nil
+}
+
+// distinctSubnetAZs returns the unique availability zones covered by the given subnets.
+// A subnet's zone is taken from its AZ field, falling back to the mapping key, which is an
+// AZ name in the common form.
+//
+// This is best-effort: subnets given only by ID have their zone resolved from EC2 later, so
+// their real zone is unknown here and the mapping key is used instead. Such a configuration
+// is allowed through and is rejected by the EKS API if the subnets turn out to share a zone.
+// The check is deliberately permissive rather than risk rejecting a valid pre-existing VPC.
+func distinctSubnetAZs(subnets AZSubnetMapping) []string {
+	seen := make(map[string]struct{}, len(subnets))
+	azs := make([]string, 0, len(subnets))
+	for key, spec := range subnets {
+		az := spec.AZ
+		if az == "" {
+			az = key
+		}
+		if _, ok := seen[az]; ok {
+			continue
+		}
+		seen[az] = struct{}{}
+		azs = append(azs, az)
+	}
+	slices.Sort(azs)
+	return azs
 }
 
 func (c *ClusterConfig) unsupportedVPCCNIAddonVersion() (bool, error) {

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kris-nova/logger"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
 
@@ -576,9 +577,14 @@ func (c *ClusterConfig) validateControlPlaneOnPrivateSubnets() error {
 	}
 
 	// Subnets are nil when eksctl creates the VPC. Private subnets are then derived from
-	// availabilityZones by vpc.SetSubnets, which runs after validation and always covers
-	// every requested zone, so there is nothing to check yet.
+	// availabilityZones by vpc.SetSubnets, which runs after validation and keys private
+	// subnets by zone name, so duplicate zones collapse into a single subnet.
+	// validateAvailabilityZones only checks the count of c.AvailabilityZones and explicitly
+	// permits duplicates, so distinct zones must be counted here instead.
 	if c.VPC.Subnets == nil {
+		if azs := sets.NewString(c.AvailabilityZones...); azs.Len() < MinRequiredAvailabilityZones {
+			return fmt.Errorf("vpc.controlPlaneOnPrivateSubnets requires at least %d distinct availability zones, got %d (%v)", MinRequiredAvailabilityZones, azs.Len(), c.AvailabilityZones)
+		}
 		return nil
 	}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1526,6 +1526,121 @@ var _ = Describe("ClusterConfig validation", func() {
 			})
 		})
 
+		Context("controlPlaneOnPrivateSubnets", func() {
+			privateSubnets := func(azs ...string) api.AZSubnetMapping {
+				m := api.NewAZSubnetMapping()
+				for i, az := range azs {
+					m.Set(fmt.Sprintf("subnet-alias-%d", i), api.AZSubnetSpec{
+						ID: fmt.Sprintf("subnet-%d", i),
+						AZ: az,
+					})
+				}
+				return m
+			}
+
+			When("it is enabled and eksctl creates the VPC", func() {
+				It("does not reject the config, since subnets are derived from availabilityZones later", func() {
+					cfg.VPC.Subnets = nil
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("it is enabled with two private subnets across two AZs", func() {
+				It("does not return an error", func() {
+					cfg.VPC.Subnets = &api.ClusterSubnets{
+						Private: privateSubnets("us-west-2a", "us-west-2b"),
+					}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("it is enabled together with controlPlaneSubnetIDs", func() {
+				It("returns an error", func() {
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					cfg.VPC.ControlPlaneSubnetIDs = []string{"subnet-1234", "subnet-5678"}
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("only one of vpc.controlPlaneSubnetIDs and vpc.controlPlaneOnPrivateSubnets can be specified"))
+				})
+			})
+
+			When("it is enabled but the VPC has no private subnets", func() {
+				It("returns an error instead of silently using public subnets", func() {
+					cfg.VPC.Subnets = &api.ClusterSubnets{
+						Public: privateSubnets("us-west-2a", "us-west-2b"),
+					}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires at least 2 private subnets, got 0"))
+				})
+			})
+
+			When("it is enabled with only one private subnet", func() {
+				It("returns an error", func() {
+					cfg.VPC.Subnets = &api.ClusterSubnets{
+						Private: privateSubnets("us-west-2a"),
+					}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires at least 2 private subnets, got 1"))
+				})
+			})
+
+			When("it is enabled with two private subnets in the same AZ", func() {
+				It("returns an error, since EKS requires two availability zones", func() {
+					cfg.VPC.Subnets = &api.ClusterSubnets{
+						Private: privateSubnets("us-west-2a", "us-west-2a"),
+					}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires private subnets in at least 2 availability zones, got 1 ([us-west-2a])"))
+				})
+			})
+
+			When("private subnets are given only by ID", func() {
+				It("allows the config through, since their zones are resolved from EC2 later", func() {
+					subnets := api.NewAZSubnetMapping()
+					subnets.Set("alias-a", api.AZSubnetSpec{ID: "subnet-aaa"})
+					subnets.Set("alias-b", api.AZSubnetSpec{ID: "subnet-bbb"})
+					cfg.VPC.ID = "vpc-123"
+					cfg.VPC.Subnets = &api.ClusterSubnets{Private: subnets}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("one private subnet is keyed by AZ and another repeats that AZ explicitly", func() {
+				It("returns an error", func() {
+					subnets := api.NewAZSubnetMapping()
+					subnets.Set("us-west-2a", api.AZSubnetSpec{ID: "subnet-aaa"})
+					subnets.Set("alias-b", api.AZSubnetSpec{ID: "subnet-bbb", AZ: "us-west-2a"})
+					cfg.VPC.ID = "vpc-123"
+					cfg.VPC.Subnets = &api.ClusterSubnets{Private: subnets}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires private subnets in at least 2 availability zones, got 1 ([us-west-2a])"))
+				})
+			})
+
+			When("it is enabled on Outposts", func() {
+				It("does not enforce the multi-AZ requirement", func() {
+					cfg.VPC.Subnets = &api.ClusterSubnets{
+						Private: privateSubnets("us-west-2a"),
+					}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					cfg.Outpost = &api.Outpost{
+						ControlPlaneOutpostARN: "arn:aws:outposts:us-west-2:1234:outpost/op-1234",
+					}
+					err = cfg.ValidateVPCConfig()
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+		})
+
 		Context("ipv6 CIDRs", func() {
 			When("IPv6Cidr or IPv6CidrPool is provided and ipv6 is not set", func() {
 				It("returns an error", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1559,12 +1559,12 @@ var _ = Describe("ClusterConfig validation", func() {
 			})
 
 			When("it is enabled and eksctl creates the VPC without availability zones set", func() {
-				It("returns an error", func() {
+				It("does not reject the config, since eksctl selects distinct zones itself later", func() {
 					cfg.VPC.Subnets = nil
 					cfg.AvailabilityZones = nil
 					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
 					err = cfg.ValidateVPCConfig()
-					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires at least 2 distinct availability zones, got 0 ([])"))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1538,12 +1538,33 @@ var _ = Describe("ClusterConfig validation", func() {
 				return m
 			}
 
-			When("it is enabled and eksctl creates the VPC", func() {
+			When("it is enabled and eksctl creates the VPC with two distinct availability zones", func() {
 				It("does not reject the config, since subnets are derived from availabilityZones later", func() {
 					cfg.VPC.Subnets = nil
+					cfg.AvailabilityZones = []string{"us-west-2a", "us-west-2b"}
 					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
 					err = cfg.ValidateVPCConfig()
 					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("it is enabled and eksctl creates the VPC with a duplicated availability zone", func() {
+				It("returns an error, since the duplicate collapses into a single private subnet", func() {
+					cfg.VPC.Subnets = nil
+					cfg.AvailabilityZones = []string{"us-west-2a", "us-west-2a"}
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires at least 2 distinct availability zones, got 1 ([us-west-2a us-west-2a])"))
+				})
+			})
+
+			When("it is enabled and eksctl creates the VPC without availability zones set", func() {
+				It("returns an error", func() {
+					cfg.VPC.Subnets = nil
+					cfg.AvailabilityZones = nil
+					cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("vpc.controlPlaneOnPrivateSubnets requires at least 2 distinct availability zones, got 0 ([])"))
 				})
 			})
 

--- a/pkg/apis/eksctl.io/v1alpha5/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha5/vpc.go
@@ -178,6 +178,14 @@ type (
 		// ControlPlaneSubnetIDs configures the subnets for the control plane.
 		// +optional
 		ControlPlaneSubnetIDs []string `json:"controlPlaneSubnetIDs,omitempty"`
+		// ControlPlaneOnPrivateSubnets restricts the control plane (the cross-account ENIs
+		// that EKS places in the cluster subnets) to private subnets only, excluding public
+		// subnets. It applies both when eksctl creates the VPC and when a pre-existing VPC
+		// is used. Cannot be combined with ControlPlaneSubnetIDs. Requires at least two
+		// private subnets spanning at least two availability zones, which must have NAT or
+		// the relevant VPC endpoints for nodes to reach the API server.
+		// +optional
+		ControlPlaneOnPrivateSubnets *bool `json:"controlPlaneOnPrivateSubnets,omitempty"`
 		// ControlPlaneSecurityGroupIDs configures the security groups for the control plane.
 		// +optional
 		ControlPlaneSecurityGroupIDs []string `json:"controlPlaneSecurityGroupIDs,omitempty"`

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -1148,6 +1148,11 @@ func (in *ClusterVPC) DeepCopyInto(out *ClusterVPC) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ControlPlaneOnPrivateSubnets != nil {
+		in, out := &in.ControlPlaneOnPrivateSubnets, &out.ControlPlaneOnPrivateSubnets
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ControlPlaneSecurityGroupIDs != nil {
 		in, out := &in.ControlPlaneSecurityGroupIDs, &out.ControlPlaneSecurityGroupIDs
 		*out = make([]string, len(*in))

--- a/pkg/cfn/builder/cluster_test.go
+++ b/pkg/cfn/builder/cluster_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder/fakes"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
+	"github.com/weaveworks/eksctl/pkg/vpc"
 )
 
 var _ = Describe("Cluster Template Builder", func() {
@@ -97,6 +98,67 @@ var _ = Describe("Cluster Template Builder", func() {
 			It("should include UpgradePolicy with SupportType in control plane resources", func() {
 				Expect(clusterTemplate.Resources["ControlPlane"].Properties.UpgradePolicy).NotTo(BeNil())
 				Expect(clusterTemplate.Resources["ControlPlane"].Properties.UpgradePolicy.SupportType).To(Equal(api.SupportTypeStandard))
+			})
+		})
+
+		Context("when VPC.ControlPlaneOnPrivateSubnets is true", func() {
+			BeforeEach(func() {
+				cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+			})
+
+			It("should add only the private subnets to the control plane's VPC config", func() {
+				subnetIDs := clusterTemplate.Resources["ControlPlane"].Properties.ResourcesVpcConfig.SubnetIDs
+				Expect(subnetIDs).To(ConsistOf(
+					map[string]interface{}{"Ref": "SubnetPrivateUSWEST2A"},
+					map[string]interface{}{"Ref": "SubnetPrivateUSWEST2B"},
+				))
+			})
+
+			Context("and ControlPlaneSubnetIDs is also set", func() {
+				BeforeEach(func() {
+					cfg.VPC.ControlPlaneSubnetIDs = []string{"subnet-1234", "subnet-5678"}
+				})
+
+				It("should give ControlPlaneSubnetIDs precedence in the template", func() {
+					subnetIDs := clusterTemplate.Resources["ControlPlane"].Properties.ResourcesVpcConfig.SubnetIDs
+					Expect(subnetIDs).To(ConsistOf("subnet-1234", "subnet-5678"))
+				})
+			})
+		})
+
+		Context("when VPC.ControlPlaneOnPrivateSubnets is not set", func() {
+			It("should add both public and private subnets to the control plane's VPC config", func() {
+				subnetIDs := clusterTemplate.Resources["ControlPlane"].Properties.ResourcesVpcConfig.SubnetIDs
+				Expect(subnetIDs).To(ConsistOf(
+					map[string]interface{}{"Ref": "SubnetPublicUSWEST2A"},
+					map[string]interface{}{"Ref": "SubnetPublicUSWEST2B"},
+					map[string]interface{}{"Ref": "SubnetPrivateUSWEST2A"},
+					map[string]interface{}{"Ref": "SubnetPrivateUSWEST2B"},
+				))
+			})
+		})
+
+		Context("when subnets are derived from availabilityZones by vpc.SetSubnets", func() {
+			BeforeEach(func() {
+				// This is the primary path: the user supplies only availabilityZones and
+				// eksctl creates the VPC and subnets.
+				cfg.VPC = api.NewClusterVPC(false)
+				cfg.VPC.ClusterEndpoints = api.ClusterEndpointAccessDefaults()
+				cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+				Expect(vpc.SetSubnets(cfg.VPC, cfg.AvailabilityZones, nil)).To(Succeed())
+			})
+
+			It("should add only the generated private subnets to the control plane's VPC config", func() {
+				Expect(addErr).NotTo(HaveOccurred())
+				subnetIDs := clusterTemplate.Resources["ControlPlane"].Properties.ResourcesVpcConfig.SubnetIDs
+				Expect(subnetIDs).To(ConsistOf(
+					map[string]interface{}{"Ref": "SubnetPrivateUSWEST2A"},
+					map[string]interface{}{"Ref": "SubnetPrivateUSWEST2B"},
+				))
+
+				By("still creating the public subnets for NAT and load balancers")
+				Expect(clusterTemplate.Resources).To(HaveKey("SubnetPublicUSWEST2A"))
+				Expect(clusterTemplate.Resources).To(HaveKey("SubnetPublicUSWEST2B"))
 			})
 		})
 

--- a/pkg/cfn/builder/vpc_existing.go
+++ b/pkg/cfn/builder/vpc_existing.go
@@ -34,9 +34,8 @@ func NewExistingVPCResourceSet(rs *resourceSet, clusterConfig *api.ClusterConfig
 		clusterConfig: clusterConfig,
 		ec2API:        ec2API,
 		vpcID:         gfnt.NewString(clusterConfig.VPC.ID),
-		subnetDetails: &SubnetDetails{
-			controlPlaneOnOutposts: clusterConfig.IsControlPlaneOnOutposts(),
-		},
+		// autoMode is not applied to a pre-existing VPC; see newSubnetDetails.
+		subnetDetails: newSubnetDetails(clusterConfig, false),
 	}
 }
 

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -179,6 +179,50 @@ var _ = Describe("Existing VPC", func() {
 			})
 		})
 
+		Context("when vpc.controlPlaneOnPrivateSubnets is enabled", func() {
+			BeforeEach(func() {
+				cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+			})
+
+			It("restricts the control plane to the existing private subnets", func() {
+				Expect(addErr).NotTo(HaveOccurred())
+				Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+					gfnt.NewString(privateSubnet1),
+					gfnt.NewString(privateSubnet2),
+				))
+			})
+		})
+
+		Context("when vpc.controlPlaneOnPrivateSubnets is not set", func() {
+			It("uses both the existing public and private subnets for the control plane", func() {
+				Expect(addErr).NotTo(HaveOccurred())
+				Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+					gfnt.NewString(publicSubnet1),
+					gfnt.NewString(publicSubnet2),
+					gfnt.NewString(privateSubnet1),
+					gfnt.NewString(privateSubnet2),
+				))
+			})
+		})
+
+		Context("when Auto Mode is enabled", func() {
+			BeforeEach(func() {
+				cfg.AutoModeConfig = &api.AutoModeConfig{Enabled: api.Enabled()}
+			})
+
+			It("does not restrict the control plane to private subnets", func() {
+				// Auto Mode only restricts the control plane for VPCs that eksctl creates.
+				// Restricting a pre-existing VPC requires vpc.controlPlaneOnPrivateSubnets.
+				Expect(addErr).NotTo(HaveOccurred())
+				Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+					gfnt.NewString(publicSubnet1),
+					gfnt.NewString(publicSubnet2),
+					gfnt.NewString(privateSubnet1),
+					gfnt.NewString(privateSubnet2),
+				))
+			})
+		})
+
 		Context("when ipv6 is true", func() {
 			BeforeEach(func() {
 				cfg.KubernetesNetworkConfig.IPFamily = api.IPV6Family

--- a/pkg/cfn/builder/vpc_ipv4.go
+++ b/pkg/cfn/builder/vpc_ipv4.go
@@ -49,20 +49,33 @@ type SubnetDetails struct {
 	PrivateLocalZone []SubnetResource
 	PublicLocalZone  []SubnetResource
 
-	controlPlaneOnOutposts bool
-	autoMode               bool
+	controlPlaneOnOutposts       bool
+	controlPlaneOnPrivateSubnets bool
+	autoMode                     bool
+}
+
+// newSubnetDetails returns a SubnetDetails with the control plane placement flags derived
+// from clusterConfig. All construction sites must go through this to stay in sync as flags
+// are added.
+//
+// autoMode is passed in rather than derived, because it only restricts the control plane to
+// private subnets for VPCs that eksctl creates; the pre-existing VPC path has never applied
+// it. Use vpc.controlPlaneOnPrivateSubnets to restrict a pre-existing VPC.
+func newSubnetDetails(clusterConfig *api.ClusterConfig, autoMode bool) *SubnetDetails {
+	return &SubnetDetails{
+		controlPlaneOnOutposts:       clusterConfig.IsControlPlaneOnOutposts(),
+		controlPlaneOnPrivateSubnets: clusterConfig.IsControlPlaneOnPrivateSubnets(),
+		autoMode:                     autoMode,
+	}
 }
 
 // NewIPv4VPCResourceSet creates and returns a new VPCResourceSet
 func NewIPv4VPCResourceSet(rs *resourceSet, clusterConfig *api.ClusterConfig, ec2API awsapi.EC2, extendForOutposts bool) *IPv4VPCResourceSet {
 	return &IPv4VPCResourceSet{
-		rs:            rs,
-		clusterConfig: clusterConfig,
-		ec2API:        ec2API,
-		subnetDetails: &SubnetDetails{
-			controlPlaneOnOutposts: clusterConfig.IsControlPlaneOnOutposts(),
-			autoMode:               clusterConfig.IsAutoModeEnabled(),
-		},
+		rs:                rs,
+		clusterConfig:     clusterConfig,
+		ec2API:            ec2API,
+		subnetDetails:     newSubnetDetails(clusterConfig, clusterConfig.IsAutoModeEnabled()),
 		azToRTMap:         make(map[string]*gfnt.Value),
 		extendForOutposts: extendForOutposts,
 	}
@@ -157,7 +170,12 @@ func (s *SubnetDetails) ControlPlaneSubnetRefs() []*gfnt.Value {
 	if s.controlPlaneOnOutposts && len(privateSubnetRefs) > 0 {
 		return privateSubnetRefs
 	}
-	if s.autoMode {
+	// Auto Mode and controlPlaneOnPrivateSubnets are independent settings that happen to
+	// require the same outcome; either one on its own restricts the control plane to
+	// private subnets. No length guard here: the subnets are validated by
+	// ValidateVPCConfig, and an empty set must surface as an error from the EKS API
+	// rather than silently falling back to public subnets.
+	if s.autoMode || s.controlPlaneOnPrivateSubnets {
 		return privateSubnetRefs
 	}
 	return append(s.PublicSubnetRefs(), privateSubnetRefs...)

--- a/pkg/cfn/builder/vpc_ipv4_test.go
+++ b/pkg/cfn/builder/vpc_ipv4_test.go
@@ -443,6 +443,34 @@ var _ = Describe("VPC Template Builder", func() {
 			Expect(refs).To(ContainElement(makePrimitive(privateSubnetRef2)))
 		})
 	})
+
+	Describe("ControlPlaneSubnetRefs", func() {
+		It("returns both public and private subnet references by default", func() {
+			_, subnetDetails, err := vpcRs.CreateTemplate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+				makePrimitive(publicSubnetRef1),
+				makePrimitive(publicSubnetRef2),
+				makePrimitive(privateSubnetRef1),
+				makePrimitive(privateSubnetRef2),
+			))
+		})
+
+		Context("when vpc.controlPlaneOnPrivateSubnets is enabled", func() {
+			BeforeEach(func() {
+				cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+			})
+
+			It("returns only the private subnet references", func() {
+				_, subnetDetails, err := vpcRs.CreateTemplate(context.Background())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+					makePrimitive(privateSubnetRef1),
+					makePrimitive(privateSubnetRef2),
+				))
+			})
+		})
+	})
 })
 
 func makePrimitive(primitive string) *gfnt.Value {

--- a/pkg/cfn/builder/vpc_ipv6.go
+++ b/pkg/cfn/builder/vpc_ipv6.go
@@ -75,9 +75,9 @@ func (v *IPv6VPCResourceSet) CreateTemplate(ctx context.Context) (*gfnt.Value, *
 	addSubnetOutput(privateSubnetResourceRefs, v.clusterConfig.VPC.Subnets.Private, outputs.ClusterSubnetsPrivate)
 
 	if v.clusterConfig.IsFullyPrivate() {
-		return vpcResourceRef, &SubnetDetails{
-			Private: privateSubnets,
-		}, nil
+		subnetDetails := newSubnetDetails(v.clusterConfig, v.clusterConfig.IsAutoModeEnabled())
+		subnetDetails.Private = privateSubnets
+		return vpcResourceRef, subnetDetails, nil
 	}
 
 	// add the rest of the public resources.
@@ -153,11 +153,10 @@ func (v *IPv6VPCResourceSet) CreateTemplate(ctx context.Context) (*gfnt.Value, *
 	}
 	addSubnetOutput(publicSubnetResourceRefs, v.clusterConfig.VPC.Subnets.Public, outputs.ClusterSubnetsPublic)
 
-	return vpcResourceRef, &SubnetDetails{
-		Private:  privateSubnets,
-		Public:   publicSubnets,
-		autoMode: v.clusterConfig.IsAutoModeEnabled(),
-	}, nil
+	subnetDetails := newSubnetDetails(v.clusterConfig, v.clusterConfig.IsAutoModeEnabled())
+	subnetDetails.Private = privateSubnets
+	subnetDetails.Public = publicSubnets
+	return vpcResourceRef, subnetDetails, nil
 }
 
 func (v *IPv6VPCResourceSet) addIpv6CidrBlock() {

--- a/pkg/cfn/builder/vpc_ipv6_test.go
+++ b/pkg/cfn/builder/vpc_ipv6_test.go
@@ -604,6 +604,31 @@ var _ = Describe("IPv6 VPC builder", func() {
 		})
 	})
 
+	Context("when vpc.controlPlaneOnPrivateSubnets is enabled", func() {
+		It("restricts the control plane to private subnets", func() {
+			cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+			vpcRs := builder.NewIPv6VPCResourceSet(builder.NewRS(), cfg, nil)
+			_, subnetDetails, err := vpcRs.CreateTemplate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+				makePrimitive(builder.PrivateSubnetKey+azAFormatted),
+				makePrimitive(builder.PrivateSubnetKey+azBFormatted),
+			))
+		})
+
+		It("is also honoured for a fully-private cluster", func() {
+			cfg.VPC.ControlPlaneOnPrivateSubnets = api.Enabled()
+			cfg.PrivateCluster = &api.PrivateCluster{Enabled: true}
+			vpcRs := builder.NewIPv6VPCResourceSet(builder.NewRS(), cfg, nil)
+			_, subnetDetails, err := vpcRs.CreateTemplate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subnetDetails.ControlPlaneSubnetRefs()).To(ConsistOf(
+				makePrimitive(builder.PrivateSubnetKey+azAFormatted),
+				makePrimitive(builder.PrivateSubnetKey+azBFormatted),
+			))
+		})
+	})
+
 	Context("when there are 3 AZs", func() {
 		BeforeEach(func() {
 			cfg.AvailabilityZones = []string{azA, azB, azC}

--- a/pkg/ctl/cmdutils/update_cluster_vpc.go
+++ b/pkg/ctl/cmdutils/update_cluster_vpc.go
@@ -1,6 +1,7 @@
 package cmdutils
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -84,6 +85,9 @@ func NewUpdateClusterVPCLoader(cmd *Cmd, options UpdateClusterVPCOptions) Cluste
 		logger.Info("only changes to vpc.clusterEndpoints, vpc.publicAccessCIDRs, vpc.controlPlaneSubnetIDs, vpc.controlPlaneSecurityGroupIDs and vpc.controlPlaneEgressMode are updated in the EKS API, changes to any other fields will be ignored")
 		if l.ClusterConfig.VPC == nil {
 			l.ClusterConfig.VPC = api.NewClusterVPC(false)
+		}
+		if api.IsEnabled(l.ClusterConfig.VPC.ControlPlaneOnPrivateSubnets) {
+			return errors.New("vpc.controlPlaneOnPrivateSubnets is only supported when creating a cluster; to change the control plane subnets of an existing cluster, set vpc.controlPlaneSubnetIDs to the IDs of the private subnets")
 		}
 		api.SetClusterEndpointAccessDefaults(l.ClusterConfig.VPC)
 		return nil

--- a/pkg/ctl/cmdutils/update_cluster_vpc.go
+++ b/pkg/ctl/cmdutils/update_cluster_vpc.go
@@ -1,7 +1,6 @@
 package cmdutils
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -87,7 +86,7 @@ func NewUpdateClusterVPCLoader(cmd *Cmd, options UpdateClusterVPCOptions) Cluste
 			l.ClusterConfig.VPC = api.NewClusterVPC(false)
 		}
 		if api.IsEnabled(l.ClusterConfig.VPC.ControlPlaneOnPrivateSubnets) {
-			return errors.New("vpc.controlPlaneOnPrivateSubnets is only supported when creating a cluster; to change the control plane subnets of an existing cluster, set vpc.controlPlaneSubnetIDs to the IDs of the private subnets")
+			logger.Warning("vpc.controlPlaneOnPrivateSubnets is not supported by `eksctl utils update-cluster-vpc-config` and will be ignored; to change the control plane subnets of an existing cluster, set vpc.controlPlaneSubnetIDs to the IDs of the private subnets")
 		}
 		api.SetClusterEndpointAccessDefaults(l.ClusterConfig.VPC)
 		return nil

--- a/pkg/ctl/utils/update_cluster_vpc_config_test.go
+++ b/pkg/ctl/utils/update_cluster_vpc_config_test.go
@@ -1,9 +1,11 @@
 package utils_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 
+	"github.com/kris-nova/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -47,8 +49,14 @@ vpc:
 	}
 
 	// load runs the loader for `eksctl utils update-cluster-vpc-config` directly, without
-	// going through the command handler that talks to AWS.
-	load := func(configFile string) error {
+	// going through the command handler that talks to AWS. It returns the log output so
+	// that the warning can be asserted on.
+	load := func(configFile string) (*api.ClusterConfig, string, error) {
+		output := &bytes.Buffer{}
+		defaultWriter := logger.Writer
+		logger.Writer = output
+		defer func() { logger.Writer = defaultWriter }()
+
 		cfg := api.NewClusterConfig()
 		cmd := &cmdutils.Cmd{
 			ClusterConfig:     cfg,
@@ -58,20 +66,25 @@ vpc:
 				Run: func(_ *cobra.Command, _ []string) {},
 			},
 		}
-		return cmdutils.NewUpdateClusterVPCLoader(cmd, cmdutils.UpdateClusterVPCOptions{}).Load()
+		err := cmdutils.NewUpdateClusterVPCLoader(cmd, cmdutils.UpdateClusterVPCOptions{}).Load()
+		return cfg, output.String(), err
 	}
 
 	When("vpc.controlPlaneOnPrivateSubnets is set", func() {
-		It("does not return a validation error", func() {
-			err := load(writeConfigFile("  controlPlaneOnPrivateSubnets: true\n"))
+		It("warns that it is ignored instead of returning an error", func() {
+			cfg, output, err := load(writeConfigFile("  controlPlaneOnPrivateSubnets: true\n"))
 			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("vpc.controlPlaneOnPrivateSubnets is not supported by `eksctl utils update-cluster-vpc-config` and will be ignored"))
+			// The field is ignored rather than translated into control plane subnets.
+			Expect(cfg.VPC.ControlPlaneSubnetIDs).To(BeEmpty())
 		})
 	})
 
 	When("vpc.controlPlaneOnPrivateSubnets is explicitly false", func() {
-		It("does not return a validation error", func() {
-			err := load(writeConfigFile("  controlPlaneOnPrivateSubnets: false\n  controlPlaneSubnetIDs: [subnet-1234, subnet-5678]\n"))
+		It("does not warn and does not return an error", func() {
+			_, output, err := load(writeConfigFile("  controlPlaneOnPrivateSubnets: false\n  controlPlaneSubnetIDs: [subnet-1234, subnet-5678]\n"))
 			Expect(err).NotTo(HaveOccurred())
+			Expect(output).NotTo(ContainSubstring("vpc.controlPlaneOnPrivateSubnets"))
 		})
 	})
 })

--- a/pkg/ctl/utils/update_cluster_vpc_config_test.go
+++ b/pkg/ctl/utils/update_cluster_vpc_config_test.go
@@ -1,6 +1,9 @@
 package utils_test
 
 import (
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,3 +27,37 @@ var _ = DescribeTable("invalid usage of update-cluster-vpc-config", func(e updat
 		expectedErr: "at least one of these options must be specified: --private-access, --public-access, --public-access-cidrs, --control-plane-subnet-ids, --control-plane-security-group-ids",
 	}),
 )
+
+var _ = Describe("update-cluster-vpc-config with a config file", func() {
+	writeConfigFile := func(vpc string) string {
+		path := filepath.Join(GinkgoT().TempDir(), "config.yaml")
+		contents := `apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: test
+  region: us-west-2
+vpc:
+` + vpc
+		Expect(os.WriteFile(path, []byte(contents), 0600)).To(Succeed())
+		return path
+	}
+
+	When("vpc.controlPlaneOnPrivateSubnets is set", func() {
+		It("returns an error instead of silently ignoring it", func() {
+			cmd := newMockCmd("update-cluster-vpc-config", "-f", writeConfigFile("  controlPlaneOnPrivateSubnets: true\n"))
+			_, err := cmd.execute()
+			Expect(err).To(MatchError(ContainSubstring("vpc.controlPlaneOnPrivateSubnets is only supported when creating a cluster")))
+		})
+	})
+
+	When("vpc.controlPlaneOnPrivateSubnets is explicitly false", func() {
+		It("does not return a validation error", func() {
+			cmd := newMockCmd("update-cluster-vpc-config", "-f", writeConfigFile("  controlPlaneOnPrivateSubnets: false\n  controlPlaneSubnetIDs: [subnet-1234, subnet-5678]\n"))
+			_, err := cmd.execute()
+			// The command proceeds past validation and fails when reaching AWS.
+			if err != nil {
+				Expect(err.Error()).NotTo(ContainSubstring("controlPlaneOnPrivateSubnets"))
+			}
+		})
+	})
+})

--- a/pkg/ctl/utils/update_cluster_vpc_config_test.go
+++ b/pkg/ctl/utils/update_cluster_vpc_config_test.go
@@ -6,6 +6,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 type updateClusterVPCEntry struct {
@@ -42,22 +46,32 @@ vpc:
 		return path
 	}
 
+	// load runs the loader for `eksctl utils update-cluster-vpc-config` directly, without
+	// going through the command handler that talks to AWS.
+	load := func(configFile string) error {
+		cfg := api.NewClusterConfig()
+		cmd := &cmdutils.Cmd{
+			ClusterConfig:     cfg,
+			ClusterConfigFile: configFile,
+			CobraCommand: &cobra.Command{
+				Use: "update-cluster-vpc-config",
+				Run: func(_ *cobra.Command, _ []string) {},
+			},
+		}
+		return cmdutils.NewUpdateClusterVPCLoader(cmd, cmdutils.UpdateClusterVPCOptions{}).Load()
+	}
+
 	When("vpc.controlPlaneOnPrivateSubnets is set", func() {
-		It("returns an error instead of silently ignoring it", func() {
-			cmd := newMockCmd("update-cluster-vpc-config", "-f", writeConfigFile("  controlPlaneOnPrivateSubnets: true\n"))
-			_, err := cmd.execute()
-			Expect(err).To(MatchError(ContainSubstring("vpc.controlPlaneOnPrivateSubnets is only supported when creating a cluster")))
+		It("does not return a validation error", func() {
+			err := load(writeConfigFile("  controlPlaneOnPrivateSubnets: true\n"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	When("vpc.controlPlaneOnPrivateSubnets is explicitly false", func() {
 		It("does not return a validation error", func() {
-			cmd := newMockCmd("update-cluster-vpc-config", "-f", writeConfigFile("  controlPlaneOnPrivateSubnets: false\n  controlPlaneSubnetIDs: [subnet-1234, subnet-5678]\n"))
-			_, err := cmd.execute()
-			// The command proceeds past validation and fails when reaching AWS.
-			if err != nil {
-				Expect(err.Error()).NotTo(ContainSubstring("controlPlaneOnPrivateSubnets"))
-			}
+			err := load(writeConfigFile("  controlPlaneOnPrivateSubnets: false\n  controlPlaneSubnetIDs: [subnet-1234, subnet-5678]\n"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/userdocs/src/usage/cluster-subnets-security-groups.md
+++ b/userdocs/src/usage/cluster-subnets-security-groups.md
@@ -67,9 +67,12 @@ public subnets at all, see [EKS Private Cluster without Outbound Internet Access
 Note the following when using this setting:
 
 - At least two private subnets across at least two availability zones are required, because EKS places its cross-account
-  ENIs in a minimum of two zones. eksctl validates this before creating anything, except when pre-existing subnets are
-  specified only by ID: their availability zone is not known until eksctl looks them up in EC2, which happens after
-  validation, so insufficient AZ coverage is instead rejected by the EKS API.
+  ENIs in a minimum of two zones. eksctl validates this before creating anything, with two exceptions where the zones are
+  not yet known at validation time:
+    - `availabilityZones` is left unset, so eksctl selects the zones itself afterwards. Auto-selection always yields
+      distinct zones, so there is nothing to check.
+    - Pre-existing subnets are given only by ID, so their zone is only resolved from EC2 afterwards. Insufficient zone
+      coverage is then rejected by the EKS API instead.
 - The private subnets must have a NAT gateway or the relevant VPC endpoints, otherwise nodes cannot reach the API server.
   When eksctl creates the VPC this is handled by the `vpc.nat` configuration.
 - It cannot be combined with `vpc.controlPlaneSubnetIDs`; specify one or the other.

--- a/userdocs/src/usage/cluster-subnets-security-groups.md
+++ b/userdocs/src/usage/cluster-subnets-security-groups.md
@@ -77,6 +77,9 @@ Note the following when using this setting:
   When eksctl creates the VPC this is handled by the `vpc.nat` configuration.
 - It cannot be combined with `vpc.controlPlaneSubnetIDs`; specify one or the other.
 - It applies both when eksctl creates the VPC and when a pre-existing VPC is supplied via `vpc.id`.
+- It only takes effect at cluster creation time. `eksctl utils update-cluster-vpc-config` warns and ignores it, since it
+  updates the EKS API directly and cannot keep the cluster's CloudFormation stack in sync; use
+  `vpc.controlPlaneSubnetIDs` to change the control plane subnets of an existing cluster.
 
 ## Updating control plane security groups
 To manage traffic between the control plane and worker nodes, EKS supports passing additional security groups that are applied to the cross-account network interfaces

--- a/userdocs/src/usage/cluster-subnets-security-groups.md
+++ b/userdocs/src/usage/cluster-subnets-security-groups.md
@@ -31,6 +31,48 @@ eksctl utils update-cluster-vpc-config -f config.yaml
 Without the `--approve` flag, eksctl only logs the proposed changes. Once you are satisfied with the proposed changes, rerun the command with
 the  `--approve` flag.
 
+## Restricting the control plane to private subnets at creation time
+
+`eksctl utils update-cluster-vpc-config` changes the control plane subnets of an existing cluster, and it does so by
+calling the EKS API directly rather than by updating the cluster's CloudFormation stack. That leaves the stack out of sync
+with the actual configuration.
+
+To place the control plane on private subnets from the outset, set `vpc.controlPlaneOnPrivateSubnets` when creating the
+cluster. Only the private subnets are then passed to the EKS API, so the cross-account ENIs are never created in public
+subnets, and the CloudFormation stack reflects the intended configuration from the start:
+
+```yaml
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: cluster
+  region: us-west-2
+
+availabilityZones:
+  - us-west-2a
+  - us-west-2b
+
+vpc:
+  controlPlaneOnPrivateSubnets: true
+```
+
+```console
+eksctl create cluster -f config.yaml
+```
+
+Public subnets are still created and are still used for NAT gateways, internet-facing load balancers, and any nodegroup
+that is not private, so this setting does not turn the cluster into a fully-private one. To create a cluster with no
+public subnets at all, see [EKS Private Cluster without Outbound Internet Access](/usage/eks-private-cluster/).
+
+Note the following when using this setting:
+
+- At least two private subnets across at least two availability zones are required, because EKS places its cross-account
+  ENIs in a minimum of two zones. eksctl validates this before creating anything.
+- The private subnets must have a NAT gateway or the relevant VPC endpoints, otherwise nodes cannot reach the API server.
+  When eksctl creates the VPC this is handled by the `vpc.nat` configuration.
+- It cannot be combined with `vpc.controlPlaneSubnetIDs`; specify one or the other.
+- It applies both when eksctl creates the VPC and when a pre-existing VPC is supplied via `vpc.id`.
+
 ## Updating control plane security groups
 To manage traffic between the control plane and worker nodes, EKS supports passing additional security groups that are applied to the cross-account network interfaces
 provisioned by EKS. To update the security groups for the EKS control plane, run:

--- a/userdocs/src/usage/cluster-subnets-security-groups.md
+++ b/userdocs/src/usage/cluster-subnets-security-groups.md
@@ -67,7 +67,9 @@ public subnets at all, see [EKS Private Cluster without Outbound Internet Access
 Note the following when using this setting:
 
 - At least two private subnets across at least two availability zones are required, because EKS places its cross-account
-  ENIs in a minimum of two zones. eksctl validates this before creating anything.
+  ENIs in a minimum of two zones. eksctl validates this before creating anything, except when pre-existing subnets are
+  specified only by ID: their availability zone is not known until eksctl looks them up in EC2, which happens after
+  validation, so insufficient AZ coverage is instead rejected by the EKS API.
 - The private subnets must have a NAT gateway or the relevant VPC endpoints, otherwise nodes cannot reach the API server.
   When eksctl creates the VPC this is handled by the `vpc.nat` configuration.
 - It cannot be combined with `vpc.controlPlaneSubnetIDs`; specify one or the other.


### PR DESCRIPTION
### Description

Closes #8792.

When eksctl creates a VPC, it currently passes both the public and the private subnets to the EKS API, so the control plane's cross-account ENIs are placed in public subnets as well as private ones. Restricting them to private subnets afterwards requires `eksctl utils update-cluster-vpc-config`, which calls the EKS API directly and leaves the cluster's CloudFormation stack out of sync with the actual configuration.

This PR adds a `vpc.controlPlaneOnPrivateSubnets` field so that only the private subnets are passed to the EKS API at cluster creation time. Public subnets are still created and used for NAT gateways and internet-facing load balancers — this does not make the cluster fully private, it only changes which subnets the control plane's ENIs land in.

Key implementation points:

- The field is honoured for eksctl-created VPCs (IPv4 and IPv6, including fully-private clusters) and for pre-existing/imported VPCs.
- It is rejected when combined with `vpc.controlPlaneSubnetIDs`, since that field already gives explicit control over control plane subnets.
- It is rejected when the configured private subnets do not cover at least two availability zones, which EKS requires. When `availabilityZones` is set explicitly, distinct zones are counted, since duplicates are permitted elsewhere and collapse into a single private subnet. When subnets are pre-existing, their zones are counted directly. The check is best-effort and is skipped in the two cases where the zones are not yet known at validation time:
  - `availabilityZones` is left unset, so eksctl selects the zones itself in `eks.SetAvailabilityZones`, which runs after validation. Auto-selection always yields distinct zones, so there is nothing to check.
  - Subnets are given only by ID, so their AZ is resolved from EC2 after validation runs. Those are allowed through and rejected by the EKS API instead if insufficient.
- Outposts clusters are exempt, since the control plane there is already private-only.
- `eksctl utils update-cluster-vpc-config` now warns and ignores the field (consistent with how `eksctl update nodegroup` handles other unsupported fields) and points users at `vpc.controlPlaneSubnetIDs` instead, since that command talks to the EKS API directly and can't keep the CloudFormation stack in sync.
- Control plane subnet selection is now built through a single helper. `autoMode` is passed into it rather than derived internally, so the new field keeps applying only to VPCs that eksctl creates — the pre-existing VPC path has never restricted the control plane for Auto Mode clusters, and deriving `autoMode` there would have changed that behaviour for configurations not using the new field.

See `examples/49-control-plane-on-private-subnets.yaml` for a usage example, and the updated `userdocs/src/usage/cluster-subnets-security-groups.md` for documentation.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

