### PR TITLE
ci: sign releases with cosign and publish SBOMs

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -40,3 +40,25 @@ archives:
 
 checksum:
   name_template: "eksctl_checksums.txt"
+
+sboms:
+  - id: archive
+    artifacts: archive
+    # Defaults to `syft`, producing `<archive>.sbom.json` in CycloneDX JSON.
+
+signs:
+  # Keyless (Sigstore/Fulcio) signature over the checksum file, which in turn
+  # covers every archive in the release. Requires `id-token: write` on the
+  # calling job so cosign can exchange the Actions OIDC token for a
+  # short-lived certificate -- there is no long-lived signing key to hold.
+  - id: cosign-checksum
+    cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -55,6 +55,12 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/setup-build
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 #v0.24.2
+
       - name: GoReleaser Release
         if: ${{ !inputs.isReleaseCandidate }}
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 #v7.2.3

--- a/.github/workflows/start-release.yaml
+++ b/.github/workflows/start-release.yaml
@@ -33,6 +33,9 @@ jobs:
       name: release candidate
     secrets:
       customToken: ${{ secrets.EKSCTLBOT_TOKEN }}
-    permissions: 
+    permissions:
       contents: write
       pull-requests: write
+      # Required for cosign keyless signing: lets cosign exchange the Actions
+      # OIDC token for a short-lived Fulcio certificate.
+      id-token: write

--- a/userdocs/src/installation.md
+++ b/userdocs/src/installation.md
@@ -78,6 +78,37 @@ rm eksctl_$PLATFORM.zip
 
 The `eksctl` executable is placed in `$HOME/bin`, which is in `$PATH` from Git Bash.
 
+### Verifying the release signature
+
+A checksum tells you the archive you downloaded matches `eksctl_checksums.txt`, but not that
+the checksum file itself came from the eksctl release pipeline. From v0.220.0 onwards each
+release also publishes a [Sigstore](https://www.sigstore.dev/) signature over the checksum
+file — `eksctl_checksums.txt.sig` and `eksctl_checksums.txt.pem` — so the whole chain can be
+verified back to the GitHub Actions workflow that built it.
+
+Verify with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
+
+```sh
+BASE="https://github.com/eksctl-io/eksctl/releases/latest/download"
+curl -sLO "$BASE/eksctl_checksums.txt"
+curl -sLO "$BASE/eksctl_checksums.txt.sig"
+curl -sLO "$BASE/eksctl_checksums.txt.pem"
+
+cosign verify-blob eksctl_checksums.txt \
+  --signature eksctl_checksums.txt.sig \
+  --certificate eksctl_checksums.txt.pem \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/eksctl-io/eksctl/\.github/workflows/publish-release\.yaml@refs/tags/'
+```
+
+The two `--certificate-*` flags are the part that matters: they assert the signature was
+produced by that workflow in that repository, not merely by somebody with a Sigstore
+identity. Once `cosign` reports `Verified OK`, check your archive against the now-trusted
+checksum file as shown above.
+
+Each archive additionally ships a CycloneDX SBOM at `<archive>.sbom.json`, listing the Go
+modules compiled into that binary.
+
 ### Docker
 
 For every release and RC a container image is pushed to ECR repository `public.ecr.aws/eksctl/eksctl`. Learn more about the usage on [ECR Public Gallery - eksctl](https://gallery.ecr.aws/eksctl/eksctl). For example, 


### PR DESCRIPTION
## Description

`.github/.goreleaser.yml` has no `signs:` or `sboms:` block, so the only integrity signal on a released eksctl binary is `eksctl_checksums.txt`. That file establishes that an archive matches the checksum list, but not that the checksum list itself came from the eksctl release pipeline — the checksums and the archives sit side by side in the same release, so anything able to write one can rewrite the other. A user following the documented install steps has no way to tell a genuine release from a modified one.

This adds keyless [Sigstore](https://www.sigstore.dev/) signing plus per-archive SBOMs.

### Signing

```yaml
signs:
  - id: cosign-checksum
    cmd: cosign
    artifacts: checksum
    output: true
    certificate: "${artifact}.pem"
    args: [sign-blob, "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
```

Signing the checksum file rather than each archive keeps it to one signature — the checksum file already covers every archive, so verifying the signature and then the checksum covers the whole release.

Keyless means the signing identity is the workflow's Actions OIDC token, exchanged for a short-lived Fulcio certificate. There is no long-lived signing key to store in a secret or rotate. Verifiers pin the workflow identity instead:

```
--certificate-oidc-issuer https://token.actions.githubusercontent.com
--certificate-identity-regexp '^https://github.com/eksctl-io/eksctl/\.github/workflows/publish-release\.yaml@refs/tags/'
```

This needs `id-token: write`. It is added to the `publish-release-candidate` job in `start-release.yaml`, which is the only caller of `publish-release.yaml` (reusable workflows inherit the calling job's permissions). `contents: write` and `pull-requests: write` are unchanged.

### SBOMs

```yaml
sboms:
  - id: archive
    artifacts: archive
```

GoReleaser's defaults here shell out to `syft` and emit `<archive>.sbom.json` in CycloneDX JSON, so the Go modules compiled into each binary are enumerable from the release itself.

### Supporting changes

- `cosign` and `syft` installed as pinned steps in `publish-release.yaml` before the GoReleaser steps — GoReleaser invokes both by name.
- Both new blocks live in `.goreleaser.yml`, so the Homebrew release picks them up through the existing `cat .goreleaser.yml .goreleaser.brew.yml` concatenation in the "Set variables" step.
- Verification documented in `userdocs/src/installation.md`, next to the existing checksum instructions.

## Checklist

- [x] Added tests that cover your change (n/a — release tooling config)
- [x] Added/modified documentation as required
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)

## Testing

`goreleaser` could not be installed in my environment (a transitive dependency fetch is blocked), so I validated the config against GoReleaser's published JSON schema instead — the same schema `goreleaser check` uses:

```
$ python3 -c "...jsonschema.validate(yaml.safe_load(open('.github/.goreleaser.yml')), schema)"
.goreleaser.yml OK
brew combined OK
```

Both the standalone config and the `cat`-concatenated Homebrew config validate. `artifacts: archive` is a permitted value for `sboms` and `artifacts: checksum` for `signs` per the schema enums. All four touched YAML files parse.

**What I could not verify locally, and would ask a maintainer to confirm on the first tag:** that the OIDC exchange succeeds end to end, i.e. `id-token: write` propagates through the reusable-workflow call as expected and cosign gets its certificate. If it does not, the symptom is a GoReleaser failure in the signing stage rather than an unsigned release. Worth doing on a `-rc.` tag first — the RC path uses the same `.goreleaser.yml`.

The `--certificate-identity-regexp` in the docs assumes the signing job stays in `publish-release.yaml`; if that file is ever renamed the documented command needs the same change.

## Notes for reviewers

The docs say "From v0.220.0 onwards" — please correct that to whichever release this actually lands in.

This does not enable Homebrew or ECR-side signing, and does not add provenance attestations (`attestations:`/`actions/attest-build-provenance`). Both are reasonable follow-ups; I kept this to the release artifacts themselves.