### PR TITLE
fix: resolve latest addon version before pod identity lookup

### DIFF
--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -73,6 +73,11 @@ func (a *Manager) Update(ctx context.Context, addon *api.Addon, podIdentityIAMUp
 		if summary.Version != latestVersion {
 			logger.Info("new version provided %s", latestVersion)
 		}
+		// Resolve the resolved version back into the addon so that subsequent
+		// steps (e.g. describing recommended pod identity policies) use the
+		// concrete version instead of the "latest" keyword, which the EKS API
+		// rejects (see https://github.com/eksctl-io/eksctl/issues/7841).
+		addon.Version = latestVersion
 		updateAddonInput.AddonVersion = &latestVersion
 	}
 
@@ -102,7 +107,7 @@ func (a *Manager) Update(ctx context.Context, addon *api.Addon, podIdentityIAMUp
 		if requiresIAMPermissions {
 			pidConfigList, supportsPodIdentity, err := a.getRecommendedPoliciesForPodID(ctx, addon)
 			if err != nil {
-				return fmt.Errorf("getting recommended policies for addon %s", addon.Name)
+				return fmt.Errorf("getting recommended policies for addon %s: %w", addon.Name, err)
 			}
 			if !supportsPodIdentity {
 				return &unsupportedPodIdentityErr{addonName: addon.Name}

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -77,7 +77,8 @@ var _ = Describe("Update", func() {
 						},
 						{
 							// not sure if all versions come with v prefix or not, so test a mix.
-							AddonVersion: aws.String("v1.7.7-eksbuild.2"),
+							AddonVersion:           aws.String("v1.7.7-eksbuild.2"),
+							RequiresIamPermissions: true,
 						},
 						{
 							AddonVersion: aws.String("v1.7.6"),
@@ -194,6 +195,51 @@ var _ = Describe("Update", func() {
 					Expect(*updateAddonInput.AddonName).To(Equal("my-addon"))
 					Expect(*updateAddonInput.AddonVersion).To(Equal("v1.7.7-eksbuild.2"))
 					Expect(*updateAddonInput.ServiceAccountRoleArn).To(Equal("original-arn"))
+				})
+			})
+
+			When("the version is set to latest with useDefaultPodIdentityAssociations", func() {
+				It("resolves the latest version before describing recommended pod identity policies", func() {
+					var describeAddonConfigInput *awseks.DescribeAddonConfigurationInput
+					mockProvider.MockEKS().On("DescribeAddonConfiguration", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+						Expect(args).To(HaveLen(2))
+						Expect(args[1]).To(BeAssignableToTypeOf(&awseks.DescribeAddonConfigurationInput{}))
+						describeAddonConfigInput = args[1].(*awseks.DescribeAddonConfigurationInput)
+					}).Return(&awseks.DescribeAddonConfigurationOutput{
+						PodIdentityConfiguration: []ekstypes.AddonPodIdentityConfiguration{
+							{
+								ServiceAccount:             aws.String("my-app"),
+								RecommendedManagedPolicies: []string{"arn-1"},
+							},
+						},
+					}, nil)
+
+					podIdentityIAMUpdater.On("UpdateRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+						Return([]ekstypes.AddonPodIdentityAssociations{
+							{
+								RoleArn:        aws.String("role-arn"),
+								ServiceAccount: aws.String("my-app"),
+							},
+						}, nil)
+
+					err := addonManager.Update(context.Background(), &api.Addon{
+						Name:                              "my-addon",
+						Version:                           "latest",
+						UseDefaultPodIdentityAssociations: true,
+					}, &podIdentityIAMUpdater, 0)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(describeAddonConfigInput).NotTo(BeNil())
+					// The resolved version must be used, not the "latest" keyword,
+					// otherwise the EKS API rejects the request (issue #7841).
+					Expect(*describeAddonConfigInput.AddonVersion).To(Equal("v1.7.7-eksbuild.2"))
+					Expect(*updateAddonInput.AddonVersion).To(Equal("v1.7.7-eksbuild.2"))
+					Expect(updateAddonInput.PodIdentityAssociations).To(Equal([]ekstypes.AddonPodIdentityAssociations{
+						{
+							RoleArn:        aws.String("role-arn"),
+							ServiceAccount: aws.String("my-app"),
+						},
+					}))
 				})
 			})
 


### PR DESCRIPTION
Fixes #7841

### What this PR does

`eksctl update addon` failed with `Error: getting recommended policies for addon vpc-cni`
when the config used `version: latest` together with pod identity configuration
(e.g. `useDefaultPodIdentityAssociations: true`).

### Root cause

`pkg/actions/addon/update.go` resolved `latest` into a concrete version and set it on the
`UpdateAddon` input, but **never wrote it back into `addon.Version`**. Later,
`getRecommendedPoliciesForPodID` calls the EKS API `DescribeAddonConfiguration` with
`AddonVersion: addon.Version` — the literal string `"latest"` — which the EKS API rejects.
The create-addon path (`create.go`) already did `addon.Version = version` correctly.

The error was also swallowed (`%s` instead of `%w`), hiding the actual cause.

### Changes

- Write the resolved version back into `addon.Version` after resolving `latest`
  (same pattern as `create.go`).
- Wrap the underlying error in the "getting recommended policies" failure so the real
  cause surfaces.
- Add a regression test asserting `DescribeAddonConfiguration` receives the **resolved**
  version (not `latest`) and that `UpdateAddon` receives the resolved version plus the
  pod identity associations.

### Validation

- `go build ./...`
- `golangci-lint run --timeout=30m ./pkg/...`
- `go test ./pkg/actions/addon/...` (127 specs pass)

Pre-existing, unrelated failures in `pkg/info` and `pkg/iam/oidc` are environmental
(kubectl/`cfssl` missing locally) and remain unchanged.