### PR TITLE
Sync the node agent version in the aws-node generator

### DIFF
--- a/pkg/addons/default/scripts/update_aws_node.sh
+++ b/pkg/addons/default/scripts/update_aws_node.sh
@@ -37,3 +37,19 @@ fi
 
 # Update the unit test file
 sed -i "s/expectedVersion = \"\(.*\)\"/expectedVersion = \"$latest_release_tag\"/g" "$default_addons_dir/aws_node_test.go"
+
+# The aws-network-policy-agent sidecar is versioned independently of the VPC CNI
+# release tag, so it cannot be derived from $latest_release_tag. Read it back out
+# of the manifest that was just downloaded, otherwise the expected value in the
+# unit test drifts from the manifest whenever the sidecar moves and the aws-node
+# specs fail on an otherwise correct update.
+node_agent_version=$(grep -oE 'aws-network-policy-agent:v[0-9]+\.[0-9]+\.[0-9]+' \
+  "$default_addons_dir/assets/aws-node.yaml" | head -1 | cut -d: -f2)
+
+if [ -z "$node_agent_version" ]; then
+  echo "Could not determine the aws-network-policy-agent version from $default_addons_dir/assets/aws-node.yaml."
+  exit 1
+fi
+
+echo "Found the aws-network-policy-agent version: $node_agent_version"
+sed -i "s/expectedNodeAgentVersion = \"\(.*\)\"/expectedNodeAgentVersion = \"$node_agent_version\"/g" "$default_addons_dir/aws_node_test.go"


### PR DESCRIPTION
## Problem

`pkg/addons/default/scripts/update_aws_node.sh` downloads the VPC CNI manifest
and then rewrites exactly one constant in the unit test:

```bash
sed -i "s/expectedVersion = \"\(.*\)\"/expectedVersion = \"$latest_release_tag\"/g" \
  "$default_addons_dir/aws_node_test.go"
```

But `aws_node_test.go` asserts **two** image versions. Alongside the CNI it checks
the `aws-network-policy-agent` sidecar through `expectedNodeAgentVersion`, and that
sidecar is versioned independently of the VPC CNI release tag.

So whenever the sidecar moves, the regenerated manifest and the expected value in
the test disagree, and two specs fail on an otherwise correct update:

```
[FAIL] AWS Node UpdateAWSNode when it is out of date [It] updates it
[FAIL] AWS Node UpdateAWSNode when using a chinese region [It] updates it and
       uses the amazonaws.com.cn address
```

## This is the second occurrence

- **#8747** bumped the sidecar v1.3.1 -> v1.4.0. Fixed by hand.
- **#8832** bumps v1.4.0 -> v1.4.1 and fails identically.

Left alone it recurs on every VPC CNI release where the sidecar also changes, and
each occurrence costs a maintainer a manual one-line patch on a bot PR.

## Fix

The sidecar version cannot be derived from `$latest_release_tag`, so read it back
out of the manifest that was just downloaded and apply the same `sed`:

```bash
node_agent_version=$(grep -oE 'aws-network-policy-agent:v[0-9]+\.[0-9]+\.[0-9]+' \
  "$default_addons_dir/assets/aws-node.yaml" | head -1 | cut -d: -f2)
```

It exits non-zero if the version cannot be found, so a manifest layout change
fails the generator loudly instead of silently writing an empty version into the
test.

## Testing

The generator only runs from the `Update generated files` workflow, so this
cannot be exercised by PR CI. Verified locally against the manifest currently on
`main`:

- extraction yields `v1.4.0`, which matches `expectedNodeAgentVersion` on `main`
- each `sed` matches only its own constant, checked in both directions:
  rewriting `expectedVersion` leaves `expectedNodeAgentVersion` untouched and
  vice versa (`expectedNodeAgentVersion` does not contain the substring
  `expectedVersion`, so there is no cross-match)
- `bash -n` passes

The real confirmation is the next generator run: the regenerated PR should carry
both constants in step with the manifest and pass without manual intervention.

## Note for reviewers

A broader alternative would be to derive **both** constants from the downloaded
manifest rather than taking the CNI version from the release tag. That would
eliminate this class of drift outright rather than fixing one instance. I kept the
change targeted because the release-tag path demonstrably works for the CNI today,
but it is worth a decision if you would rather not revisit this again.

## Follow-up

#8832 still needs its `expectedNodeAgentVersion` set to `v1.4.1` to go green,
since its branch was generated before this fix. That can be a one-line push to
the branch, or a regeneration once this lands.