### PR TITLE
Add support for eusc-de-east-1 (AWS European Sovereign Cloud)

### DIFF
--- a/pkg/actions/nodegroup/testdata/al2-force-false-template.json
+++ b/pkg/actions/nodegroup/testdata/al2-force-false-template.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/actions/nodegroup/testdata/al2-no-force-template.json
+++ b/pkg/actions/nodegroup/testdata/al2-no-force-template.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/actions/nodegroup/testdata/al2-updated-template.json
+++ b/pkg/actions/nodegroup/testdata/al2-updated-template.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/actions/nodegroup/testdata/br-force-false-template.json
+++ b/pkg/actions/nodegroup/testdata/br-force-false-template.json
@@ -16,6 +16,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/actions/nodegroup/testdata/br-force-true-template.json
+++ b/pkg/actions/nodegroup/testdata/br-force-true-template.json
@@ -16,6 +16,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/actions/nodegroup/testdata/br-updated-template.json
+++ b/pkg/actions/nodegroup/testdata/br-updated-template.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -41,6 +41,7 @@ var KnownAddons = map[string]struct {
 			RegionUSISOFEast1,
 			RegionUSISOFSouth1,
 			RegionEUISOEWest1,
+			RegionEUSCDEEast1,
 		},
 		// Don't require waiting for metrics-server to be up if it's the only add-on to wait for.
 		// This is because this add-on is installed by default and we don't

--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -41,7 +41,6 @@ var KnownAddons = map[string]struct {
 			RegionUSISOFEast1,
 			RegionUSISOFSouth1,
 			RegionEUISOEWest1,
-			RegionEUSCDEEast1,
 		},
 		// Don't require waiting for metrics-server to be up if it's the only add-on to wait for.
 		// This is because this add-on is installed by default and we don't

--- a/pkg/apis/eksctl.io/v1alpha5/partitions.go
+++ b/pkg/apis/eksctl.io/v1alpha5/partitions.go
@@ -11,6 +11,7 @@ const (
 	PartitionISOB  = "aws-iso-b"
 	PartitionISOF  = "aws-iso-f"
 	PartitionISOE  = "aws-iso-e"
+	PartitionEUSC  = "aws-eusc"
 )
 
 // partition is an AWS partition.
@@ -148,6 +149,13 @@ var Partitions = partitions{
 		endpointServiceDomainPrefix:    standardPartitionServiceDomainPrefix,
 		endpointServiceDomainPrefixAlt: "gov.ic.hci.csp",
 		v1SDKDNSPrefix:                 "csp.hci.ic.gov",
+	},
+	{
+		name:                        PartitionEUSC,
+		serviceMappings:             standardServiceMappings,
+		regions:                     []string{RegionEUSCDEEast1},
+		endpointServiceDomainPrefix: standardPartitionServiceDomainPrefix,
+		v1SDKDNSPrefix:              "amazonaws.eu",
 	},
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/partitions_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/partitions_test.go
@@ -25,6 +25,7 @@ func TestV1SDKDNSPrefix(t *testing.T) {
 		{RegionUSISOBEast1, "sc2s.sgov.gov"},
 		{RegionEUISOEWest1, "cloud.adc-e.uk"},
 		{RegionUSISOFSouth1, "csp.hci.ic.gov"},
+		{RegionEUSCDEEast1, "amazonaws.eu"},
 	}
 	for _, test := range tests {
 		dns, err := Partitions.V1SDKDNSPrefixForRegion(test.region)

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -201,6 +201,9 @@ const (
 	// Region represents the region EU ISOE West.
 	RegionEUISOEWest1 = "eu-isoe-west-1"
 
+	// RegionEUSCDEEast1 represents the AWS European Sovereign Cloud region Germany East.
+	RegionEUSCDEEast1 = "eusc-de-east-1"
+
 	// DefaultRegion defines the default region, where to deploy the EKS cluster
 	DefaultRegion = RegionUSWest2
 )
@@ -420,6 +423,9 @@ const (
 
 	// eksResourceAccountEUISOEWest1 defines the AWS EKS account ID that provides node resources in eu-isoe-west-1
 	eksResourceAccountEUISOEWest1 = "249663109785"
+
+	// eksResourceAccountEUSCDEEast1 defines the AWS EKS account ID that provides node resources in eusc-de-east-1
+	eksResourceAccountEUSCDEEast1 = "877088126301"
 )
 
 // Values for `VolumeType`
@@ -581,6 +587,7 @@ func SupportedRegions() []string {
 		RegionUSISOFSouth1,
 		RegionUSISOFEast1,
 		RegionEUISOEWest1,
+		RegionEUSCDEEast1,
 	}
 }
 
