### PR TITLE
ci: pass workflow inputs to run steps via env vars

### DIFF
--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -9,13 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create update issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
         run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/aws/homebrew-tap/issues \
-            -d '{
-              "title": "Update eksctl to ${{ github.event.release.tag_name }}",
-              "body": "New eksctl release ${{ github.event.release.tag_name }} is available.\n\nRelease URL: ${{ github.event.release.html_url }}",
-              "labels": ["eksctl-update"]
-            }'
+          jq -n \
+            --arg tag "$TAG_NAME" \
+            --arg url "$RELEASE_URL" \
+            '{
+              title: "Update eksctl to \($tag)",
+              body: "New eksctl release \($tag) is available.\n\nRelease URL: \($url)",
+              labels: ["eksctl-update"]
+            }' \
+          | curl -sSf -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/aws/homebrew-tap/issues \
+              -d @-

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -32,10 +32,16 @@ jobs:
           commitish: main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          # The Upsert pull request step below authenticates with its own token,
+          # so there is no need to leave a credential behind in the git config.
+          persist-credentials: false
       - name: Copy release notes from Draft
+        env:
+          TAG_NAME: ${{ steps.draft.outputs.tag_name }}
+          RELEASE_BODY: ${{ steps.draft.outputs.body }}
         run: |
-          tag_name=${{ steps.draft.outputs.tag_name }}
-          echo "${{ steps.draft.outputs.body }}" > docs/release_notes/${tag_name:1}.md
+          printf '%s\n' "$RELEASE_BODY" > "docs/release_notes/${TAG_NAME#v}.md"
       - name: Upsert pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:


### PR DESCRIPTION
## Description

`${{ }}` expressions are substituted into a `run:` block as raw text before bash parses it, so an interpolated value has to survive shell parsing rather than simply being used as data. Two workflow steps relied on that. This passes the values through `env:` and references them as quoted variables instead.

### `release-drafter.yaml` — "Copy release notes from Draft"

```
tag_name=${{ steps.draft.outputs.tag_name }}
echo "${{ steps.draft.outputs.body }}" > docs/release_notes/${tag_name:1}.md
```

`steps.draft.outputs.body` is a rendered list of merged PR titles (`change-template: '- $TITLE (#$NUMBER)'`), so characters that are meaningful to bash — `"`, `$`, `(`, `)`, `;` — land in the script itself. `change-title-escapes` in `.github/release-drafter.yml` is set to ``'\<*_&#@`'``, which does not cover them, so a title containing a double quote produces a broken script and a garbled or missing release-notes file.

Now:

```yaml
        env:
          TAG_NAME: ${{ steps.draft.outputs.tag_name }}
          RELEASE_BODY: ${{ steps.draft.outputs.body }}
        run: |
          printf '%s\n' "$RELEASE_BODY" > "docs/release_notes/${TAG_NAME#v}.md"
```

- `printf '%s\n'` rather than `echo`, so backslash sequences in the notes are written verbatim.
- `${TAG_NAME#v}` replaces `${tag_name:1}` — same result for a `vX.Y.Z` tag, but it strips the prefix by name rather than by offset.
- The output path is quoted.

Also set `persist-credentials: false` on this job's checkout. The following **Upsert pull request** step authenticates with its own `token:` input — [`create-pull-request` configures the git `extraheader` itself and unsets any persisted one](https://github.com/peter-evans/create-pull-request/blob/main/src/git-config-helper.ts) — so nothing in the job needs the credential checkout otherwise leaves behind in the git config.

### `homebrew-update.yml` — "Create update issue"

The request body was a single-quoted JSON literal with `${{ }}` values pasted in, which emits malformed JSON if any value contains a quote or backslash. It is now built with `jq -n --arg` from `env:` values, which handles the escaping, and piped to curl with `-d @-`. Added `-sSf` so a failed API call fails the step instead of passing silently, and moved the token into `env:` so it is not part of the script text.

## Checklist

- [x] Added tests that cover your change (n/a — GitHub Actions workflow config)
- [x] Added/modified documentation as required (n/a)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)

## Testing

Ran both rewritten `run:` bodies locally with representative env values.

`release-drafter.yaml` — a body containing `- evil"; whoami; echo " (#124)` plus `\n`, `$VAR` and backticks writes to `docs/release_notes/0.220.0.md` with every character intact and no expansion:

```
# Release v0.220.0

- normal PR title (#123)
- evil"; whoami; echo " (#124)
- backslash \n and $VAR and `cmd`
```

Under the previous version the same body produced a truncated file. For an ordinary body the output is byte-identical.

`homebrew-update.yml` — `jq` output for `TAG_NAME=v0.220.0` matches the previous payload exactly:

```json
{
  "title": "Update eksctl to v0.220.0",
  "body": "New eksctl release v0.220.0 is available.\n\nRelease URL: https://github.com/eksctl-io/eksctl/releases/tag/v0.220.0",
  "labels": ["eksctl-update"]
}
```

Both files parse as valid YAML.