### PR TITLE
Use a current-generation GPU type in the SSM resolver spec

### DIFF
--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -760,7 +760,12 @@ var _ = Describe("AMI Auto Resolution", func() {
 
 				Context("and gpu instance", func() {
 					BeforeEach(func() {
-						instanceType = "p3.2xlarge"
+						// Any NVIDIA instance type exercises the same "-nvidia"
+						// SSM parameter path. Prefer a current-generation family:
+						// the previous exemplar, p3, has since been retired and
+						// dropped out of the generated instance data, which broke
+						// this spec.
+						instanceType = "g5.xlarge"
 						version = "1.23"
 					})
 


### PR DESCRIPTION
## Problem

The Bottlerocket GPU specs in `pkg/ami/ssm_resolver_test.go` use
**`p3.2xlarge`** as their NVIDIA exemplar.

GPU detection is a map lookup into the generated `InstanceTypesMap`
(`instanceutils.IsNvidiaInstanceType` and friends), so an instance type that is
absent from that data silently reads back as *not* GPU. When that happens the
SSM resolver builds the plain parameter path instead of the `-nvidia` one, the
mocked `GetParameter` call no longer matches, and six specs fail with
`mock: Unexpected Method Call`.

p3 is being retired. Regenerating `pkg/utils/instance/instance_types.go` removes
**p3, f1 and dl1** outright, because `cmd/ec2geninfo` unions
`DescribeInstanceTypes` across us-east-1, us-east-2 and us-west-2 and none of
those families is returned any more. (`ec2geninfo` already hardcodes a skip for
`^(p2).*`, so there is precedent.)

That is what currently blocks **#8723**, and it will block every future
`ec2-info` regeneration until the exemplar moves.

## Fix

Switch the exemplar to **`g5.xlarge`**, which is NVIDIA-backed (A10G) in both the
current and the regenerated data:

```
InstanceType:       "g5.xlarge"
NvidiaGPUSupported: true
NvidiaGPUType:      "A10G"
```

So the spec passes both before and after the ec2-info update. The mocked SSM
parameter path is unchanged, since it depends only on the type being NVIDIA, not
on which family it belongs to.

## Scope

This is the only spec that needs changing, verified empirically rather than by
inspection. In the #8723 CI run the regenerated data is already in effect, and
the results are:

```
FAIL  github.com/weaveworks/eksctl/pkg/ami
ok    github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5
ok    github.com/weaveworks/eksctl/pkg/eks
```

Two other p3 references exist but are insensitive to the removal, and are
deliberately left alone:

- `gpu_validation_test.go` uses `p3.2xlarge` for the Windows Full AMI families.
  The adjacent Core entries already use `g3.8xlarge`, which is *also* absent from
  the generated data and passes, so those entries do not depend on GPU-ness.
- `instance_selection_test.go` lists `p3.8xlarge` among GPU types, but
  `SelectInstanceType` returns the *first* GPU entry and `g5.8xlarge` precedes
  it, so the expected result is unaffected.

They are still references to a retiring family and worth tidying, but not as part
of a fix that unblocks a regeneration.

## Follow-up

With this merged, dispatching the `Update generated files` workflow will refresh
#8723 in place (`create-pull-request` upserts onto the `update-ec2-info` branch)
with current data, and it should then pass. That regeneration also brings the
M9g/M9gd types that #8769 adds by hand, so #8769 can be closed as redundant.