@@ -691,6 +698,8 @@ func EKSResourceAccountID(region string) string {
 		return eksResourceAccountUSISOFEast1
 	case RegionEUISOEWest1:
 		return eksResourceAccountEUISOEWest1
+	case RegionEUSCDEEast1:
+		return eksResourceAccountEUSCDEEast1
 	default:
 		return eksResourceAccountStandard
 	}

--- a/pkg/cfn/builder/karpenter_test.go
+++ b/pkg/cfn/builder/karpenter_test.go
@@ -84,6 +84,13 @@ var expectedTemplate = `{
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",
@@ -244,6 +251,13 @@ var expectedTemplateWithPermissionBoundary = `{
         "EC2": "ec2.amazonaws.com.cn",
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
+      },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
       },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
@@ -406,6 +420,13 @@ var expectedTemplateWithSpotInterruptionQueue = `{
         "EC2": "ec2.amazonaws.com.cn",
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
+      },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
       },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",

--- a/pkg/cfn/builder/testdata/nodegroup_access_entry/1.json
+++ b/pkg/cfn/builder/testdata/nodegroup_access_entry/1.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/cfn/builder/testdata/nodegroup_access_entry/2.json
+++ b/pkg/cfn/builder/testdata/nodegroup_access_entry/2.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/cfn/builder/testdata/nodegroup_access_entry/3.json
+++ b/pkg/cfn/builder/testdata/nodegroup_access_entry/3.json
@@ -15,6 +15,13 @@
         "EKS": "eks.amazonaws.com",
         "EKSFargatePods": "eks-fargate-pods.amazonaws.com"
       },
+      "aws-eusc": {
+        "EC2": "ec2.amazonaws.com",
+        "EKS": "eks.amazonaws.com",
+        "EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+        "IRA": "rolesanywhere.amazonaws.com",
+        "SSM": "ssm.amazonaws.com"
+      },
       "aws-iso": {
         "EC2": "ec2.c2s.ic.gov",
         "EKS": "eks.amazonaws.com",

--- a/pkg/connector/arn_test.go
+++ b/pkg/connector/arn_test.go
@@ -23,6 +23,7 @@ var arnTests = []struct {
 	{"arn:aws-iso-b:iam::123456789012:user/Chris", "arn:aws-iso-b:iam::123456789012:user/Chris", nil},
 	{"arn:aws-iso-f:iam::123456789012:user/Chris", "arn:aws-iso-f:iam::123456789012:user/Chris", nil},
 	{"arn:aws-iso-e:iam::123456789012:user/Chris", "arn:aws-iso-e:iam::123456789012:user/Chris", nil},
+	{"arn:aws-eusc:iam::123456789012:user/Chris", "arn:aws-eusc:iam::123456789012:user/Chris", nil},
 }
 
 func TestUserARN(t *testing.T) {

--- a/userdocs/theme/home.html
+++ b/userdocs/theme/home.html
@@ -543,6 +543,7 @@
                                 Calgary - (<code>ca-west-1</code>),
                                 US ISO, ISOB and ISOF - (<code>us-iso-east-1</code>, <code>us-iso-west-1</code>, <code>us-isob-east-1</code>, <code>us-isob-west-1</code>, <code>us-isof-south-1</code>, <code>us-isof-east-1</code>),
                                 EU ISOE - (<code>eu-isoe-west-1</code>),
+                                EU Sovereign Cloud - (<code>eusc-de-east-1</code>),
                                 Tel Aviv (<code>il-central-1</code>),
                                 Melbourne (<code>ap-southeast-4</code>),
                                 Hyderabad (<code>ap-south-2</code>),


### PR DESCRIPTION
### Description

Adds support for the AWS European Sovereign Cloud: the `aws-eusc` partition and its first region, Germany East (`eusc-de-east-1`).

This overlaps with #8743, which is also open and came first. I'm not trying to jump the queue — I started out reviewing that PR and ended up with a branch. If the maintainers would rather land #8743, I'm happy to close this and move the notes below over as review comments; the findings matter more than which PR merges.

**Partition entry** (`pkg/apis/eksctl.io/v1alpha5/partitions.go`)

- `v1SDKDNSPrefix` is `amazonaws.eu`, not `amazonaws.com`. This is the part with real consequences: `addons.UseRegionalImage` formats `%s.dkr.ecr.%s.%s`, so the suffix decides whether the regional add-on images resolve at all. The correct host is `877088126301.dkr.ecr.eusc-de-east-1.amazonaws.eu`, per [View Amazon container image registries for Amazon EKS add-ons](https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html) — the same table the EKS resource account ID comes from. The suffix is corroborated by botocore's `endpoints.json` (`aws-eusc` → `dnsSuffix: amazonaws.eu`) and by the SDK already vendored here: `aws-sdk-go-v2/service/eks@v1.80.2` resolves `aws-eusc` to `eks.{region}.amazonaws.eu`.
- Uses `standardServiceMappings` rather than a reduced EC2/EKS/EKSFargatePods map. Both `ssm` and `rolesanywhere` are present in the `aws-eusc` partition in `endpoints.json`, so the `SSM` and `IRA` service principals are valid there. That keeps `ClusterResourceSet.addSSM` and the IAM Roles Anywhere path for hybrid nodes from hitting a missing `FindInMap` key, and makes this entry identical in shape to `aws-us-gov`.
- No `endpointServiceDomainPrefixAlt`. `GetEndpointServiceDomainPrefix` only reads that field under `case PartitionISOE, PartitionISOF`, so setting it for a partition outside that switch would be dead weight. EUSC takes the `default:` branch and gets the standard `com.amazonaws` prefix. That's also why there's no new `service_details_*` / `vpc_private_*` fixture here: the ISOE/ISOF fixtures exist specifically to cover their alternate prefix, and EUSC has no such special case to cover.

**Default add-ons** — `eusc-de-east-1` is deliberately *not* added to `MetricsServerAddon.ExcludedRegions`. That list currently holds every other non-standard partition, so it looks like an omission; it isn't. `metrics-server` is available in the AWS European Sovereign Cloud, and excluding the region would silently drop a default add-on there. Flagging it so a reviewer doesn't "fix" it.

**Fixtures** — the `aws-eusc` block is inserted between `aws-cn` and `aws-iso`. `cloudformation.Template.Mappings` is a `map[string]interface{}` and `Template.JSON()` goes through `json.MarshalIndent`, so rendered key order is sorted, and `pkg/actions/nodegroup/upgrade_test.go` plus `karpenter_test.go` both compare with exact-string `Equal` — position matters. All three expected templates in `karpenter_test.go` are updated, not just the first.

### Testing

`go build ./...` is clean and `go test ./pkg/...` passes for 85 packages. Two packages fail in my environment for reasons unrelated to this change, and fail identically on unmodified `main`: `pkg/iam/oidc` needs `cfssl`/`cfssljson` on `PATH`, and `pkg/karpenter/providers/helm` pulls a chart from `public.ecr.aws` and gets a 403.

**I could not manually test this** — I have no access to `eusc-de-east-1`. The one thing worth confirming in-region is the DNS suffix, via either of the commands that actually consume it:

```
eksctl utils update-aws-node --cluster <cluster> --region eusc-de-east-1
eksctl utils update-coredns  --cluster <cluster> --region eusc-de-east-1
```

Both should resolve images under `877088126301.dkr.ecr.eusc-de-east-1.amazonaws.eu`.

Worth noting for anyone validating: `addons.UseRegionalImage` is reached only from `utils update-aws-node`, `utils update-coredns`, `utils update-addon` and `utils install-vpc-controllers`. It is *not* on the `eksctl create cluster` path when EKS-managed add-ons are used, which is the default. So a successful cluster-creation smoke test in the region does not exercise the DNS suffix and will pass whichever value is set.

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)
