### PR TITLE
Grant ec2:DescribeSecurityGroups to the IPv6 VPC CNI role

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -490,12 +490,15 @@ func makeIPv6VPCCNIPolicyDocument(partition string) map[string]interface{} {
 					"ec2:DescribeTags",
 					"ec2:DescribeNetworkInterfaces",
 					"ec2:DescribeInstanceTypes",
-					// Required by the VPC CNI's subnet discovery, which is enabled
-					// by default. Without it ipamd fails to initialise, aws-node
-					// crash-loops and nodes never become ready. The IPv4 path gets
-					// this from the AWS-managed AmazonEKS_CNI_Policy; the IPv6
-					// path uses this inline policy, so it must be granted here.
+					// Both of these are required by the VPC CNI's subnet discovery,
+					// which is enabled by default since VPC CNI v1.22.1. Without
+					// them ipamd fails to initialise, aws-node crash-loops and nodes
+					// never become ready. The IPv4 path gets them from the
+					// AWS-managed AmazonEKS_CNI_Policy; the IPv6 path uses this
+					// inline policy, so they must be granted here. See
+					// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/iam-policy.md
 					"ec2:DescribeSubnets",
+					"ec2:DescribeSecurityGroups",
 				},
 				"Resource": "*",
 			},

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -3,6 +3,7 @@ package addon_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -988,6 +989,12 @@ var _ = Describe("Create", func() {
 						Expect(args[1]).To(BeAssignableToTypeOf(&api.PodIdentityAssociation{}))
 						Expect(args[1].(*api.PodIdentityAssociation).ServiceAccountName).To(Equal("aws-node"))
 						Expect(args[1].(*api.PodIdentityAssociation).PermissionPolicy).NotTo(BeEmpty())
+						// The pod identity path shares the IPv6 CNI policy document with
+						// the IRSA path; subnet discovery permissions must reach both.
+						policy, err := json.Marshal(args[1].(*api.PodIdentityAssociation).PermissionPolicy)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(string(policy)).To(ContainSubstring("ec2:DescribeSubnets"))
+						Expect(string(policy)).To(ContainSubstring("ec2:DescribeSecurityGroups"))
 					}).
 					Return("arn:aws:iam::111122223333:role/aws-node", nil).
 					Once()
@@ -1168,9 +1175,10 @@ var _ = Describe("Create", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(output)).To(ContainSubstring("AssignIpv6Addresses"))
 					// Subnet discovery is on by default in the VPC CNI; without
-					// this permission ipamd fails to initialise and nodes never
+					// these permissions ipamd fails to initialise and nodes never
 					// become ready.
 					Expect(string(output)).To(ContainSubstring("DescribeSubnets"))
+					Expect(string(output)).To(ContainSubstring("DescribeSecurityGroups"))
 					rsr.(*builder.IAMRoleResourceSet).OutputRole = "arn:aws:iam::111122223333:role/role-name-1"
 					return nil
 				}


### PR DESCRIPTION
## Problem

Subnet discovery in the VPC CNI requires two EC2 permissions, not one.
#8835 granted `ec2:DescribeSubnets`; this grants the other half,
`ec2:DescribeSecurityGroups`.

#8768 reported both denials. The first surfaced as a Kubernetes event on the
`aws-node` pod:

```
Warning  MissingIAMPermissions  Unauthorized operation: failed to call
ec2:DescribeSubnets due to missing permissions.
```

Once that action was granted, the CNI got further and failed on the second.
That one appears only in `/var/log/aws-routed-eni/ipamd.log`, because the
container writes nothing about it to stdout — it just prints
`Checking for IPAM connectivity...` and appears to hang:

```
Initialization failure: unable to describe security groups: operation error
EC2: DescribeSecurityGroups, https response error StatusCode: 403, api error
UnauthorizedOperation: You are not authorized to perform this operation...
no identity-based policy allows the ec2:DescribeSecurityGroups action
```

Without the CNI running the node reports `NetworkPluginNotReady: cni plugin
not initialized` and stays `NotReady`, so this presents identically to #8835:
the nodegroup sits in `CREATING` until eksctl gives up.

`makeIPv6VPCCNIPolicyDocument` does not grant `ec2:DescribeSecurityGroups`.

## Why both actions are needed

Upstream documents both as required for subnet discovery since VPC CNI
**v1.22.1**, and subnet discovery is enabled by default:
aws/amazon-vpc-cni-k8s#3709. That PR is what added `ec2:DescribeSecurityGroups`
to the upstream [IAM policy docs](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/iam-policy.md).

This is the same root cause as #8835 — one CNI behaviour change requiring two
permissions — which is why #8768 is still open after that fix shipped in
v0.230.0.

## Why only IPv6

The IPv4 path attaches the AWS-managed `AmazonEKS_CNI_Policy`. I checked the
live policy rather than relying on the docs: it is at version **v6** and its
`AmazonEKSCNIPolicy` statement already grants both `ec2:DescribeSubnets` and
`ec2:DescribeSecurityGroups`. The IPv6 path uses this hand-written inline
policy instead, so each action has to be granted explicitly.

## Fix

Add `ec2:DescribeSecurityGroups` to the IPv6 VPC CNI policy. After this change
the document matches the upstream IPv6 policy exactly — no missing and no extra
actions.

This closes out the follow-up I flagged in #8835, where I noted the IPv6 policy
was worth auditing against the upstream doc more broadly in case subnet
discovery was not the only capability added since the list was written. It was
not: subnet discovery itself needed a second action. The integration suite
reproduction used for #8835 stopped at the first denial, so
`ec2:DescribeSecurityGroups` never became visible there.

## Test coverage

Both callers of `makeIPv6VPCCNIPolicyDocument` are affected, so both are now
covered:

- the IRSA path, via `addon.AttachPolicy` (`create.go:424`)
- the pod identity path, via `PodIdentityAssociation.PermissionPolicy`
  (`create.go:197`)

The pod identity test previously only asserted the document was non-empty, so
it would not have caught a missing action. It now asserts both subnet discovery
permissions, matching what the IRSA test already did for `ec2:DescribeSubnets`.

## Testing done on this change

I verified the rendered policy document by extracting `makeIPv6VPCCNIPolicyDocument`
and diffing its output against the upstream IPv6 action list:

```
missing vs upstream IPv6 policy: []
extra vs upstream IPv6 policy:   []
RESULT: PASS - matches upstream IPv6 policy exactly
```

Running the same check against the function before this change yields
`missing: [ec2:DescribeSecurityGroups]`, so the check is discriminating rather
than vacuously passing.

`AmazonEKS_CNI_Policy` v6 was read back from IAM directly to confirm the IPv4
path is unaffected.

**Caveat, flagging honestly:** I could not execute `go test ./pkg/actions/addon/`
locally. `github.com/charmbracelet/x/ansi@v0.10.1` fetched via `GOPROXY=direct`
hashes differently than `go.sum` records, and `proxy.golang.org` is unreachable
from the machine I was on, so the package would not compile. I did not bypass
checksum verification or touch `go.mod`/`go.sum` to work around it. The two
added Ginkgo assertions are therefore unexecuted and depend on CI. `gofmt` is
clean on both files.

Unlike #8835, I have not reproduced this end to end against a live IPv6 cluster;
the evidence here is the reporter's ipamd log in #8768 plus the upstream
requirement. Worth a reviewer confirming against a real IPv6 cluster before
merge if that is cheap to do.

Fixes #8768
