### PR TITLE
Exclude golangci-lint from the grouped Go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,15 +62,23 @@ updates:
 
       # Everything else non-major, including indirect dependencies.
       #
-      # helm is excluded on purpose: it is load-bearing for eksctl and its
-      # minor releases have carried behavioural change, so it should arrive as
-      # its own reviewable PR rather than buried in a batch.
+      # Exclusions are for dependencies that should not be able to block an
+      # otherwise healthy batch:
+      #
+      # - helm is load-bearing for eksctl and its minor releases have carried
+      #   behavioural change, so it should arrive as its own reviewable PR.
+      # - golangci-lint pulls the whole linter tree (staticcheck, and dozens of
+      #   analyser plugins) and is constrained by the `replace` directive
+      #   pinning golang.org/x/tools below the version it needs. A grouped
+      #   update including it therefore cannot build, which blocks every other
+      #   dependency in the same pull request.
       go-minor-patch:
         applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
           - "helm.sh/helm/v3"
+          - "github.com/golangci/golangci-lint/v2"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Problem

The `go-minor-patch` group opened #8824 with seven updates, and it cannot build:

```
golangci-lint/v2@v2.12.2/pkg/goanalysis/runner_checker.go:452:23:
  undefined: analysis.ModuleError
... unknown field Replace / Time / Main / Indirect / Dir / GoMod
    in struct literal of type analysis.Module
honnef.co/go/tools@v0.7.0/internal/passes/buildir/buildir.go:64:24:
  cfgs.NoReturn undefined
```

golangci-lint 2.12.2 needs a newer `golang.org/x/tools/go/analysis` API than the
version `go.mod` forces:

```
golang.org/x/tools v0.47.0            // required
replace golang.org/x/tools => v0.39.0 // forced down
```

## Effect

One dependency blocks six unrelated ones in the same pull request:
`Masterminds/semver`, `mark3labs/mcp-go`, `sethvargo/go-password`,
`tidwall/gjson`, `vburenin/ifacemaker` and `golang.org/x/crypto`.

golangci-lint also accounts for nearly all of #8824's indirect churn, because it
carries the entire linter plugin tree (staticcheck plus dozens of analysers such
as `go-errorlint`, `unqueryvet`, `forbidigo`, `makezero`, `wsl`).

## Fix

Add `github.com/golangci/golangci-lint/v2` to the group's `exclude-patterns`, so
those six updates group cleanly and golangci-lint arrives as its own pull
request. This mirrors the existing `helm.sh/helm/v3` exclusion and relies on the
same documented behaviour: dependencies matching no group still get an
individual PR.

`honnef.co/go/tools` needs no separate exclusion. It only moves as golangci-lint's
transitive dependency, so holding golangci-lint back holds it back too.

## What this does not fix

The golangci-lint upgrade itself remains blocked and will now fail in its own PR
instead of a shared one. Unblocking it means raising or removing the
`golang.org/x/tools` pin, which deserves review on its own since whoever added
that `replace` presumably had a reason. Worth noting there is a second pin of the
same kind, `replace k8s.io/apimachinery => v0.34.1`, which is currently blocking
the helm 3.21.3 CVE fix in #8825.

## Testing

Config-only change. Validated that the file parses and that all group keys,
`applies-to` values and `update-types` values conform to the documented
Dependabot schema. The observable outcome is on the next Dependabot run: the
`go-minor-patch` group should be recreated without golangci-lint, and #8824
superseded.