### PR TITLE
chore: harden addon warning logging and empty drain

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -267,11 +267,11 @@ func (a *Manager) Create(ctx context.Context, addon *api.Addon, iamRoleCreator I
 			defer func() {
 				deleteAddonIAMTasks, err := NewRemover(a.stackManager).DeleteAddonIAMTasksFiltered(ctx, addon.Name, false)
 				if err != nil {
-					logger.Warning("failed to cleanup IAM role stacks: %w; please remove any remaining stacks manually", err)
+					logger.Warning("failed to cleanup IAM role stacks: %v; please remove any remaining stacks manually", err)
 					return
 				}
 				if err := runAllTasks(deleteAddonIAMTasks); err != nil {
-					logger.Warning("failed to cleanup IAM role stacks: %w; please remove any remaining stacks manually", err)
+					logger.Warning("failed to cleanup IAM role stacks: %v; please remove any remaining stacks manually", err)
 				}
 			}()
 			var addonServiceAccounts []string

--- a/pkg/actions/nodegroup/drain.go
+++ b/pkg/actions/nodegroup/drain.go
@@ -33,6 +33,9 @@ type Drainer struct {
 
 // Drain drains nodegroups.
 func (d *Drainer) Drain(ctx context.Context, input *DrainInput) error {
+	if len(input.NodeGroups) == 0 {
+		return nil
+	}
 	parallelLimit := int64(input.Parallel)
 	sem := semaphore.NewWeighted(parallelLimit)
 	logger.Info("starting parallel draining, max in-flight of %d", parallelLimit)


### PR DESCRIPTION
### What this PR does

Two small hardening fixes found during issue investigations:

1. `pkg/actions/addon/create.go` — `logger.Warning` used the `%w` verb (intended for
   `fmt.Errorf`/error wrapping). Loggers that follow the `go-kit` convention render
   `%w` as a literal `%!w(...)` placeholder, so the actual error text was garbled.
   Switched to `%v`.

2. `pkg/actions/nodegroup/drain.go` — `Drainer.Drain` now returns early when it is
   asked to drain zero nodegroups, instead of logging *"starting parallel draining"*
   and clearing with nothing to do.

### Validation

- `go build ./...`
- `golangci-lint run --timeout=30m ./pkg/...`
- `go test ./pkg/actions/...`

Pre-existing, unrelated failures in `pkg/info` and `pkg/iam/oidc` are environmental
(kubectl/`cfssl` missing locally) and remain unchanged.