### PR TITLE
docs: bump Netlify Python from EOL 3.8 to 3.12

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,4 @@
   ignore = "git diff --quiet HEAD^ HEAD ./"
 
 [build.environment]
-  PYTHON_VERSION = "3.8"
+  PYTHON_VERSION = "3.12"


### PR DESCRIPTION
### Description

Bump the Netlify docs build from Python 3.8 (end-of-life) to 3.12.

`userdocs/requirements.txt` leaves several docs dependencies unpinned
(`mkdocs-redirects`, `mkdocs-minify-plugin`, `mkdocs-glightbox`,
`pillow`, `cairosvg`, `pygments`, `markdown`). Python 3.8 is EOL, so a
fresh install on the pinned 3.8 now resolves a dependency release that
has dropped 3.8 support and the Netlify build fails during dependency
setup, before `mkdocs build` runs.

This only surfaces on PRs that touch `userdocs/` — the `[context.deploy-preview]`
`ignore` rule skips the build otherwise — so most PRs are unaffected and it
went unnoticed. PRs that do touch the docs (e.g. #8821) now fail their docs
deploy through no fault of their own, and the production docs deploy would
fail the same way on merge since the `ignore` rule is scoped to deploy-preview
only.

The docs site builds cleanly on 3.12 (`mkdocs build`, no errors).

Note: this PR changes only `netlify.toml` at the repo root, so its own
deploy-preview is skipped by the `ignore` rule; the fix is exercised by
the production build on merge.

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
